### PR TITLE
fix: harden BatchWriterSettings when batching HOCON is missing (#7178)

### DIFF
--- a/src/core/Akka.Remote.Tests/Transport/DotNettyBatchWriterSpecs.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyBatchWriterSpecs.cs
@@ -75,6 +75,35 @@ namespace Akka.Remote.Tests.Transport
             s.BatchWriterSettings.MaxExplicitFlushes.Should().NotBe(BatchWriterSettings.DefaultMaxPendingWrites);
         }
 
+        [Fact]
+        public void Bugfix7178_should_use_defaults_when_batching_section_is_missing()
+        {
+            // Reproduces multi-homed / custom transport configs that do not fall back
+            // to akka.remote.dot-netty.tcp and therefore omit the batching HOCON block.
+            Config c = @"
+                akka.remote.dot-netty.tcp-eth0 {
+                    transport-class = ""Akka.Remote.Transport.DotNetty.TcpTransport, Akka.Remote""
+                    transport-protocol = tcp
+                    port = 50051
+                    hostname = ""127.0.0.1""
+                }
+            ";
+
+            var s = DotNettyTransportSettings.Create(c.GetConfig("akka.remote.dot-netty.tcp-eth0"));
+
+            s.BatchWriterSettings.EnableBatching.Should().BeTrue();
+            s.BatchWriterSettings.MaxExplicitFlushes.Should().Be(BatchWriterSettings.DefaultMaxPendingWrites);
+        }
+
+        [Fact]
+        public void Bugfix7178_BatchWriterSettings_should_tolerate_null_config()
+        {
+            var settings = new BatchWriterSettings(null);
+
+            settings.EnableBatching.Should().BeTrue();
+            settings.MaxExplicitFlushes.Should().Be(BatchWriterSettings.DefaultMaxPendingWrites);
+        }
+
         /// <summary>
         /// Stay below the write / count and write / byte threshold. Rely on the timer.
         /// </summary>

--- a/src/core/Akka.Remote/Transport/DotNetty/BatchWriter.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/BatchWriter.cs
@@ -215,6 +215,16 @@ namespace Akka.Remote.Transport.DotNetty
 
         public BatchWriterSettings(Config hocon)
         {
+            // Custom transports (e.g. akka.remote.dot-netty.tcp-eth0) often omit the
+            // batching section. Fall back to defaults instead of NRE on null Config.
+            // See https://github.com/akkadotnet/akka.net/issues/7178
+            if (hocon.IsNullOrEmpty())
+            {
+                EnableBatching = true;
+                MaxExplicitFlushes = DefaultMaxPendingWrites;
+                return;
+            }
+
             EnableBatching = hocon.GetBoolean("enabled", true);
             MaxExplicitFlushes = hocon.GetInt("max-pending-writes", DefaultMaxPendingWrites);
         }


### PR DESCRIPTION
Hardens BatchWriterSettings so missing/null batching HOCON falls back to defaults instead of erroring.
Fixes #7178
