### PR TITLE
Akka.Remote: stop, don't restart, failed throttler children

### DIFF
--- a/src/core/Akka.Remote.Tests/Transport/ThrottlerManagerLifecycleSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/ThrottlerManagerLifecycleSpec.cs
@@ -1,0 +1,192 @@
+//-----------------------------------------------------------------------
+// <copyright file="ThrottlerManagerLifecycleSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Remote.Transport;
+using Akka.TestKit;
+using FluentAssertions;
+using Google.Protobuf;
+using Xunit;
+
+namespace Akka.Remote.Tests.Transport
+{
+    /// <summary>
+    /// Specs for how <see cref="ThrottlerManager"/> manages the lifecycle of its
+    /// <see cref="ThrottledAssociation"/> children.
+    ///
+    /// Uses a stub <see cref="Transport"/> so the throttler can be driven directly, without any
+    /// real network I/O in the picture.
+    /// </summary>
+    public class ThrottlerManagerLifecycleSpec : AkkaSpec
+    {
+        private static readonly Config Config = ConfigurationFactory.ParseString(@"
+            akka {
+              loglevel = DEBUG
+              actor.provider = ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
+              remote.dot-netty.tcp.hostname = ""localhost""
+              remote.dot-netty.tcp.port = 0
+            }");
+
+        public ThrottlerManagerLifecycleSpec(ITestOutputHelper output) : base(Config, output)
+        {
+        }
+
+        private static readonly Address LocalAddress = new("akka.test", "local", "localhost", 1234);
+        private static readonly Address RemoteAddress = new("akka.test", "remote", "localhost", 4321);
+
+        #region Test transport
+
+        private sealed class StubHandle : AssociationHandle
+        {
+            public StubHandle(Address localAddress, Address remoteAddress) : base(localAddress, remoteAddress)
+            {
+            }
+
+            public bool Disassociated { get; private set; }
+
+            public override bool Write(ByteString payload) => true;
+
+#pragma warning disable CS0672 // the base member is obsolete, but it is the abstract one we have to implement
+            public override void Disassociate()
+#pragma warning restore CS0672
+            {
+                Disassociated = true;
+            }
+        }
+
+        /// <summary>
+        /// Blows the throttler up the way the real thing does when the layer above it faults.
+        /// </summary>
+        private sealed class ThrowingAssociationEventListener : IAssociationEventListener
+        {
+            public void Notify(IAssociationEvent ev) => throw new ApplicationException("boom");
+        }
+
+        private sealed class StubTransport : Akka.Remote.Transport.Transport
+        {
+            public StubTransport(ActorSystem system)
+            {
+                System = system;
+                Config = ConfigurationFactory.Empty;
+                SchemeIdentifier = "test";
+                MaximumPayloadBytes = 32000;
+            }
+
+            public override Task<(Address, TaskCompletionSource<IAssociationEventListener>)> Listen()
+                => Task.FromResult((LocalAddress, new TaskCompletionSource<IAssociationEventListener>()));
+
+            public override bool IsResponsibleFor(Address remote) => true;
+
+            public override Task<AssociationHandle> Associate(Address remoteAddress)
+                => Task.FromResult<AssociationHandle>(new StubHandle(LocalAddress, remoteAddress));
+
+            public override Task<bool> Shutdown() => Task.FromResult(true);
+        }
+
+        #endregion
+
+        private IActorRef StartManager(IAssociationEventListener? associationListener = null)
+        {
+            var manager = Sys.ActorOf(Props.Create(() => new ThrottlerManager(new StubTransport(Sys))));
+
+            // move the manager into its `Ready` behavior
+            manager.Tell(new ListenUnderlying(LocalAddress,
+                Task.FromResult(associationListener ?? new ActorAssociationEventListener(TestActor))));
+            return manager;
+        }
+
+        private async Task<ThrottlerHandle> AssociateAsync(IActorRef manager)
+        {
+            var promise = new TaskCompletionSource<AssociationHandle>(TaskCreationOptions.RunContinuationsAsynchronously);
+            manager.Tell(new AssociateUnderlying(RemoteAddress, promise));
+            var handle = await promise.Task.WaitAsync(RemainingOrDefault);
+            return (ThrottlerHandle)handle;
+        }
+
+        [Fact(DisplayName = "ThrottlerManager should stop, not restart, an inbound throttler child that fails")]
+        public async Task Should_stop_failed_inbound_throttler_child()
+        {
+            var manager = StartManager(new ThrowingAssociationEventListener());
+
+            var inboundHandle = new StubHandle(LocalAddress, RemoteAddress);
+            manager.Tell(new InboundAssociation(inboundHandle));
+
+            // the throttler registers itself as the read handler as soon as it gets its `Handle` message
+            var listener = (ActorHandleEventListener)await inboundHandle.ReadHandlerSource.Task.WaitAsync(RemainingOrDefault);
+            var throttler = listener.Actor;
+            await WatchAsync(throttler);
+
+            // an ASSOCIATE PDU carries the origin address, so the throttler checks in with the manager,
+            // gets its throttle mode back, and hands the association up to the (throwing) listener
+            var associate = new AkkaPduProtobuffCodec(Sys).ConstructAssociate(new HandshakeInfo(RemoteAddress, 1));
+
+            // the default decider Restarts on this, which is what makes the association a black hole:
+            // the restarted FSM re-enters `WaitExposedHandle`, and the `Handle` message that gets it out
+            // of there is only ever sent once, when the child is created
+            await EventFilter.Exception<ApplicationException>().ExpectOneAsync(async () =>
+            {
+                listener.Notify(new InboundPayload(associate));
+                await ExpectTerminatedAsync(throttler);
+            });
+        }
+
+        [Fact(DisplayName = "ThrottlerManager should purge terminated throttlers from its handle table")]
+        public async Task Should_purge_terminated_throttler_from_handle_table()
+        {
+            var manager = StartManager();
+            var handle = await AssociateAsync(manager);
+            var throttler = handle.ThrottlerActor;
+
+            await WatchAsync(throttler);
+            throttler.Tell(PoisonPill.Instance);
+            await ExpectTerminatedAsync(throttler);
+
+            // the death watch notification is a system message enqueued before anything we send from
+            // here, so the manager has already processed it by the time it handles `SetThrottle`
+            var deadLetters = CreateTestProbe("dead-letters");
+            Sys.EventStream.Subscribe(deadLetters.Ref, typeof(DeadLetter));
+
+            manager.Tell(new SetThrottle(RemoteAddress, ThrottleTransportAdapter.Direction.Both, Blackhole.Instance),
+                TestActor);
+
+            await ExpectMsgAsync<SetThrottleAck>();
+
+            // a stale handle table entry shows up as the throttle mode dead-lettering to the dead child
+            await deadLetters.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+        }
+
+        [Fact(DisplayName = "ThrottledAssociation should disassociate rather than black hole payloads received before initialization")]
+        public async Task Should_disassociate_when_payload_arrives_before_handle()
+        {
+            // reproduces the state a restarted inbound throttler is left in: back in `WaitExposedHandle`,
+            // with the read handler of the previous incarnation still pointed at this actor
+            var originalHandle = new StubHandle(LocalAddress, RemoteAddress);
+            var association = Sys.ActorOf(Props.Create(() => new ThrottledAssociation(
+                TestActor,
+                new ActorAssociationEventListener(TestActor),
+                originalHandle,
+                true)));
+
+            await WatchAsync(association);
+
+            await EventFilter.Warning(contains: "received an InboundPayload before it was initialized").ExpectOneAsync(
+                async () =>
+                {
+                    association.Tell(new InboundPayload(ByteString.CopyFromUtf8("ping")));
+                    await ExpectTerminatedAsync(association);
+                });
+
+            originalHandle.Disassociated.Should().BeTrue("the association has to be torn down so remoting can re-establish it");
+        }
+    }
+}

--- a/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Dispatch.SysMsg;
+using Akka.Event;
 using Akka.Remote.Serialization;
 using Akka.Util;
 using Akka.Util.Internal;
@@ -345,6 +346,25 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
+        /// A <see cref="ThrottledAssociation"/> cannot recover its own state: an inbound throttler
+        /// only ever receives the <see cref="Handle"/> message that moves it out of
+        /// <see cref="ThrottledAssociation.ThrottlerState.WaitExposedHandle"/> once, when it is created.
+        /// Restarting one therefore leaves it parked in that state forever, silently discarding every
+        /// inbound packet on that association.
+        ///
+        /// Stopping the child instead surfaces the failure as a disassociation, which the remoting
+        /// layer above knows how to recover from. This mirrors <c>AkkaProtocolManager</c>, which uses
+        /// the same strategy for the same reason.
+        /// </summary>
+        private readonly SupervisorStrategy _supervisor = new OneForOneStrategy(_ => Directive.Stop);
+
+        /// <inheritdoc/>
+        protected override SupervisorStrategy SupervisorStrategy()
+        {
+            return _supervisor;
+        }
+
+        /// <summary>
         /// TBD
         /// </summary>
         /// <param name="message">TBD</param>
@@ -487,6 +507,21 @@ namespace Akka.Remote.Transport
                     SetMode(naked, chkin.ThrottlerHandle);
                     return;
                 }
