### PR TITLE
docs: clarify BackoffSupervisor.PropsWithSupervisorStrategy (#5065)

### DIFF
--- a/docs/articles/concepts/supervision.md
+++ b/docs/articles/concepts/supervision.md
@@ -157,6 +157,33 @@ var supervisor = BackoffSupervisor.Props(
 
 The above code sets up a back-off supervisor that restarts the child after back-off if `MyException` is thrown, any other exception will be escalated. The back-off is automatically reset if the child does not throw any errors within 10 seconds.
 
+### `PropsWithSupervisorStrategy` vs `Backoff.OnStop` / `Backoff.OnFailure`
+
+`BackoffSupervisor.PropsWithSupervisorStrategy` is easy to confuse with the `Backoff.OnFailure` / `Backoff.OnStop` builders, but it is **not** a shorthand for either of them.
+
+| API | Supervisor created | When exponential back-off applies |
+|-----|--------------------|-----------------------------------|
+| `Backoff.OnStop(...)` | `BackoffSupervisor` | After the child **stops** (failures are typically turned into stops via a stopping strategy) |
+| `Backoff.OnFailure(...)` | Internal restart-oriented supervisor | When the strategy decides **`Directive.Restart`** — that restart is translated into stop + delayed restart |
+| `BackoffSupervisor.PropsWithSupervisorStrategy(...)` | `BackoffSupervisor` | Only after the child is **`Terminated`**. The passed `SupervisorStrategy` still runs first: with `DefaultStrategy`, most exceptions **`Restart` immediately with no delay** |
+
+Example of the older factory with a custom strategy:
+
+```csharp
+var supervisor = BackoffSupervisor.PropsWithSupervisorStrategy(
+    childProps,
+    childName: "myEcho",
+    minBackoff: TimeSpan.FromSeconds(3),
+    maxBackoff: TimeSpan.FromSeconds(30),
+    randomFactor: 0.2,
+    strategy: new OneForOneStrategy(ex =>
+        ex is MyException ? Directive.Stop : Directive.Escalate));
+```
+
+Here `MyException` stops the child, then `BackoffSupervisor` restarts it after the back-off delay. A `Directive.Restart` from this strategy would **not** use that delay.
+
+For new code, prefer the options API — for stop-based back-off with a custom strategy use `Backoff.OnStop(...).WithSupervisorStrategy(...)`, and for restart-based back-off use `Backoff.OnFailure(...)`.
+
 ## One-For-One Strategy vs. All-For-One Strategy
 
 There are two classes of supervision strategies which come with Akka: `OneForOneStrategy` and `AllForOneStrategy`. Both are configured with a mapping from exception type to supervision directive and limits on how often a child is allowed to fail before terminating it. The difference between them is that the former applies the obtained directive only to the failed child, whereas the latter applies it to all siblings as well. Normally, you should use the `OneForOneStrategy`, which also is the default if none is specified explicitly.

--- a/src/core/Akka/Pattern/BackoffSupervisor.cs
+++ b/src/core/Akka/Pattern/BackoffSupervisor.cs
@@ -239,12 +239,47 @@ namespace Akka.Pattern
         /// <summary>
         /// Props for creating a <see cref="BackoffSupervisor"/> actor with a custom supervision strategy.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is <b>not</b> a shorthand for <c>BackoffSupervisor.Props(Backoff.OnFailure(...))</c>
+        /// or <c>Backoff.OnStop(...)</c>. Those builders create different supervisors:
+        /// </para>
+        /// <list type="bullet">
+        /// <item>
+        /// <description>
+        /// <see cref="Backoff.OnStop"/> also creates a <see cref="BackoffSupervisor"/>, but defaults to a
+        /// stopping strategy so failures become stops and the exponential back-off applies after the child stops.
+        /// </description>
+        /// </item>
+        /// <item>
+        /// <description>
+        /// <see cref="Backoff.OnFailure"/> creates a different supervisor that translates
+        /// <see cref="Directive.Restart"/> into a stop + delayed restart (back-off on crash/restart).
+        /// </description>
+        /// </item>
+        /// <item>
+        /// <description>
+        /// <see cref="PropsWithSupervisorStrategy"/> always creates <see cref="BackoffSupervisor"/>:
+        /// <paramref name="strategy"/> handles exceptions immediately (for example
+        /// <see cref="Actor.SupervisorStrategy.DefaultStrategy"/> restarts the child <b>without</b> delay),
+        /// while the exponential back-off only runs after the child is <see cref="Terminated"/>
+        /// (stop, or a strategy that chooses <see cref="Directive.Stop"/>).
+        /// </description>
+        /// </item>
+        /// </list>
+        /// <para>
+        /// Prefer <see cref="Backoff.OnStop"/> / <see cref="Backoff.OnFailure"/> for new code unless you
+        /// specifically need a custom <see cref="SupervisorStrategy"/> with stop-based back-off.
+        /// Equivalent stop-based setup via options:
+        /// <c>Backoff.OnStop(...).WithSupervisorStrategy(strategy)</c>.
+        /// </para>
+        /// </remarks>
         /// <param name="childProps">The <see cref="Akka.Actor.Props"/> of the child actor that will be started and supervised</param>
         /// <param name="childName">Name of the child actor</param>
         /// <param name="minBackoff">Minimum (initial) duration until the child actor will started again, if it is terminated</param>
         /// <param name="maxBackoff">The exponential back-off is capped to this duration</param>
         /// <param name="randomFactor">After calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
-        /// <param name="strategy">The supervision strategy to use for handling exceptions in the child</param>
+        /// <param name="strategy">The supervision strategy to use for handling exceptions in the child. Does not by itself enable back-off on <see cref="Directive.Restart"/>; use <see cref="Backoff.OnFailure"/> for that.</param>
         public static Props PropsWithSupervisorStrategy(
             Props childProps,
             string childName,


### PR DESCRIPTION
Clarifies that PropsWithSupervisorStrategy is not a shorthand for Backoff.OnFailure/OnStop.
Fixes #5065
