### PR TITLE
docs: document MergeSubstreams IFlow cast requirement (#5381)

### DIFF
--- a/docs/articles/streams/builtinstages.md
+++ b/docs/articles/streams/builtinstages.md
@@ -1074,6 +1074,9 @@ a new substream is opened and subsequently fed with all elements belonging to th
 
 > [!WARNING]
 > If `allowClosedSubstreamRecreation` is set to `false` (default behavior) the stage keeps track of all keys of streams that have already been closed. If you expect an infinite number of keys this can cause memory issues. Elements belonging to those keys are drained directly and not send to the substream.
+
+> [!IMPORTANT]
+> After transforming the substreams, call `MergeSubstreams` (or `ConcatSubstream`) to flatten them. Those methods return `IFlow<TOut, TMat>`; cast back to `Source` / `Flow` if you need operators that are not defined on `IFlow`. See [Implementing Reduce-By-Key](xref:streams-cookbook#implementing-reduce-by-key) and [#5381](https://github.com/akkadotnet/akka.net/issues/5381).
 <!-- markdownlint-enable MD028 -->
 
 **emits** an element for which the grouping function returns a group that has not yet been created. Emits the new group

--- a/docs/articles/streams/cookbook.md
+++ b/docs/articles/streams/cookbook.md
@@ -214,6 +214,23 @@ var counts = words
     .MergeSubstreams();
 ```
 
+> [!IMPORTANT]
+> `MergeSubstreams`, `MergeSubstreamsWithParallelism`, and `ConcatSubstream` return `IFlow<TOut, TMat>`, not the concrete `Source` / `Flow` you started from. .NET cannot express the higher-kinded typing used by the Scala API, so cast back when you need Source- or Flow-specific operators:
+>
+> ```csharp
+> var merged = words
+>     .GroupBy(MaximumDistinctWords, x => x)
+>     .Select(x => Tuple.Create(x, 1))
+>     .Sum((l, r) => Tuple.Create(l.Item1, l.Item2 + r.Item2))
+>     .MergeSubstreams();
+>
+> // Continue with Source-specific APIs after an explicit cast
+> ((Source<Tuple<string, int>, NotUsed>)merged)
+>     .WireTapMaterialized(Sink.Ignore<Tuple<string, int>>(), Keep.Left);
+> ```
+>
+> Operators that already exist on `IFlow` (for example `Select`, `Where`, `RunWith`) do not need a cast.
+
 By extracting the parts specific to `wordcount` into
 
 * a ``GroupKey`` function that defines the groups

--- a/src/core/Akka.Streams/Dsl/SubFlow.cs
+++ b/src/core/Akka.Streams/Dsl/SubFlow.cs
@@ -75,7 +75,18 @@ namespace Akka.Streams.Dsl
         /// without parallelism limit (i.e. having an unbounded number of sub-flows
         /// active concurrently).
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <remarks>
+        /// Returns <see cref="IFlow{TOut,TMat}"/> rather than the concrete <see cref="Source{TOut,TMat}"/>
+        /// or <see cref="Flow{TIn,TOut,TMat}"/> that produced the sub-flows. .NET cannot express the
+        /// higher-kinded / F-bounded typing used by the Scala API, so cast back when you need
+        /// Source- or Flow-specific operators (for example <c>WireTapMaterialized</c>):
+        /// <code>
+        /// var merged = source.GroupBy(10, x => x % 10).Sum((a, b) => a + b).MergeSubstreams();
+        /// ((Source&lt;int, NotUsed&gt;)merged).WireTapMaterialized(...);
+        /// </code>
+        /// See https://github.com/akkadotnet/akka.net/issues/5381
+        /// </remarks>
+        /// <returns>The flattened flow as an <see cref="IFlow{TOut,TMat}"/>.</returns>
         public virtual IFlow<TOut, TMat> MergeSubstreams() => MergeSubstreamsWithParallelism(int.MaxValue);
 
         /// <summary>
@@ -86,18 +97,28 @@ namespace Akka.Streams.Dsl
         /// be exerted at the operator that creates the substreams when the parallelism
         /// limit is reached.
         /// </summary>
-        /// <param name="parallelism">TBD</param>
-        /// <returns>TBD</returns>
+        /// <remarks>
+        /// Same typing caveat as <see cref="MergeSubstreams"/>: the result is an
+        /// <see cref="IFlow{TOut,TMat}"/> and must be cast back to <see cref="Source{TOut,TMat}"/>
+        /// or <see cref="Flow{TIn,TOut,TMat}"/> to keep using the concrete builder APIs.
+        /// </remarks>
+        /// <param name="parallelism">Maximum number of substreams that may run concurrently.</param>
+        /// <returns>The flattened flow as an <see cref="IFlow{TOut,TMat}"/>.</returns>
         public abstract IFlow<TOut, TMat> MergeSubstreamsWithParallelism(int parallelism);
 
         /// <summary>
         /// Flatten the sub-flows back into the super-flow by concatenating them.
         /// This is usually a bad idea when combined with <see cref="Akka.Streams.Implementation.Fusing.GroupBy{TIn,TKey}"/>
-        /// since it can easily lead to deadlockâ€”the concatenation does not consume from the second
+        /// since it can easily lead to deadlock—the concatenation does not consume from the second
         /// substream until the first has finished and the <see cref="Akka.Streams.Implementation.Fusing.GroupBy{TIn,TKey}"/>
         /// stage will get back-pressure from the second stream.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <remarks>
+        /// Same typing caveat as <see cref="MergeSubstreams"/>: the result is an
+        /// <see cref="IFlow{TOut,TMat}"/> and must be cast back to the concrete <c>Source</c>/<c>Flow</c>
+        /// type to continue with type-specific operators.
+        /// </remarks>
+        /// <returns>The concatenated flow as an <see cref="IFlow{TOut,TMat}"/>.</returns>
         public virtual IFlow<TOut, TMat> ConcatSubstream() => MergeSubstreamsWithParallelism(1);
     }
 }


### PR DESCRIPTION
Documents that MergeSubstreams returns IFlow and must be cast back to Source/Flow.
Fixes #5381
