### PR TITLE
Clarify DotNetty hostname validation direction

### DIFF
--- a/docs/articles/remoting/security.md
+++ b/docs/articles/remoting/security.md
@@ -125,10 +125,10 @@ When `suppress-validation = true`:
 
 ### Validation Strategies: HOCON vs Programmatic (v1.5.52+)
 
-Two independent validation decisions determine your TLS security posture:
+Three independent validation decisions determine your TLS security posture:
 
 1. **Chain Validation** - Verify certificate against trusted CAs (`suppress-validation`)
-2. **Hostname Validation** - Verify certificate CN/SAN matches target (`validate-certificate-hostname`)
+2. **Hostname Validation** - Verify an outbound server certificate CN/SAN matches the connection target (`validate-certificate-hostname`)
 3. **Mutual Authentication** - Require both sides authenticate (`require-mutual-authentication`)
 
 #### Decision Matrix: Which Combination to Use
@@ -151,9 +151,11 @@ When `validate-certificate-hostname = false` (the default):
 
 When `validate-certificate-hostname = true`:
 
-* Certificate CN (Common Name) or SAN (Subject Alternative Name) must match the target hostname
+* The outbound server certificate CN (Common Name) or SAN (Subject Alternative Name) must match the target hostname
 * Traditional TLS hostname validation as used in HTTPS
 * **Best for:** Client-server architectures with shared certificates and stable DNS names
+
+Hostname validation is an outbound server-identity check: the connecting node knows the hostname it intends to reach. The receiving node does not have an independently known hostname for an inbound client, so this setting does not infer one from the client's IP address or certificate. Use a `DotNettySslSetup` custom validator when inbound clients must satisfy application-specific identity or authorization rules such as certificate pinning, subject/issuer checks, or an explicit expected identity.
 
 **HOCON Example - P2P Cluster (Common Default):**
 
@@ -370,7 +372,7 @@ Perform standard chain validation, then apply custom business logic:
 
 #### Hostname Validation
 
-Enable traditional TLS hostname validation (certificate CN/SAN must match target hostname). Use for client-server architectures with shared certificates:
+Enable traditional outbound TLS hostname validation (the server certificate CN/SAN must match the connection target). Use for client-server architectures with stable DNS names:
 
 [!code-csharp[HostnameValidationExample](../../../src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs?name=HostnameValidationExample)]
 
@@ -385,7 +387,7 @@ Accept only certificates with specific subject names:
 | Method | Purpose |
 |--------|---------|
 | `ValidateChain()` | CA chain validation with full error details |
-| `ValidateHostname()` | Traditional TLS hostname validation (CN/SAN matching) |
+| `ValidateHostname()` | Uses the outbound hostname-validation result supplied by `SslStream` |
 | `PinnedCertificate()` | Certificate pinning by thumbprint whitelist |
 | `ValidateSubject()` | Subject DN pattern matching (e.g., CN, O, OU) |
 | `ValidateIssuer()` | Issuer DN pattern matching |

--- a/src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs
+++ b/src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs
@@ -179,19 +179,19 @@ namespace Akka.Docs.Tests.Configuration
 
         #region HostnameValidationExample
         /// <summary>
-        /// Example of enabling traditional hostname validation for client-server architectures.
+        /// Example of enabling traditional outbound hostname validation for client-server architectures.
         /// Use when all nodes share the same certificate with matching CN/SAN.
         /// </summary>
         public static void HostnameValidationSetup()
         {
             var certificate = LoadCertificate("path/to/certificate.pfx", "password");
 
-            // Enable both chain validation and hostname validation
+            // Enable both chain validation and outbound server hostname validation
             var sslSetup = new DotNettySslSetup(
                 certificate: certificate,
                 suppressValidation: false,
                 requireMutualAuthentication: true,
-                validateCertificateHostname: true  // Enable traditional TLS hostname validation
+                validateCertificateHostname: true  // Validate the outbound server certificate against the target hostname
             );
         }
         #endregion

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -567,7 +567,8 @@ akka {
         require-mutual-authentication = true
 
         # Enable or disable certificate hostname validation during TLS handshake.
-        # When true: Traditional TLS hostname validation is performed (certificate CN/SAN must match target hostname)
+        # When true: Traditional outbound TLS hostname validation is performed
+        # (the server certificate CN/SAN must match the connection target hostname)
         # When false: Only validates certificate chain against CA, ignores hostname mismatches
         #
         # Set to false for scenarios such as:
@@ -576,6 +577,9 @@ akka {
         #   - Service discovery with dynamic addresses
         #
         # Default: false (disabled for backward compatibility and mutual TLS flexibility)
+        #
+        # This setting does not infer a hostname for inbound client certificates. Use a
+        # DotNettySslSetup custom validator for application-specific inbound client authorization.
         validate-certificate-hostname = false
       }
     }

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettySslSetup.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettySslSetup.cs
@@ -15,7 +15,7 @@ namespace Akka.Remote.Transport.DotNetty;
 /// Programmatic setup for DotNetty SSL/TLS configuration.
 /// Provides a fluent API alternative to HOCON configuration.
 /// </summary>
