### PR TITLE
Backport #8430 and #8441 to v1.5: AutoDilate metadata + double-dilate fix

### DIFF
--- a/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="MultiNodeClusterSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -316,7 +316,7 @@ namespace Akka.Cluster.TestKit
             await EnterBarrierAsync(cancellationToken, roles.Select(r => r.Name).Aggregate((a, b) => a + "-" + b) + "-joined");
         }
 
-        public void JoinWithin(RoleName joinNode, TimeSpan? max = null, TimeSpan? interval = null)
+        public void JoinWithin(RoleName joinNode, [AutoDilate] TimeSpan? max = null, TimeSpan? interval = null)
         {
             if (max == null) max = RemainingOrDefault;
             if (interval == null) interval = TimeSpan.FromSeconds(1);
@@ -395,7 +395,7 @@ namespace Akka.Cluster.TestKit
         public void AwaitMembersUp(
             int numbersOfMembers,
             ImmutableHashSet<Address> canNotBePartOfMemberRing = null,
-            TimeSpan? timeout = null)
+            [AutoDilate] TimeSpan? timeout = null)
         {
             if (canNotBePartOfMemberRing == null)
                 canNotBePartOfMemberRing = ImmutableHashSet.Create<Address>();
@@ -420,7 +420,7 @@ namespace Akka.Cluster.TestKit
         public async Task AwaitMembersUpAsync(
             int numbersOfMembers,
             ImmutableHashSet<Address> canNotBePartOfMemberRing = null,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             CancellationToken cancellationToken = default)
         {
             canNotBePartOfMemberRing ??= ImmutableHashSet.Create<Address>();

--- a/src/core/Akka.Cluster.Tests.MultiNode/AutoDilateMetadataSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/AutoDilateMetadataSpec.cs
@@ -1,0 +1,60 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AutoDilateMetadataSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Linq;
+using System.Reflection;
+using Akka.Cluster.TestKit;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Cluster.Tests.MultiNode;
+
+public class AutoDilateMetadataSpec
+{
+    [Fact]
+    public void MultiNodeClusterSpec_should_mark_automatically_dilated_parameters()
+    {
+        AssertAutoDilated(nameof(MultiNodeClusterSpec.JoinWithin), "max",
+            "joinNode", "max", "interval");
+        AssertAutoDilated(nameof(MultiNodeClusterSpec.AwaitMembersUp), "timeout",
+            "numbersOfMembers", "canNotBePartOfMemberRing", "timeout");
+        AssertAutoDilated(nameof(MultiNodeClusterSpec.AwaitMembersUpAsync), "timeout",
+            "numbersOfMembers", "canNotBePartOfMemberRing", "timeout", "cancellationToken");
+    }
+
+    [Fact]
+    public void MultiNodeClusterSpec_should_not_mark_raw_interval_parameters()
+    {
+        var parameter = FindParameter(nameof(MultiNodeClusterSpec.JoinWithin), "interval",
+            "joinNode", "max", "interval");
+
+        Assert.False(parameter.IsDefined(typeof(AutoDilateAttribute), inherit: false));
+    }
+
+    private static void AssertAutoDilated(
+        string methodName,
+        string parameterName,
+        params string[] parameterNames)
+    {
+        var parameter = FindParameter(methodName, parameterName, parameterNames);
+        Assert.True(parameter.IsDefined(typeof(AutoDilateAttribute), inherit: false));
+    }
+
+    private static ParameterInfo FindParameter(
+        string methodName,
+        string parameterName,
+        params string[] parameterNames)
+    {
+        var method = typeof(MultiNodeClusterSpec)
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Single(candidate =>
+                candidate.Name == methodName &&
+                candidate.GetParameters().Select(parameter => parameter.Name).SequenceEqual(parameterNames));
+
+        return method.GetParameters().Single(parameter => parameter.Name == parameterName);
+    }
+}

--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/AutoDilateMetadataTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/AutoDilateMetadataTests.cs
@@ -1,0 +1,134 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AutoDilateMetadataTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Reflection;
+using Akka.TestKit.Internal;
+using Xunit;
+
+namespace Akka.TestKit.Tests.TestKitBaseTests;
+
+public class AutoDilateMetadataTests
+{
+    [Fact]
+    public void AutoDilateAttribute_should_be_parameter_only_metadata()
+    {
+        var usage = typeof(AutoDilateAttribute).GetCustomAttribute<AttributeUsageAttribute>();
+
+        Assert.NotNull(usage);
+        Assert.Equal(AttributeTargets.Parameter, usage.ValidOn);
+        Assert.False(usage.AllowMultiple);
+        Assert.False(usage.Inherited);
+    }
+
+    [Fact]
+    public void AutoDilateAttribute_should_only_mark_duration_parameters()
+    {
+        var annotatedParameters = typeof(TestKitBase).Assembly
+            .GetTypes()
+            .SelectMany(type => type
+                .GetMembers(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public |
+                            BindingFlags.NonPublic)
+                .OfType<MethodBase>())
+            .SelectMany(method => method.GetParameters())
+            .Where(HasAutoDilateAttribute)
+            .ToArray();
+
+        Assert.NotEmpty(annotatedParameters);
+        Assert.All(annotatedParameters, parameter =>
+            Assert.True(
+                parameter.ParameterType == typeof(TimeSpan) ||
+                parameter.ParameterType == typeof(TimeSpan?),
+                $"{parameter.Member.DeclaringType?.FullName}.{parameter.Member.Name} parameter " +
+                $"'{parameter.Name}' has unexpected type {parameter.ParameterType}."));
+    }
+
+    [Fact]
+    public void Automatically_dilated_TestKit_parameters_should_be_marked()
+    {
+        AssertAutoDilated(typeof(TestKitBase), nameof(TestKitBase.Dilated), "duration", "duration");
+        AssertAutoDilated(typeof(TestKitBase), nameof(TestKitBase.RemainingOrDilated), "duration", "duration");
+        AssertAutoDilated(typeof(TestKitBase), nameof(TestKitBase.AwaitAssert), "duration",
+            "assertion", "duration", "interval", "cancellationToken");
+        AssertAutoDilated(typeof(TestKitBase), nameof(TestKitBase.ReceiveWhile), "max",
+            "filter", "max", "idle", "msgs", "cancellationToken");
+        AssertAutoDilated(typeof(TestKitBase), nameof(TestKitBase.Within), "max",
+            "min", "max", "action", "hint", "epsilonValue", "cancellationToken");
+        AssertAutoDilated(typeof(TestKitBase), nameof(TestKitBase.FishUntilMessageAsync), "max",
+            "max", "cancellationToken");
+        AssertAutoDilated(typeof(IEventFilterApplier), nameof(IEventFilterApplier.ExpectOne), "timeout",
+            "timeout", "action", "cancellationToken");
+        AssertAutoDilated(typeof(InternalEventFilterApplier), nameof(InternalEventFilterApplier.ExpectOne),
+            "timeout", "timeout", "action", "cancellationToken");
+        AssertAutoDilated(typeof(TestBarrier), nameof(TestBarrier.Await), "timeout", "timeout");
+
+        var constructor = typeof(TestBarrier).GetConstructors()
+            .Single(ctor => HasParameterNames(ctor, "testKit", "count", "defaultTimeout"));
+        Assert.True(HasAutoDilateAttribute(constructor.GetParameters().Single(p => p.Name == "defaultTimeout")));
+    }
+
+    [Fact]
+    public void Raw_or_conditionally_dilated_TestKit_parameters_should_not_be_marked()
+    {
+        AssertNotAutoDilated(typeof(TestKitBase), nameof(TestKitBase.AwaitAssert), "interval",
+            "assertion", "duration", "interval", "cancellationToken");
+        AssertNotAutoDilated(typeof(TestKitBase), nameof(TestKitBase.ReceiveWhile), "idle",
+            "filter", "max", "idle", "msgs", "cancellationToken");
+        AssertNotAutoDilated(typeof(TestKitBase), nameof(TestKitBase.Within), "min",
+            "min", "max", "action", "hint", "epsilonValue", "cancellationToken");
+        AssertNotAutoDilated(typeof(TestKitBase), nameof(TestKitBase.Within), "epsilonValue",
+            "min", "max", "action", "hint", "epsilonValue", "cancellationToken");
+        AssertNotAutoDilated(typeof(TestKitBase), nameof(TestKitBase.ReceiveOne), "max",
+            "max", "cancellationToken");
+        AssertNotAutoDilated(typeof(TestKitBase), nameof(TestKitBase.AwaitConditionNoThrow), "max",
+            "conditionIsFulfilled", "max", "interval", "cancellationToken");
+        AssertNotAutoDilated(typeof(TestLatch), nameof(TestLatch.Ready), "timeout", "timeout");
+    }
+
+    private static void AssertAutoDilated(
+        Type declaringType,
+        string methodName,
+        string parameterName,
+        params string[] parameterNames)
+    {
+        var parameter = FindParameter(declaringType, methodName, parameterName, parameterNames);
+        Assert.True(HasAutoDilateAttribute(parameter));
+    }
+
+    private static void AssertNotAutoDilated(
+        Type declaringType,
+        string methodName,
+        string parameterName,
+        params string[] parameterNames)
+    {
+        var parameter = FindParameter(declaringType, methodName, parameterName, parameterNames);
+        Assert.False(HasAutoDilateAttribute(parameter));
+    }
+
+    private static ParameterInfo FindParameter(
+        Type declaringType,
+        string methodName,
+        string parameterName,
+        params string[] parameterNames)
+    {
+        var method = declaringType
+            .GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public |
+                        BindingFlags.NonPublic)
+            .Single(candidate =>
+                candidate.Name == methodName &&
+                HasParameterNames(candidate, parameterNames));
+
+        return method.GetParameters().Single(parameter => parameter.Name == parameterName);
+    }
+
+    private static bool HasParameterNames(MethodBase method, params string[] parameterNames)
+        => method.GetParameters().Select(parameter => parameter.Name).SequenceEqual(parameterNames);
+
+    private static bool HasAutoDilateAttribute(ParameterInfo parameter)
+        => parameter.IsDefined(typeof(AutoDilateAttribute), inherit: false);
+}

--- a/src/core/Akka.TestKit/AutoDilateAttribute.cs
+++ b/src/core/Akka.TestKit/AutoDilateAttribute.cs
@@ -1,0 +1,26 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AutoDilateAttribute.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+
+namespace Akka.TestKit;
+
+/// <summary>
+/// Marks a duration parameter whose value is automatically scaled by
+/// <see cref="TestKitSettings.TestTimeFactor"/>.
+/// </summary>
+/// <remarks>
+/// Callers should pass an undilated duration to parameters marked with this attribute.
+/// Passing a value that has already been scaled by <see cref="TestKitBase.Dilated(TimeSpan)"/>
+/// applies the configured time factor twice.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+public sealed class AutoDilateAttribute : Attribute
+{
+}

--- a/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="IEventFilterApplier.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -48,7 +48,7 @@ namespace Akka.TestKit
         /// <param name="timeout">The time to wait for a log event after executing <paramref name="action"/></param>
         /// <param name="action">The action.</param>
         /// <param name="cancellationToken"></param>
-        void ExpectOne(TimeSpan timeout, Action action, CancellationToken cancellationToken = default);
+        void ExpectOne([AutoDilate] TimeSpan timeout, Action action, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="action"/> and
@@ -59,7 +59,7 @@ namespace Akka.TestKit
         /// <param name="timeout">The time to wait for a log event after executing <paramref name="action"/></param>
         /// <param name="action">The action.</param>
         /// <param name="cancellationToken"></param>
-        Task ExpectOneAsync(TimeSpan timeout, Func<Task> action, CancellationToken cancellationToken = default);
+        Task ExpectOneAsync([AutoDilate] TimeSpan timeout, Func<Task> action, CancellationToken cancellationToken = default);
 
         [Obsolete(
             "Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) instead beginning in Akka.NET v1.5")]
@@ -113,7 +113,7 @@ namespace Akka.TestKit
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="action">The action.</param>
         /// <param name="cancellationToken"></param>
-        void Expect(int expectedCount, TimeSpan timeout, Action action, CancellationToken cancellationToken = default);
+        void Expect(int expectedCount, [AutoDilate] TimeSpan timeout, Action action, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="action"/> and expects the specified number
@@ -126,10 +126,10 @@ namespace Akka.TestKit
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="action">The action.</param>
         /// <param name="cancellationToken"></param>
-        Task ExpectAsync(int expectedCount, TimeSpan timeout, Func<Task> action, CancellationToken cancellationToken = default);
+        Task ExpectAsync(int expectedCount, [AutoDilate] TimeSpan timeout, Func<Task> action, CancellationToken cancellationToken = default);
         
         [Obsolete("Use ExpectAsync<T>(expectedCount, TimeSpan, Func<Task<T>>) instead. This method only exists to support backwards compatibility as of Akka.NET v1.5.")]
-        Task ExpectAsync(int expectedCount, TimeSpan timeout, Action action, CancellationToken cancellationToken = default);
+        Task ExpectAsync(int expectedCount, [AutoDilate] TimeSpan timeout, Action action, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="func"/> and
@@ -168,7 +168,7 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <param name="cancellationToken"></param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        T ExpectOne<T>(TimeSpan timeout, Func<T> func, CancellationToken cancellationToken = default);
+        T ExpectOne<T>([AutoDilate] TimeSpan timeout, Func<T> func, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="func"/> and
@@ -181,7 +181,7 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <param name="cancellationToken"></param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        Task<T> ExpectOneAsync<T>(TimeSpan timeout, Func<Task<T>> func, CancellationToken cancellationToken = default);
+        Task<T> ExpectOneAsync<T>([AutoDilate] TimeSpan timeout, Func<Task<T>> func, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="func"/> and expects the specified number
@@ -225,7 +225,7 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <param name="cancellationToken"></param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        T Expect<T>(int expectedCount, TimeSpan timeout, Func<T> func, CancellationToken cancellationToken = default);
+        T Expect<T>(int expectedCount, [AutoDilate] TimeSpan timeout, Func<T> func, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="func"/> and expects the specified number
@@ -240,7 +240,7 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <param name="cancellationToken"></param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        Task<T> ExpectAsync<T>(int expectedCount, TimeSpan timeout, Func<Task<T>> func, CancellationToken cancellationToken = default);
+        Task<T> ExpectAsync<T>(int expectedCount, [AutoDilate] TimeSpan timeout, Func<Task<T>> func, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="func"/> and prevent events from being logged during the execution.

--- a/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="EventFilterApplier.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -74,7 +74,7 @@ namespace Akka.TestKit.Internal
         }
         
         public void ExpectOne(
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Action action,
             CancellationToken cancellationToken = default)
         {
@@ -86,7 +86,7 @@ namespace Akka.TestKit.Internal
         /// Async version of <see cref="ExpectOne(System.TimeSpan,System.Action,CancellationToken) "/>
         /// </summary>
         public async Task ExpectOneAsync(
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Func<Task> action,
             CancellationToken cancellationToken = default)
         {
@@ -143,7 +143,7 @@ namespace Akka.TestKit.Internal
         
         public void Expect(
             int expectedCount,
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Action action,
             CancellationToken cancellationToken = default)
         {
@@ -156,7 +156,7 @@ namespace Akka.TestKit.Internal
         /// </summary>
         public async Task ExpectAsync(
             int expectedCount,
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Func<Task> action,
             CancellationToken cancellationToken = default)
         {
@@ -169,7 +169,7 @@ namespace Akka.TestKit.Internal
                 ;
         }
 
-        public async Task ExpectAsync(int expectedCount, TimeSpan timeout, Action action, CancellationToken cancellationToken = default)
+        public async Task ExpectAsync(int expectedCount, [AutoDilate] TimeSpan timeout, Action action, CancellationToken cancellationToken = default)
         {
             await ExpectAsync(expectedCount, timeout, Wrapped, cancellationToken);
             return;
@@ -203,7 +203,7 @@ namespace Akka.TestKit.Internal
         }
         
         public T ExpectOne<T>(
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Func<T> func,
             CancellationToken cancellationToken = default)
         {
@@ -215,7 +215,7 @@ namespace Akka.TestKit.Internal
         /// Async version of ExpectOne
         /// </summary>
         public Task<T> ExpectOneAsync<T>(
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Func<Task<T>> func,
             CancellationToken cancellationToken = default)
         {
@@ -256,7 +256,7 @@ namespace Akka.TestKit.Internal
         
         public T Expect<T>(
             int expectedCount,
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Func<T> func,
             CancellationToken cancellationToken = default)
         {
@@ -270,7 +270,7 @@ namespace Akka.TestKit.Internal
         /// </summary>
         public Task<T> ExpectAsync<T>(
             int expectedCount,
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Func<Task<T>> func,
             CancellationToken cancellationToken = default)
         {

--- a/src/core/Akka.TestKit/TestBarrier.cs
+++ b/src/core/Akka.TestKit/TestBarrier.cs
@@ -36,7 +36,7 @@ namespace Akka.TestKit
         /// <param name="testKit">TBD</param>
         /// <param name="count">TBD</param>
         /// <param name="defaultTimeout">TBD</param>
-        public TestBarrier(TestKitBase testKit, int count, TimeSpan? defaultTimeout=null)
+        public TestBarrier(TestKitBase testKit, int count, [AutoDilate] TimeSpan? defaultTimeout=null)
         {
             _testKit = testKit;
             _count = count;
@@ -56,7 +56,7 @@ namespace Akka.TestKit
         /// TBD
         /// </summary>
         /// <param name="timeout">TBD</param>
-        public void Await(TimeSpan timeout)
+        public void Await([AutoDilate] TimeSpan timeout)
         {
             _barrier.SignalAndWait(_testKit.Dilated(timeout));
         }

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -513,7 +513,7 @@ namespace Akka.TestKit
         /// <param name="duration">The maximum.</param>
         /// <returns>A finite <see cref="TimeSpan"/> properly dilated</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="duration"/> is infinite</exception>
-        public TimeSpan RemainingOrDilated(TimeSpan? duration)
+        public TimeSpan RemainingOrDilated([AutoDilate] TimeSpan? duration)
         {
             if(!duration.HasValue) return RemainingOrDefault;
             if(duration < TimeSpan.Zero) throw new ArgumentException("Must be positive TimeSpan", nameof(duration));
@@ -527,7 +527,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="duration">TBD</param>
         /// <returns>TBD</returns>
-        public TimeSpan Dilated(TimeSpan duration)
+        public TimeSpan Dilated([AutoDilate] TimeSpan duration)
         {
             if (duration < TimeSpan.Zero)
                 throw new ArgumentException("Must not be negative", nameof(duration));

--- a/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
@@ -34,14 +34,14 @@ namespace Akka.TestKit
         /// <param name="duration">The timeout.</param>
         /// <param name="interval">The interval to wait between executing the assertion.</param>
         /// <param name="cancellationToken"></param>
-        public void AwaitAssert(Action assertion, TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
+        public void AwaitAssert(Action assertion, [AutoDilate] TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
         {
             AwaitAssertAsync(assertion, duration, interval, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
         
         /// <inheritdoc cref="AwaitAssert(Action, TimeSpan?, TimeSpan?, CancellationToken)"/>
-        public async Task AwaitAssertAsync(Action assertion, TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
+        public async Task AwaitAssertAsync(Action assertion, [AutoDilate] TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
         {
             var intervalValue = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
             if(intervalValue == Timeout.InfiniteTimeSpan) intervalValue = TimeSpan.MaxValue;
@@ -91,7 +91,7 @@ namespace Akka.TestKit
         /// <param name="duration">The timeout.</param>
         /// <param name="interval">The interval to wait between executing the assertion.</param>
         /// <param name="cancellationToken"></param>
-        public async Task AwaitAssertAsync(Func<Task> assertion, TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
+        public async Task AwaitAssertAsync(Func<Task> assertion, [AutoDilate] TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
         {
             var intervalValue = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
             if(intervalValue == Timeout.InfiniteTimeSpan) intervalValue = TimeSpan.MaxValue;

--- a/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
@@ -72,13 +72,13 @@ namespace Akka.TestKit
         /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
         /// specified in config value "akka.test.timefactor".</param>
         /// <param name="cancellationToken"></param>
-        public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, CancellationToken cancellationToken = default)
+        public void AwaitCondition(Func<bool> conditionIsFulfilled, [AutoDilate] TimeSpan? max, CancellationToken cancellationToken = default)
         {
             AwaitConditionAsync(() => Task.FromResult(conditionIsFulfilled()), max, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
         
-        public async Task AwaitConditionAsync(Func<Task<bool>> conditionIsFulfilled, TimeSpan? max, CancellationToken cancellationToken = default)
+        public async Task AwaitConditionAsync(Func<Task<bool>> conditionIsFulfilled, [AutoDilate] TimeSpan? max, CancellationToken cancellationToken = default)
         {
             var maxDur = RemainingOrDilated(max);
             var interval = new TimeSpan(maxDur.Ticks / 10);
@@ -106,13 +106,13 @@ namespace Akka.TestKit
         /// specified in config value "akka.test.timefactor".</param>
         /// <param name="message">The message used if the timeout expires.</param>
         /// <param name="cancellationToken"></param>
-        public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, string message, CancellationToken cancellationToken = default)
+        public void AwaitCondition(Func<bool> conditionIsFulfilled, [AutoDilate] TimeSpan? max, string message, CancellationToken cancellationToken = default)
         {
             AwaitConditionAsync(conditionIsFulfilled, max, message, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
         
-        public async Task AwaitConditionAsync(Func<Task<bool>> conditionIsFulfilled, TimeSpan? max, string message, CancellationToken cancellationToken = default)
+        public async Task AwaitConditionAsync(Func<Task<bool>> conditionIsFulfilled, [AutoDilate] TimeSpan? max, string message, CancellationToken cancellationToken = default)
         {
             var maxDur = RemainingOrDilated(max);
             var interval = new TimeSpan(maxDur.Ticks / 10);
@@ -120,7 +120,7 @@ namespace Akka.TestKit
             await InternalAwaitConditionAsync(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger, cancellationToken);
         }
         
-        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan? max, string message, CancellationToken cancellationToken = default)
+        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, [AutoDilate] TimeSpan? max, string message, CancellationToken cancellationToken = default)
         {
             Task<bool> Wrapped() => Task.FromResult(conditionIsFulfilled());
             await AwaitConditionAsync(Wrapped, max, message, cancellationToken);
@@ -154,13 +154,13 @@ namespace Akka.TestKit
         /// </param>
         /// <param name="message">The message used if the timeout expires.</param>
         /// <param name="cancellationToken"></param>
-        public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, TimeSpan? interval, string message = null, CancellationToken cancellationToken = default)
+        public void AwaitCondition(Func<bool> conditionIsFulfilled, [AutoDilate] TimeSpan? max, TimeSpan? interval, string message = null, CancellationToken cancellationToken = default)
         { 
             AwaitConditionAsync(conditionIsFulfilled, max, interval, message, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
         
-        public async Task AwaitConditionAsync(Func<Task<bool>> conditionIsFulfilled, TimeSpan? max, TimeSpan? interval, string message = null, CancellationToken cancellationToken = default)
+        public async Task AwaitConditionAsync(Func<Task<bool>> conditionIsFulfilled, [AutoDilate] TimeSpan? max, TimeSpan? interval, string message = null, CancellationToken cancellationToken = default)
         {
             var maxDur = RemainingOrDilated(max);
             var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
@@ -168,7 +168,7 @@ namespace Akka.TestKit
                 (format, args) => AssertionsFail(format, args, message), logger, cancellationToken);
         }
         
-        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan? max, TimeSpan? interval, string message = null, CancellationToken cancellationToken = default)
+        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, [AutoDilate] TimeSpan? max, TimeSpan? interval, string message = null, CancellationToken cancellationToken = default)
         {
             Task<bool> Wrapped() => Task.FromResult(conditionIsFulfilled());
             await AwaitConditionAsync(Wrapped, max, interval, message, cancellationToken);
@@ -186,7 +186,7 @@ namespace Akka.TestKit
         /// Between calls the thread sleeps. If <paramref name="interval"/> is not specified or <c>null</c> 100 ms is used.</para>
         /// </summary>
         /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
-        /// <param name="max">The maximum duration.</param>
+        /// <param name="max">The maximum duration. This value is not automatically dilated.</param>
         /// <param name="interval">Optional. The time between calls to <paramref name="conditionIsFulfilled"/> to check
         /// if the condition is fulfilled. Between calls the thread sleeps. If undefined, 100 ms is used
         /// </param>
@@ -213,10 +213,7 @@ namespace Akka.TestKit
         /// <summary>
         /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
         /// expires, whichever comes first.</para>
-        /// <para>If no timeout is given, take it from the innermost enclosing `within`
-        /// block.</para>
-        /// <para>Note that the timeout is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
-        /// specified in config value "akka.test.timefactor".</para>
+        /// <para>Note that the timeout is not automatically scaled using <see cref="Dilated(TimeSpan)"/>.</para>
         /// <para>The parameter <paramref name="interval"/> specifies the time between calls to <paramref name="conditionIsFulfilled"/>
         /// Between calls the thread sleeps. If <paramref name="interval"/> is undefined the thread only sleeps 
         /// one time, using the <paramref name="max"/> as duration, and then rechecks the condition and ultimately 
@@ -225,8 +222,7 @@ namespace Akka.TestKit
         /// instead set it to a relatively small value.</para>
         /// </summary>
         /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
-        /// <param name="max">The maximum duration. The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. 
-        /// scaled by the factor specified in config value "akka.test.timefactor".</param>
+        /// <param name="max">The maximum duration. This value is not automatically dilated.</param>
         /// <param name="interval">The time between calls to <paramref name="conditionIsFulfilled"/> to check
         /// if the condition is fulfilled. Between calls the thread sleeps. If undefined the thread only sleeps 
         /// one time, using the <paramref name="max"/>, and then rechecks the condition and ultimately 
@@ -252,10 +248,7 @@ namespace Akka.TestKit
         /// <summary>
         /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
         /// expires, whichever comes first.</para>
-        /// <para>If no timeout is given, take it from the innermost enclosing `within`
-        /// block.</para>
-        /// <para>Note that the timeout is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
-        /// specified in config value "akka.test.timefactor".</para>
+        /// <para>Note that the timeout is not automatically scaled using <see cref="Dilated(TimeSpan)"/>.</para>
         /// <para>The parameter <paramref name="interval"/> specifies the time between calls to <paramref name="conditionIsFulfilled"/>
         /// Between calls the thread sleeps. If <paramref name="interval"/> is undefined the thread only sleeps 
         /// one time, using the <paramref name="max"/> as duration, and then rechecks the condition and ultimately 
@@ -264,8 +257,7 @@ namespace Akka.TestKit
         /// instead set it to a relatively small value.</para>
         /// </summary>
         /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
-        /// <param name="max">The maximum duration. The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. 
-        /// scaled by the factor specified in config value "akka.test.timefactor".</param>
+        /// <param name="max">The maximum duration. This value is not automatically dilated.</param>
         /// <param name="interval">The time between calls to <paramref name="conditionIsFulfilled"/> to check
         /// if the condition is fulfilled. Between calls the thread sleeps. If undefined the thread only sleeps 
         /// one time, using the <paramref name="max"/>, and then rechecks the condition and ultimately 

--- a/src/core/Akka.TestKit/TestKitBase_Expect.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Expect.cs
@@ -204,7 +204,7 @@ namespace Akka.TestKit
             CancellationToken cancellationToken = default)
         {
             return InternalExpectMsgAsync<T>(
-                    timeout: RemainingOrDilated(RemainingOrDilated(timeout)),
+                    timeout: RemainingOrDilated(timeout),
                     assert: (m, sender) =>
                     {
                         _assertions.AssertTrue(

--- a/src/core/Akka.TestKit/TestKitBase_Expect.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Expect.cs
@@ -36,7 +36,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         /// <returns>TBD</returns>
         public T ExpectMsg<T>(
-            TimeSpan? duration = null,
+            [AutoDilate] TimeSpan? duration = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -45,7 +45,7 @@ namespace Akka.TestKit
         
         /// <inheritdoc cref="ExpectMsg{T}(TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> ExpectMsgAsync<T>(
-            TimeSpan? duration = null, 
+            [AutoDilate] TimeSpan? duration = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -68,7 +68,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T ExpectMsg<T>(
             T message,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -79,7 +79,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ExpectMsg{T}(T, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> ExpectMsgAsync<T>(
             T message,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -108,7 +108,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T ExpectMsg<T>(
             Predicate<T> isMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null, 
             CancellationToken cancellationToken = default)
         {
@@ -119,7 +119,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ExpectMsg{T}(Predicate{T}, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> ExpectMsgAsync<T>(
             Predicate<T> isMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -152,7 +152,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T ExpectMsg<T>(
             Action<T> assert,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -163,7 +163,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ExpectMsg{T}(Action{T}, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> ExpectMsgAsync<T>(
             Action<T> assert,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -188,7 +188,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T ExpectMsg<T>(
             Func<T, IActorRef, bool> isMessageAndSender, 
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -199,7 +199,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ExpectMsg{T}(Func{T, IActorRef, bool}, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> ExpectMsgAsync<T>(
             Func<T, IActorRef, bool> isMessageAndSender,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -235,7 +235,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T ExpectMsg<T>(
             Action<T, IActorRef> assertMessageAndSender, 
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -246,7 +246,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ExpectMsg{T}(Action{T, IActorRef}, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> ExpectMsgAsync<T>(
             Action<T, IActorRef> assertMessageAndSender,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -272,7 +272,7 @@ namespace Akka.TestKit
         public T ExpectMsg<T>(
             T expected,
             Func<T, T, bool> comparer,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -284,7 +284,7 @@ namespace Akka.TestKit
         public ValueTask<T> ExpectMsgAsync<T>(
             T expected,
             Func<T, T, bool> comparer,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -310,7 +310,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public Terminated ExpectTerminated(
             IActorRef target,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -321,7 +321,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ExpectTerminated(IActorRef, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<Terminated> ExpectTerminatedAsync(
             IActorRef target,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -474,13 +474,13 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="duration">TBD</param>
         /// <param name="cancellationToken"></param>
-        public void ExpectNoMsg(TimeSpan duration, CancellationToken cancellationToken = default)
+        public void ExpectNoMsg([AutoDilate] TimeSpan duration, CancellationToken cancellationToken = default)
         {
             ExpectNoMsgAsync(duration, cancellationToken).GetAwaiter().GetResult();
         }
         
         /// <inheritdoc cref="ExpectNoMsg(TimeSpan, CancellationToken)"/>
-        public ValueTask ExpectNoMsgAsync(TimeSpan duration, CancellationToken cancellationToken = default)
+        public ValueTask ExpectNoMsgAsync([AutoDilate] TimeSpan duration, CancellationToken cancellationToken = default)
         {
             return InternalExpectNoMsgAsync(Dilated(duration), cancellationToken);
         }
@@ -596,7 +596,7 @@ namespace Akka.TestKit
         }
         
         public IReadOnlyCollection<T> ExpectMsgAllOf<T>(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             params T[] messages)
         {
             return ExpectMsgAllOf(max, messages, default(CancellationToken));
@@ -622,7 +622,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         /// <returns>The received messages in received order</returns>
         public IReadOnlyCollection<T> ExpectMsgAllOf<T>(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             IReadOnlyCollection<T> messages,
             CancellationToken cancellationToken = default)
         {
@@ -632,7 +632,7 @@ namespace Akka.TestKit
         }
         
         public async IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             IReadOnlyCollection<T> messages,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {

--- a/src/core/Akka.TestKit/TestKitBase_ExpectAllWithPredicates.cs
+++ b/src/core/Akka.TestKit/TestKitBase_ExpectAllWithPredicates.cs
@@ -44,13 +44,13 @@ public abstract partial class TestKitBase
         }
     }
 
-    public IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(TimeSpan max, params PredicateInfo[] predicates)
+    public IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates([AutoDilate] TimeSpan max, params PredicateInfo[] predicates)
     {
         using var cts = new CancellationTokenSource(RemainingOrDefault);
         return ExpectMsgAllOfMatchingPredicates(max, predicates, cts.Token);
     }
 
-    public IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(TimeSpan max,
+    public IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates([AutoDilate] TimeSpan max,
         IReadOnlyCollection<PredicateInfo> predicates, CancellationToken cancellationToken)
     {
         return ExpectMsgAllOfMatchingPredicatesAsync(max, predicates, cancellationToken)
@@ -59,7 +59,7 @@ public abstract partial class TestKitBase
     }
 
     public async IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(
-        TimeSpan max,
+        [AutoDilate] TimeSpan max,
         IReadOnlyCollection<PredicateInfo> predicates,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {

--- a/src/core/Akka.TestKit/TestKitBase_ExpectMsgFrom.cs
+++ b/src/core/Akka.TestKit/TestKitBase_ExpectMsgFrom.cs
@@ -34,7 +34,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T ExpectMsgFrom<T>(
             IActorRef sender,
-            TimeSpan? duration = null,
+            [AutoDilate] TimeSpan? duration = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -48,7 +48,7 @@ namespace Akka.TestKit
 
         public ValueTask<T> ExpectMsgFromAsync<T>(
             IActorRef sender,
-            TimeSpan? duration = null,
+            [AutoDilate] TimeSpan? duration = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -81,7 +81,7 @@ namespace Akka.TestKit
         public T ExpectMsgFrom<T>(
             IActorRef sender,
             T message,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -97,7 +97,7 @@ namespace Akka.TestKit
         public ValueTask<T> ExpectMsgFromAsync<T>(
             IActorRef sender,
             T message,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -131,7 +131,7 @@ namespace Akka.TestKit
         public T ExpectMsgFrom<T>(
             IActorRef sender,
             Predicate<T> isMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -147,7 +147,7 @@ namespace Akka.TestKit
         public ValueTask<T> ExpectMsgFromAsync<T>(
             IActorRef sender,
             Predicate<T> isMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -182,7 +182,7 @@ namespace Akka.TestKit
         public T ExpectMsgFrom<T>(
             Predicate<IActorRef> isSender, 
             Predicate<T> isMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -198,7 +198,7 @@ namespace Akka.TestKit
         public ValueTask<T> ExpectMsgFromAsync<T>(
             Predicate<IActorRef> isSender,
             Predicate<T> isMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -250,7 +250,7 @@ namespace Akka.TestKit
         public T ExpectMsgFrom<T>(
             IActorRef sender,
             Action<T> assertMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -266,7 +266,7 @@ namespace Akka.TestKit
         public ValueTask<T> ExpectMsgFromAsync<T>(
             IActorRef sender,
             Action<T> assertMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -297,7 +297,7 @@ namespace Akka.TestKit
         public T ExpectMsgFrom<T>(
             Action<IActorRef> assertSender, 
             Action<T> assertMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -313,7 +313,7 @@ namespace Akka.TestKit
         public ValueTask<T> ExpectMsgFromAsync<T>(
             Action<IActorRef> assertSender, 
             Action<T> assertMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -33,7 +33,7 @@ namespace Akka.TestKit
         /// <returns>Returns the message that <paramref name="isMessage"/> matched</returns>
         public object FishForMessage(
             Predicate<object> isMessage,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             string hint = "",
             CancellationToken cancellationToken = default)
         {
@@ -44,7 +44,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="FishForMessage(Predicate{object}, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<object> FishForMessageAsync(
             Predicate<object> isMessage,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             string hint = "",
             CancellationToken cancellationToken = default)
         {
@@ -63,7 +63,7 @@ namespace Akka.TestKit
         /// <returns>Returns the message that <paramref name="isMessage"/> matched</returns>
         public T FishForMessage<T>(
             Predicate<T> isMessage,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             string hint = "",
             CancellationToken cancellationToken = default)
         {
@@ -74,7 +74,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="FishForMessage{T}(Predicate{T}, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> FishForMessageAsync<T>(
             Predicate<T> isMessage,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             string hint = "",
             CancellationToken cancellationToken = default)
         {
@@ -95,7 +95,7 @@ namespace Akka.TestKit
         public T FishForMessage<T>(
             Predicate<T> isMessage,
             ArrayList allMessages,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             string hint = "",
             CancellationToken cancellationToken = default)
         {
@@ -107,7 +107,7 @@ namespace Akka.TestKit
         public async ValueTask<T> FishForMessageAsync<T>(
             Predicate<T> isMessage,
             ArrayList allMessages, 
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             string hint = "",
             CancellationToken cancellationToken = default)
         {
@@ -139,7 +139,7 @@ namespace Akka.TestKit
         /// <typeparam name="T">The type that the message is not supposed to be.</typeparam>
         /// <param name="max">Optional. The maximum wait duration. Defaults to <see cref="RemainingOrDefault"/> when unset.</param>
         /// <param name="cancellationToken"></param>
-        public async Task FishUntilMessageAsync<T>(TimeSpan? max = null, CancellationToken cancellationToken = default)
+        public async Task FishUntilMessageAsync<T>([AutoDilate] TimeSpan? max = null, CancellationToken cancellationToken = default)
         {
             var enumerable = ReceiveWhileAsync<object>(
                 max: max, 
@@ -485,7 +485,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         /// <returns>TBD</returns>
         public IReadOnlyList<T> ReceiveWhile<T>(
-            TimeSpan? max,
+            [AutoDilate] TimeSpan? max,
             Func<object, T> filter, 
             int msgs = int.MaxValue,
             CancellationToken cancellationToken = default)
@@ -497,7 +497,7 @@ namespace Akka.TestKit
 
         /// <inheritdoc cref="ReceiveWhile{T}(TimeSpan?, Func{object, T}, int, CancellationToken)"/>
         public async IAsyncEnumerable<T> ReceiveWhileAsync<T>(
-            TimeSpan? max,
+            [AutoDilate] TimeSpan? max,
             Func<object, T> filter,
             int msgs = int.MaxValue,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -526,7 +526,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         /// <returns>TBD</returns>
         public IReadOnlyList<T> ReceiveWhile<T>(
-            TimeSpan? max,
+            [AutoDilate] TimeSpan? max,
             TimeSpan? idle,
             Func<object, T> filter, 
             int msgs = int.MaxValue,
@@ -539,7 +539,7 @@ namespace Akka.TestKit
 
         /// <inheritdoc cref="ReceiveWhile{T}(TimeSpan?, TimeSpan?, Func{object, T}, int, CancellationToken)"/>
         public async IAsyncEnumerable<T> ReceiveWhileAsync<T>(
-            TimeSpan? max,
+            [AutoDilate] TimeSpan? max,
             TimeSpan? idle,
             Func<object, T> filter,
             int msgs = int.MaxValue,
@@ -570,7 +570,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public IReadOnlyList<T> ReceiveWhile<T>(
             Func<object, T> filter,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             TimeSpan? idle = null,
             int msgs = int.MaxValue,
             CancellationToken cancellationToken = default)
@@ -583,7 +583,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ReceiveWhile{T}(Func{object, T}, TimeSpan?, TimeSpan?, int, CancellationToken)"/>
         public async IAsyncEnumerable<T> ReceiveWhileAsync<T>(
             Func<object, T> filter,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             TimeSpan? idle = null,
             int msgs = int.MaxValue,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -663,7 +663,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public IReadOnlyList<T> ReceiveWhile<T>(
             Predicate<T> shouldContinue, 
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             TimeSpan? idle = null,
             int msgs = int.MaxValue,
             bool shouldIgnoreOtherMessageTypes = true, 
@@ -677,7 +677,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ReceiveWhile{T}(Predicate{T}, TimeSpan?, TimeSpan?, int, bool, CancellationToken)"/>
         public async IAsyncEnumerable<T> ReceiveWhileAsync<T>(
             Predicate<T> shouldContinue,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             TimeSpan? idle = null,
             int msgs = int.MaxValue,
             bool shouldIgnoreOtherMessageTypes = true,
@@ -789,7 +789,7 @@ namespace Akka.TestKit
         /// <returns>The received messages</returns>
         public IReadOnlyCollection<object> ReceiveN(
             int numberOfMessages,
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             CancellationToken cancellationToken = default)
         {
             return ReceiveNAsync(numberOfMessages, max, cancellationToken)
@@ -800,7 +800,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ReceiveN(int, TimeSpan, CancellationToken)"/>
         public async IAsyncEnumerable<object> ReceiveNAsync(
             int numberOfMessages, 
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             max.EnsureIsPositiveFinite("max");

--- a/src/core/Akka.TestKit/TestKitBase_Within.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Within.cs
@@ -30,7 +30,7 @@ namespace Akka.TestKit
         /// <param name="epsilonValue">TBD</param>
         /// <param name="cancellationToken"></param>
         public void Within(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Action action,
             TimeSpan? epsilonValue = null,
             CancellationToken cancellationToken = default)
@@ -54,7 +54,7 @@ namespace Akka.TestKit
         /// that takes a <see cref="Func{Task}"/> instead of an <see cref="Action"/>
         /// </summary>
         public async Task WithinAsync(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Func<Task> actionAsync,
             TimeSpan? epsilonValue = null,
             CancellationToken cancellationToken = default)
@@ -88,7 +88,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         public void Within(
             TimeSpan min,
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Action action,
             string hint = null,
             TimeSpan? epsilonValue = null,
@@ -114,7 +114,7 @@ namespace Akka.TestKit
         /// </summary>
         public async Task WithinAsync(
             TimeSpan min,
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Func<Task> actionAsync,
             string hint = null,
             TimeSpan? epsilonValue = null,
@@ -148,7 +148,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         /// <returns>TBD</returns>
         public T Within<T>(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Func<T> function,
             TimeSpan? epsilonValue = null,
             CancellationToken cancellationToken = default)
@@ -177,7 +177,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         /// <returns>TBD</returns>
         public Task<T> WithinAsync<T>(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Func<Task<T>> function,
             TimeSpan? epsilonValue = null,
             CancellationToken cancellationToken = default)
@@ -208,7 +208,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T Within<T>(
             TimeSpan min,
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Func<T> function,
             string hint = null,
             TimeSpan? epsilonValue = null,
@@ -250,7 +250,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public async Task<T> WithinAsync<T>(
             TimeSpan min,
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Func<Task<T>> function,
             string hint = null,
             TimeSpan? epsilonValue = null,


### PR DESCRIPTION
Backport of #8430 and #8441 to `v1.5`.

- **#8430** — Fix double-dilated timeout in `ExpectMsgAsync<T>(Func<T, IActorRef, bool>, ...)`
- **#8441** — Add `[AutoDilate]` metadata to TestKit timeout parameters