### PR TITLE
docs: clarify tutorial NuGet packages and TestKit Sys (#7509)

### DIFF
--- a/docs/articles/intro/getting-started/tutorial-1.md
+++ b/docs/articles/intro/getting-started/tutorial-1.md
@@ -67,6 +67,9 @@ Creating a non-top-level actor is possible from any actor, by invoking
 `Context.ActorOf()` which has the exact same signature as its top-level
 counterpart. This is how it looks like in practice:
 
+> [!NOTE]
+> Snippets that call `Sys.ActorOf(...)` assume a test class inheriting `Akka.TestKit.Xunit2.TestKit` (package `Akka.TestKit.Xunit2`). See [Tutorial Overview — Prerequisites](xref:tutorial-overview#prerequisites). In a console app, use `ActorSystem.Create(...).ActorOf(...)` instead.
+
 [!code-csharp[Main](../../../../src/core/Akka.Docs.Tutorials/Tutorial1/ActorHierarchyExperiments.cs?name=print-refs)]
 [!code-csharp[Main](../../../../src/core/Akka.Docs.Tutorials/Tutorial1/ActorHierarchyExperiments.cs?name=print-refs2)]
 

--- a/docs/articles/intro/getting-started/tutorial-2.md
+++ b/docs/articles/intro/getting-started/tutorial-2.md
@@ -180,7 +180,7 @@ Putting read and write protocol together, the device actor will look like this:
 [!code-csharp[Main](../../../../src/core/Akka.Docs.Tutorials/Tutorial2/Device.cs?name=full-device)]
 
 We are also responsible for writing a new test case now, exercising both the read/query and write/record functionality
-together. Note, that your test class should implement Akka.TestKit.XUnit2.TestKit in order to access CreateTestProbe().
+together. Note that your test class should **inherit** `Akka.TestKit.Xunit2.TestKit` (NuGet: `Akka.TestKit.Xunit2`) in order to access `CreateTestProbe()`, `Sys`, and the expectation APIs. See [Tutorial Overview — Prerequisites](xref:tutorial-overview#prerequisites).
 
 [!code-csharp[Main](../../../../src/core/Akka.Docs.Tutorials/Tutorial2/DeviceSpec.cs?name=device-write-read-test)]
 

--- a/docs/articles/intro/getting-started/tutorial-overview.md
+++ b/docs/articles/intro/getting-started/tutorial-overview.md
@@ -55,3 +55,47 @@ This tutorial is divided into four parts:
 * [Part 2. The Device Actor](../getting-started/tutorial-2.md)
 * [Part 3. Device Groups and Manager](../getting-started/tutorial-3.md)
 * [Part 4. Querying a Group of Devices](../getting-started/tutorial-4.md)
+
+## Prerequisites
+
+Create a .NET console or test project and add these packages:
+
+```shell
+dotnet add package Akka
+dotnet add package Akka.TestKit.Xunit2
+dotnet add package Xunit
+```
+
+Import namespaces as needed:
+
+```csharp
+using System;
+using Akka.Actor;
+using Akka.TestKit.Xunit2;
+using Xunit;
+```
+
+Most snippets in parts 1–4 that use `Sys`, `CreateTestProbe()`, `ExpectMsg`, etc. are meant to run **inside an xUnit test class that inherits `Akka.TestKit.Xunit2.TestKit`**. `Sys` is the `ActorSystem` created by that base class — it is not a standalone type you import.
+
+Example skeleton:
+
+```csharp
+public class MyTutorialSpec : TestKit
+{
+    [Fact]
+    public void Example()
+    {
+        var actor = Sys.ActorOf(Props.Create<MyActor>());
+        // ...
+    }
+}
+```
+
+For a plain console app (no TestKit), create the system yourself:
+
+```csharp
+using var system = ActorSystem.Create("iot-system");
+var actor = system.ActorOf(Props.Create<MyActor>(), "my-actor");
+```
+
+The in-repo samples under `src/core/Akka.Docs.Tutorials` follow the TestKit style used in this tutorial.


### PR DESCRIPTION
Clarifies tutorial NuGet packages and that Sys comes from inheriting Akka.TestKit.Xunit2.TestKit.
Fixes #7509