-public sealed class DotNettySslSetup: Setup
+public sealed class DotNettySslSetup : Setup
 {
     /// <summary>
     /// Constructor for backward compatibility - defaults to RequireMutualAuthentication = true, ValidateCertificateHostname = false
@@ -44,7 +44,7 @@ public sealed class DotNettySslSetup: Setup
     /// <param name="certificate">X509 certificate used to establish SSL/TLS</param>
     /// <param name="suppressValidation">When true, suppresses certificate chain validation (use only for development/testing)</param>
     /// <param name="requireMutualAuthentication">When true, requires mutual TLS authentication (both client and server present certificates)</param>
-    /// <param name="validateCertificateHostname">When true, enables hostname validation (certificate CN/SAN must match target hostname)</param>
+    /// <param name="validateCertificateHostname">When true, enables outbound hostname validation (server certificate CN/SAN must match target hostname)</param>
     public DotNettySslSetup(X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname)
         : this(certificate, suppressValidation, requireMutualAuthentication, validateCertificateHostname, customValidator: null)
     {
@@ -68,7 +68,7 @@ public sealed class DotNettySslSetup: Setup
     /// <param name="certificate">X509 certificate used to establish SSL/TLS</param>
     /// <param name="suppressValidation">When true, suppresses certificate chain validation (use only for development/testing)</param>
     /// <param name="requireMutualAuthentication">When true, requires mutual TLS authentication (both client and server present certificates)</param>
-    /// <param name="validateCertificateHostname">When true, enables hostname validation (certificate CN/SAN must match target hostname)</param>
+    /// <param name="validateCertificateHostname">When true, enables outbound hostname validation (server certificate CN/SAN must match target hostname)</param>
     /// <param name="customValidator">Custom certificate validation callback (overrides config-based validation when provided)</param>
     public DotNettySslSetup(X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname, CertificateValidationCallback? customValidator)
     {
@@ -97,7 +97,8 @@ public sealed class DotNettySslSetup: Setup
     public bool RequireMutualAuthentication { get; }
 
     /// <summary>
-    /// When true, enables traditional TLS hostname validation (certificate CN/SAN must match target hostname).
+    /// When true, enables traditional outbound TLS hostname validation
+    /// (the server certificate CN/SAN must match the connection target hostname).
     /// When false, only validates certificate chain against CA, ignores hostname mismatches.
     /// Default is false for backward compatibility and to support mutual TLS scenarios with per-node certificates,
     /// IP-based connections, or dynamic service discovery.

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
@@ -113,10 +113,10 @@ namespace Akka.Remote.Transport.DotNetty
     ///     Used for performance-tuning the DotNetty channels to maximize I/O performance.
     /// </param>
     internal sealed record DotNettyTransportSettings(
-        TransportMode TransportMode, 
+        TransportMode TransportMode,
         bool EnableSsl,
         TimeSpan ConnectTimeout,
-        string Hostname, 
+        string Hostname,
         string PublicHostname,
         int Port,
         int? PublicPort,
@@ -131,7 +131,7 @@ namespace Akka.Remote.Transport.DotNetty
         int Backlog,
         bool EnforceIpFamily,
         int? ReceiveBufferSize,
-        int? SendBufferSize, 
+        int? SendBufferSize,
         int? WriteBufferHighWaterMark,
         int? WriteBufferLowWaterMark,
         bool BackwardsCompatibilityModeEnabled,
@@ -192,7 +192,7 @@ namespace Akka.Remote.Transport.DotNetty
 
             var transportMode = config.GetString("transport-protocol", "tcp").ToLower();
             var host = config.GetString("hostname");
-            if (string.IsNullOrWhiteSpace(host)) 
+            if (string.IsNullOrWhiteSpace(host))
                 host = IPAddress.Any.ToString();
 
             var publicHost = config.GetString("public-hostname");
@@ -256,7 +256,7 @@ namespace Akka.Remote.Transport.DotNetty
 
         internal DotNettyTransportSettings Validate()
         {
-            if (MaxFrameSize < 32000) 
+            if (MaxFrameSize < 32000)
                 throw new ArgumentException("maximum-frame-size must be at least 32000 bytes", nameof(MaxFrameSize));
 
             return this;
@@ -366,7 +366,8 @@ namespace Akka.Remote.Transport.DotNetty
         public readonly bool RequireMutualAuthentication;
 
         /// <summary>
-        /// When true, enables traditional TLS hostname validation (certificate CN/SAN must match target hostname).
+        /// When true, enables traditional outbound TLS hostname validation
+        /// (the server certificate CN/SAN must match the connection target hostname).
         /// When false, only validates certificate chain against CA, ignores hostname mismatches.
         /// Default is false for backward compatibility and to support mutual TLS scenarios with per-node certificates,
         /// IP-based connections, or dynamic service discovery.
@@ -564,10 +565,12 @@ namespace Akka.Remote.Transport.DotNetty
         }
 
         /// <summary>
-        /// Validate certificate hostname (CN/SAN) matches expected hostname.
-        /// Use for: Per-node certificates, FQDN-based identity.
-        /// Applies bidirectionally on both client and server.
+        /// Validates the outbound server certificate using the hostname result supplied by <see cref="SslStream"/>.
+        /// The expected hostname is established when the outbound TLS connection is authenticated.
+        /// This helper does not infer or validate a hostname for inbound client certificates.
         /// </summary>
+        /// <param name="expectedHostname">Optional hostname used in validation-failure diagnostics. It does not override the outbound connection target supplied to <see cref="SslStream"/>.</param>
+        /// <param name="log">Optional logger for validation failures.</param>
         public static CertificateValidationCallback ValidateHostname(
             string? expectedHostname = null,
             ILoggingAdapter? log = null)


### PR DESCRIPTION
## Summary

- clarify that `validate-certificate-hostname` validates outbound server identity
- explain that inbound client authorization requires an application-specific `DotNettySslSetup` custom validator
- align the remoting security guide, HOCON reference, XML documentation, and configuration sample

## Validation

- `dotnet build src/core/Akka.Remote/Akka.Remote.csproj -c Release -warnaserror --no-restore`
- `dotnet build src/core/Akka.Docs.Tests/Akka.Docs.Tests.csproj -c Release -warnaserror --no-restore`
- scoped formatting and Slopwatch checks