+
+                case Terminated terminated:
+                {
+                    /*
+                     * A throttler child stopped for a reason other than ForceDisassociate[Explicitly]
+                     * (crash, PoisonPill, Blackhole-induced disassociation, transport shutdown).
+                     *
+                     * Its entry has to come out of the table for the same reason described in the
+                     * ForceDisassociate handler above: messaging a terminated handle from SetThrottle
+                     * fails Tasks all the way back up to the EndpointManager, and the table would
+                     * otherwise grow for the lifetime of the transport.
+                     */
+                    _handleTable.RemoveAll(tuple => tuple.Item2.ThrottlerActor.Equals(terminated.ActorRef));
+                    return;
+                }
             }
         }
 
@@ -559,10 +594,15 @@ namespace Akka.Remote.Transport
             bool inbound)
         {
             var managerRef = Self;
-            return new ThrottlerHandle(originalHandle, Context.ActorOf(
+            var throttlerActor = Context.ActorOf(
                 RARP.For(Context.System).ConfigureDispatcher(
-                Props.Create(() => new ThrottledAssociation(managerRef, listener, originalHandle, inbound)).WithDeploy(Deploy.Local)),
-                "throttler" + NextId()));
+                    Props.Create(() => new ThrottledAssociation(managerRef, listener, originalHandle, inbound))
+                        .WithDeploy(Deploy.Local)),
+                "throttler" + NextId());
+
+            // watch so we can purge the handle table when this association goes away
+            Context.Watch(throttlerActor);
+            return new ThrottlerHandle(originalHandle, throttlerActor);
         }
 
         #endregion
