### PR TITLE
docs: add IAsyncEnumerable Akka.Streams examples (#5460)

### DIFF
--- a/docs/articles/streams/basics.md
+++ b/docs/articles/streams/basics.md
@@ -153,6 +153,9 @@ examples show some of the most useful constructs (refer to the API documentation
 // Create a source from an Iterable
 Source.From(new List<int> {1, 2, 3});
 
+// Create a source from an IAsyncEnumerable factory (new enumerator per materialization)
+Source.From(() => GetNumbersAsync());
+
 // Create a source from a Task
 Source.FromTask(Task.FromResult("Hello Streams!"));
 
@@ -175,6 +178,10 @@ Sink.Ignore<int>();
 
 // A Sink that executes a side-effecting call for every element of the stream
 Sink.ForEach<string>(Console.WriteLine);
+
+// Run a Source as IAsyncEnumerable (re-materializes on each await foreach)
+// See streams-integration for full examples
+// await foreach (var x in source.RunAsAsyncEnumerable(materializer)) { ... }
 ```  
   
 There are various ways to wire up different parts of a stream, the following examples show some of the available options:

--- a/docs/articles/streams/builtinstages.md
+++ b/docs/articles/streams/builtinstages.md
@@ -28,6 +28,16 @@ Stream the values of an ``IEnumerable<T>``.
 
 **completes** when the last element of the enumerable has been emitted
 
+### From (IAsyncEnumerable)
+
+Stream values from an ``IAsyncEnumerable<T>`` factory. A new enumerable is created for each materialization.
+
+See [Integrating with IAsyncEnumerable](xref:streams-integration#integrating-with-iasyncenumerable).
+
+**emits** the next value returned from the async enumerator
+
+**completes** when the async enumerable reaches its end
+
 ### Never
 
 A source which never emits any elements, never completes and never fails. Useful for tests.

--- a/docs/articles/streams/integration.md
+++ b/docs/articles/streams/integration.md
@@ -436,6 +436,29 @@ You may notice two extra parameters here. One of the advantages of Akka.Streams 
 
 Any other `OverflowStrategy` option is not supported by `Source.FromObservable` stage.
 
+### Integrating with IAsyncEnumerable
+
+Akka.Streams can both **consume** and **produce** [`IAsyncEnumerable<T>`](https://learn.microsoft.com/dotnet/api/system.collections.generic.iasyncenumerable-1) sequences. This is useful when bridging streams with `async`/`await` code, libraries that expose async iterators, or C# 8+ `await foreach`.
+
+#### Source from IAsyncEnumerable
+
+Use `Source.From(Func<IAsyncEnumerable<T>>)` so a fresh enumerable is created for every materialization:
+
+[!code-csharp[SourceFromAsyncEnumerable](../../../src/core/Akka.Docs.Tests/Streams/AsyncEnumerableDocTests.cs?name=source-from-asyncenumerable)]
+
+> [!NOTE]
+> Pass a **factory** (`Func<IAsyncEnumerable<T>>`), not a single enumerable instance. Each subscriber / materialization needs its own enumerator.
+
+#### Consuming a Source as IAsyncEnumerable
+
+`RunAsAsyncEnumerable` turns a `Source` into a lazy, re-runnable async sequence. Each `await foreach` re-materializes the stream:
+
+[!code-csharp[RunAsAsyncEnumerable](../../../src/core/Akka.Docs.Tests/Streams/AsyncEnumerableDocTests.cs?name=run-as-asyncenumerable)]
+
+For custom queue buffering / back-pressure, use `RunAsAsyncEnumerableBuffer`:
+
+[!code-csharp[RunAsAsyncEnumerableBuffer](../../../src/core/Akka.Docs.Tests/Streams/AsyncEnumerableDocTests.cs?name=run-as-asyncenumerable-buffer)]
+
 ### Integrating with Event Handlers
 
 C# events can also be used as a potential source of an Akka.NET stream. This is possible using `Source.FromEvent` methods. Example:

--- a/src/core/Akka.Docs.Tests/Streams/AsyncEnumerableDocTests.cs
+++ b/src/core/Akka.Docs.Tests/Streams/AsyncEnumerableDocTests.cs
@@ -1,0 +1,83 @@
+//-----------------------------------------------------------------------
+// <copyright file="AsyncEnumerableDocTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using Akka.TestKit.Xunit;
+using Xunit;
+
+namespace DocsExamples.Streams
+{
+    public class AsyncEnumerableDocTests : TestKit
+    {
+        #region source-from-asyncenumerable
+        private static async IAsyncEnumerable<int> TickAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            for (var i = 1; i <= 3; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Delay(10, cancellationToken);
+                yield return i;
+            }
+        }
+
+        public async Task SourceFromAsyncEnumerable()
+        {
+            var materializer = Sys.Materializer();
+
+            // Factory is invoked for every materialization / subscriber
+            await Source.From(() => TickAsync())
+                .RunForeach(Console.WriteLine, materializer);
+        }
+        #endregion
+
+        #region run-as-asyncenumerable
+        public async Task RunSourceAsAsyncEnumerable()
+        {
+            var materializer = Sys.Materializer();
+
+            var source = Source.From(new[] { 1, 2, 3 })
+                .Select(x => x * 2);
+
+            // Re-runnable: each await foreach materializes the stream again
+            await foreach (var n in source.RunAsAsyncEnumerable(materializer))
+            {
+                Console.WriteLine(n);
+            }
+        }
+        #endregion
+
+        #region run-as-asyncenumerable-buffer
+        public async Task RunSourceAsAsyncEnumerableWithCustomBuffer()
+        {
+            var materializer = Sys.Materializer();
+
+            var source = Source.From(Enumerable.Range(1, 20));
+
+            await foreach (var n in source.RunAsAsyncEnumerableBuffer(materializer, minBuffer: 2, maxBuffer: 8))
+            {
+                Console.WriteLine(n);
+            }
+        }
+        #endregion
+
+        [Fact]
+        public async Task Samples_should_compile_and_run()
+        {
+            await SourceFromAsyncEnumerable();
+            await RunSourceAsAsyncEnumerable();
+            await RunSourceAsAsyncEnumerableWithCustomBuffer();
+        }
+    }
+}


### PR DESCRIPTION
Adds IAsyncEnumerable Source/RunAsAsyncEnumerable examples to the Streams docs.
Fixes #5460
