### PR TITLE
docs: document ActorInitializationException on PreStart failure (#5969)

### DIFF
--- a/docs/articles/actors/fault-tolerance.md
+++ b/docs/articles/actors/fault-tolerance.md
@@ -54,8 +54,23 @@ exceptions are handled by default:
 * `ActorKilledException` will stop the failing child actor; and
 * Any other type of `Exception` will restart the failing child actor.
 
-You can combine your own strategy with the default strategy like this:
+#### `ActorInitializationException` and `PreStart` failures
 
+If an actor throws during construction or in `PreStart`, Akka wraps that failure in `ActorInitializationException` and reports it to the supervisor. Under the **default** strategy that means the child is **stopped**, not restarted — even though a plain `Exception` during normal message handling would restart.
+
+Consequences:
+
+* A failing `PreStart` does not get another chance unless the supervisor explicitly decides `Directive.Restart` for `ActorInitializationException` (or for the inner exception your decider inspects).
+* Because the actor never finished starting, **`PostStop` is not run** for that failed incarnation. Cleanup that only lives in `PostStop` (for example timer teardown via `IWithTimers`) will not run. Prefer try/finally inside `PreStart`, or supervise with a strategy that restarts initialization failures if retry is intended.
+
+Example: restart on every failure, including initialization:
+
+```csharp
+protected override SupervisorStrategy SupervisorStrategy() =>
+    new OneForOneStrategy(_ => Directive.Restart);
+```
+
+You can combine your own strategy with the default strategy like this:
 ```csharp
 protected override SupervisorStrategy SupervisorStrategy()
 {

--- a/docs/articles/actors/receive-actor-api.md
+++ b/docs/articles/actors/receive-actor-api.md
@@ -242,6 +242,9 @@ protected override void PreStart()
 
 This method is called when the actor is first created. During restarts it is called by the default implementation of `PostRestart`, which means that by overriding that method you can choose whether the initialization code in this method is called only exactly once for this actor or for every restart. Initialization code which is part of the actor's constructor will always be called when an instance of the actor class is created, which happens at every restart.
 
+> [!IMPORTANT]
+> An exception thrown from `PreStart` (or the actor constructor) becomes an `ActorInitializationException`. The default supervisor strategy **stops** the actor in that case — it will not restart. `PostStop` is also not invoked for that failed start. See [Fault Tolerance](xref:fault-tolerance#actorinitializationexception-and-prestart-failures).
+
 ### Restart Hooks
 
 All actors are supervised, i.e. linked to another actor with a fault handling strategy. Actors may be restarted in case an exception is thrown while processing a message (see [Supervision and Monitoring](xref:supervision). This restart involves the hooks mentioned above:

--- a/docs/articles/actors/untyped-actor-api.md
+++ b/docs/articles/actors/untyped-actor-api.md
@@ -269,6 +269,9 @@ protected override void PreStart()
 
 This method is called when the actor is first created. During restarts it is called by the default implementation of `PostRestart`, which means that by overriding that method you can choose whether the initialization code in this method is called only exactly once for this actor or for every restart. Initialization code which is part of the actor's constructor will always be called when an instance of the actor class is created, which happens at every restart.
 
+> [!IMPORTANT]
+> An exception thrown from `PreStart` (or the actor constructor) becomes an `ActorInitializationException`. The default supervisor strategy **stops** the actor in that case — it will not restart. `PostStop` is also not invoked for that failed start. See [Fault Tolerance](xref:fault-tolerance#actorinitializationexception-and-prestart-failures).
+
 ### Restart Hooks
 
 All actors are supervised, i.e. linked to another actor with a fault handling strategy. Actors may be restarted in case an exception is thrown while processing a message (see [Supervision and Monitoring](xref:supervision). This restart involves the hooks mentioned above:


### PR DESCRIPTION
Documents that PreStart/constructor failures become ActorInitializationException and default to Stop (no PostStop).
Fixes #5969