@@ -1055,6 +1095,8 @@ namespace Akka.Remote.Transport
         /// </summary>
         private readonly AkkaPduProtobuffCodec _codec;
 
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -1085,6 +1127,26 @@ namespace Akka.Remote.Transport
                             .Using(
                                 new ExposedHandle(handle.ThrottlerHandle));
                 }
+
+                if (@event.FsmEvent is InboundPayload)
+                {
+                    /*
+                     * Unreachable during a healthy startup: nothing can deliver an InboundPayload to us
+                     * until we complete OriginalHandle.ReadHandlerSource above, which is the same step
+                     * that leaves this state.
+                     *
+                     * Getting one here means this actor was restarted - the read handler from the previous
+                     * incarnation still points at this ActorRef, but the ThrottlerManager only ever sends
+                     * Handle once, at creation. Staying put would silently discard every inbound packet for
+                     * the life of the association, so tear it down instead and let remoting re-associate.
+                     */
+                    _log.Warning(
+                        "Throttler for [{0}] received an InboundPayload before it was initialized - most likely restarted. Disassociating so the association can be re-established.",
+                        OriginalHandle.RemoteAddress);
+                    OriginalHandle.Disassociate("throttler received inbound data before it was initialized", _log);
+                    return Stop();
+                }
+
                 return null;
             });
 


