### PR TITLE
docs: note SaveSnapshot payloads must be immutable (#5058)

### DIFF
--- a/docs/articles/persistence/architecture.md
+++ b/docs/articles/persistence/architecture.md
@@ -35,7 +35,7 @@ Persistent actors also offer a set of specialized members:
 * `DeferAsync` is used to perform various operations *after* events will be persisted and their callback handlers will be invoked. Unlike the persist methods, defer won't store an event in persistent storage. Defer method may NOT be invoked in case when the actor is restarted even though the journal will successfully persist events sent.
 * `DeleteMessages` will order attached journal to remove part of its events. It can be only physical deletion, when the messages are removed physically from the journal.
 * `LoadSnapshot` will send a request to the snapshot store to resend the current actor's snapshot.
-* `SaveSnapshot` will send the current actor's internal state as a snapshot to be saved by the configured snapshot store.
+* `SaveSnapshot` will send the current actor's internal state as a snapshot to be saved by the configured snapshot store. The snapshot payload must be immutable (or a defensive copy) — see [Snapshots](xref:snapshots).
 * `DeleteSnapshot` and `DeleteSnapshots` methods may be used to specify snapshots to be removed from the snapshot store in cases where they are no longer needed.
 * `OnReplaySuccess` is a virtual method which will be called when the recovery cycle ends successfully.
 * `OnReplayFailure` is a virtual method which will be called when the recovery cycle fails unexpectedly from some reason.

--- a/docs/articles/persistence/snapshots.md
+++ b/docs/articles/persistence/snapshots.md
@@ -8,6 +8,11 @@ Snapshots can dramatically reduce recovery times of persistent actors and views.
 
 Persistent actors can save snapshots of internal state by calling the `SaveSnapshot` method. If saving of a snapshot succeeds, the persistent actor receives a `SaveSnapshotSuccess` message, otherwise a `SaveSnapshotFailure` message.
 
+> [!IMPORTANT]
+> Snapshot payloads must be treated as **immutable messages**. `SaveSnapshot` wraps your state in a `SaveSnapshot` command that is processed asynchronously by the snapshot store plugin — the actor is **not** suspended while the snapshot is being persisted (unlike `Persist` / `PersistAsync` for events). If you keep mutating the same object instance after calling `SaveSnapshot`, the store may serialize a partially updated or corrupted copy.
+>
+> Prefer immutable snapshot types (records, immutable collections, deep copies). If your state is a mutable object, pass a defensive copy into `SaveSnapshot` and do not mutate that copy afterward.
+
 [!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Persistence/PersistentActor/Snapshots.cs?name=Snapshots)]
 
 During recovery, the persistent actor is offered a previously saved snapshot via a `SnapshotOffer` message from which it can initialize internal state.


### PR DESCRIPTION
Notes that SaveSnapshot payloads must be immutable because snapshot persistence is asynchronous.
Fixes #5058