### PR DESCRIPTION
Closes #8433. Closes #8434.

Both issues are symptoms of the same gap: `ThrottlerManager` never managed the lifecycle of its `ThrottledAssociation` children. It neither supervised them deliberately nor noticed when they died.

## 1. A restarted throttler is a permanent one-way black hole (#8433)

Three things line up:

- Neither `ThrottlerManager` (`src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs:204`) nor its base `ActorTransportAdapterManager` (`src/core/Akka.Remote/Transport/TransportAdapters.cs:561`) declared a `SupervisorStrategy`, so the default decider applied: **Restart** for a general exception.
- On restart, `ThrottledAssociation.InitializeFSM()` re-enters `WaitExposedHandle` for an inbound association (`src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs:1312`).
- The `Handle` message that leaves that state is sent exactly once, when the child is created (`src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs:378`). It is never re-sent.

The restarted FSM then sits in `WaitExposedHandle` for the life of the process, logging `unhandled event InboundPayload(...)` and discarding every inbound packet on that association. Nothing upstream notices: `transport-failure-detector.acceptable-heartbeat-pause` defaults to 120s, so there is no disassociation and no quarantine - just silent one-way data loss between two nodes.

`ThrottlerManager` now declares `OneForOneStrategy(_ => Directive.Stop)`.

**Why `Stop`, and why on `ThrottlerManager` rather than the base class:**

- `Stop` is the semantic that matches reality. A `ThrottledAssociation` cannot rebuild its own state from a restart - the state it needs (`Handle`, origin address, throttle mode, upstream listener) is all pushed to it by other actors during a one-shot startup handshake. Restart is only correct for an actor that can rebuild itself, and this one cannot. Stopping it turns the failure into a disassociation, which is a condition remoting already knows how to recover from.
- `Escalate` would take the manager down with the child, killing every association on that transport - a much bigger blast radius than the failure warrants.
- `Resume` would leave the FSM in whatever state the exception interrupted - the worst option.
- This mirrors `AkkaProtocolManager`, the only other `ActorTransportAdapterManager` subclass in the tree, which has used exactly this strategy for exactly this reason since it was written (`src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs:208`, with the comment "does not handle recovery of associations, this task is implemented in the remoting itself").
- I put it on `ThrottlerManager`, not on `ActorTransportAdapterManager`. Those two are the only subclasses in the repo, and `AkkaProtocolManager` already sets its own - so hoisting the strategy to the base would change behavior for nobody in-tree while silently re-supervising any third-party subclass of that public abstract class. The narrow change fixes the bug; the base class keeps whatever contract external subclasses were written against.

## 2. `_handleTable` retained references to terminated throttlers (#8434)

Entries were removed only in the `ForceDisassociate` / `ForceDisassociateExplicitly` paths (`src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs:468` and `:498`). A throttler that died any other way - crash, `PoisonPill`, `Blackhole`-induced disassociation, transport shutdown - left its entry behind, so later `SetThrottle` / `PassThrough` walks messaged a dead ref. The observable symptom is the throttle mode dead-lettering to an already-dead throttler and the throttle change silently not applying; the table also grows for the lifetime of the transport.

Children are now `Context.Watch`ed at their single creation site in `WrapHandle`, and a `Terminated` case in `Ready` purges the matching entry. Routing is fine: `ActorTransportAdapterManager.OnReceive` does `Context.Become(Ready)` once the listener is registered, and children are only ever created from within `Ready`, so `Terminated` always lands in the `Ready` handler. The existing `RemoveAll` calls on the `ForceDisassociate` paths are untouched - the later `Terminated` for those children simply finds nothing to remove.

## 3. `WaitExposedHandle` no longer drops payloads quietly

The issue floated this as optional; I implemented it, because it is safe by construction. Nothing can deliver an `InboundPayload` to a throttler until `OriginalHandle.ReadHandlerSource` is completed, and that completion happens in the same step that leaves `WaitExposedHandle`. There is no legitimate startup window where a payload can arrive in this state - the manager tells `Handle` as the child's first message, and no one else holds the ref before then. Receiving one means the actor was restarted (the read handler from the previous incarnation still points at this `ActorRef`), which is precisely the #8433 black hole. It now logs a warning, disassociates the underlying handle so remoting can re-associate, and stops.

## Tests

New: `src/core/Akka.Remote.Tests/Transport/ThrottlerManagerLifecycleSpec.cs` - drives a `ThrottlerManager` over a stub `Transport`, no network I/O.

1. An inbound throttler whose association listener throws is **stopped**, not restarted (the real #8433 path: `InboundAssociation` -> `Handle` -> ASSOCIATE PDU -> `Checkin` -> mode -> throw).
2. A terminated throttler's entry is purged: after the child dies, `SetThrottle` acks with no throttle mode dead-lettering to the dead ref.
3. An `InboundPayload` arriving in `WaitExposedHandle` disassociates the underlying handle and stops the actor.

All three fail on `dev` and pass with this change. Test 1 deliberately faults with a plain exception rather than `Kill`, because the default decider already stops on `ActorKilledException` and so would not discriminate. Note also that for *outbound* associations the old restart was already fatal - `ReadHandlerSource.SetResult` on an already-completed TCS throws in the constructor, so the child died via `ActorInitializationException`. Only the inbound path restarts cleanly into the black hole, which is why the regression test uses it.

Also run:

- `dotnet build src/core/Akka.Remote/Akka.Remote.csproj -c Release -warnaserror`: clean, 0 warnings.
- `dotnet slopwatch analyze -d . --fail-on error`: passes, no new findings in the touched files.
- Full `Akka.Remote.Tests`: 648 passed, 5 skipped, 0 failed.
- Multi-node specs with `TestTransport = true` (i.e. the `trttl` adapter actually in the pipeline), to confirm normal blackhole/pass-through operation still works: `Akka.Remote.Tests.MultiNode` `AttemptSysMsgRedeliverySpec` (3/3), `Akka.Cluster.Tests.MultiNode` `ClusterAccrualFailureDetectorSpec` (3/3) and `UnreachableNodeJoinsAgainSpec` (4/4).

No public API surface changed - `ThrottlerManager` and `ThrottledAssociation` are internal, and the approved API files contain no references to them - so no `Akka.API.Tests` approvals were needed. I did not add a `BREAKING_CHANGES_V1.6.md` entry: this is an internal-only bug fix that restores intended behavior, with no public API or wire-format change and nothing a user could reasonably have depended on. Happy to add one if you'd rather have it recorded.

## Scope

Keeping this honest: the throttle adapter is only in the transport pipeline when `applied-adapters` includes `trttl`/`gremlin`, which in practice means multi-node test runs rather than production deployments. This is test-infrastructure severity, not a production data-loss bug. It matters because it makes MNTR failures look like unrelated flakiness: two nodes go permanently blind to each other while the TestConductor control plane (its own connection) keeps working, so barriers still pass.

The CI trigger we actually observed was an NRE thrown during `Unwatch` that killed a throttler. That root cause is being fixed separately and is not touched here - the point of this change is that a dead throttler should be recoverable rather than silently fatal.