### PR TITLE
Backport v1.5.71: ClusterClientDiscovery fix, PromiseActorRef torn read, Remote throttler, TestKit AutoDilate

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientDiscoverySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientDiscoverySpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -164,19 +165,54 @@ public class ClusterClientDiscoverySpec : MultiNodeClusterSpec
         await EnterBarrierAsync("discovery-entry-added");
     }
 
+    /// <summary>
+    /// Wait — driven by the ClusterClient's own contact-point change events, not by polling
+    /// GetContactPoints — until the client's contact points settle to exactly the single expected node.
+    /// SubscribeContactPoints delivers the current snapshot first and then ContactPointAdded/Removed
+    /// events, so we track the running set and stop when it matches. There is no per-attempt reply
+    /// timeout to race under load, only the outer <paramref name="max"/> bound on reaching the state.
+    /// </summary>
+    private async Task AwaitSingleContactPointAsync(RoleName expected, TimeSpan max)
+    {
+        var expectedAddress = (await NodeAsync(expected)).Address;
+        _clusterClient.Tell(SubscribeContactPoints.Instance, TestActor);
+        try
+        {
+            var contacts = new HashSet<ActorPath>();
+            await FishForMessageAsync(msg =>
+            {
+                switch (msg)
+                {
+                    case ContactPoints cp:
+                        contacts.Clear();
+                        contacts.UnionWith(cp.ContactPointsList);
+                        break;
+                    case ContactPointAdded added:
+                        contacts.Add(added.ContactPoint);
+                        break;
+                    case ContactPointRemoved removed:
+                        contacts.Remove(removed.ContactPoint);
+                        break;
+                    default:
+                        return false;
+                }
+
+                return contacts.Count == 1 && contacts.First().Address.Equals(expectedAddress);
+            }, max);
+        }
+        finally
+        {
+            _clusterClient.Tell(UnsubscribeContactPoints.Instance, TestActor);
+        }
+    }
+
     private async Task ClusterClient_must_establish_connection_to_first_node()
     {
         await RunOnAsync(async () =>
         {
             _clusterClient = Sys.ActorOf(ClusterClient.Props(ClusterClientSettings.Create(Sys)), "client1");
                     
-            await AwaitAssertAsync(async () =>
-            {
-                _clusterClient.Tell(GetContactPoints.Instance, TestActor);
-                var contacts = (await ExpectMsgAsync<ContactPoints>(TimeSpan.FromSeconds(1))).ContactPointsList;
-                contacts.Count.Should().Be(1);
-                contacts.First().Address.Should().Be((await NodeAsync(_config.First)).Address);
-            }, 10.Seconds());
+            await AwaitSingleContactPointAsync(_config.First, 10.Seconds());
                     
             _clusterClient.Tell(new ClusterClient.Send("/user/testService", "hello", localAffinity:true));
             (await FishForMessageAsync(msg => msg is string)).Should().Be("hello");
@@ -241,13 +277,7 @@ public class ClusterClientDiscoverySpec : MultiNodeClusterSpec
     {
         await RunOnAsync(async () =>
         {
-            await AwaitAssertAsync(async () =>
-            {
-                _clusterClient.Tell(GetContactPoints.Instance, TestActor);
-                var contacts = (await ExpectMsgAsync<ContactPoints>(TimeSpan.FromSeconds(1))).ContactPointsList;
-                contacts.Count.Should().Be(1);
-                contacts.First().Address.Should().Be((await NodeAsync(_config.Second)).Address);
-            }, 10.Seconds());
+            await AwaitSingleContactPointAsync(_config.Second, 10.Seconds());
 
             _clusterClient.Tell(new ClusterClient.Send("/user/testService", "hello", localAffinity: true));
             (await FishForMessageAsync(msg => msg is string)).Should().Be("hello");
@@ -300,13 +330,7 @@ public class ClusterClientDiscoverySpec : MultiNodeClusterSpec
     {
         await RunOnAsync(async () =>
         {
-            await AwaitAssertAsync(async () =>
-            {
-                _clusterClient.Tell(GetContactPoints.Instance, TestActor);
-                var contacts = (await ExpectMsgAsync<ContactPoints>(TimeSpan.FromSeconds(1))).ContactPointsList;
-                contacts.Count.Should().Be(1);
-                contacts.First().Address.Should().Be((await NodeAsync(_config.Third)).Address);
-            }, 20.Seconds());
+            await AwaitSingleContactPointAsync(_config.Third, 20.Seconds());
 
             _clusterClient.Tell(new ClusterClient.Send("/user/testService", "hello", localAffinity: true));
             (await FishForMessageAsync(msg => msg is string)).Should().Be("hello");

--- a/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClientDiscovery.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClientDiscovery.cs
@@ -59,6 +59,14 @@ public class ClusterClientDiscovery: UntypedActor, IWithUnboundedStash, IWithTim
     private readonly CancellationTokenSource _shutdownCts = new ();
     private int _discoveryFailedBackoffCounter;
 
+    /// <summary>
+    /// Contact-point subscribers tracked at the supervisor level so their subscriptions can be
+    /// re-established on the freshly-created <see cref="ClusterClient"/> child after each rediscovery.
+    /// The child is recreated on every rediscovery and starts with an empty subscriber list, so without
+    /// this a subscriber would silently stop receiving contact-point events once the client rediscovers.
+    /// </summary>
+    private ImmutableHashSet<IActorRef> _contactPointSubscribers = ImmutableHashSet<IActorRef>.Empty;
+
     private readonly bool _verboseLogging;
     
     public ClusterClientDiscovery(ClusterClientSettings settings)
@@ -363,6 +371,13 @@ public class ClusterClientDiscovery: UntypedActor, IWithUnboundedStash, IWithTim
         
         var clusterClient = Context.ActorOf(Props.Create(() => new ClusterClient(currentSettings)).WithDeploy(Deploy.Local));
         Context.Watch(clusterClient);
+
+        // Re-establish any contact-point subscriptions on the freshly-created child so subscribers keep
+        // receiving ContactPoints / ContactPointAdded / ContactPointRemoved across rediscovery. Sending on
+        // the subscriber's behalf makes the child register it and reply with the current snapshot.
+        foreach (var subscriber in _contactPointSubscribers)
+            clusterClient.Tell(SubscribeContactPoints.Instance, subscriber);
+
         Stash.UnstashAll();
 
         return message =>
@@ -374,17 +389,36 @@ public class ClusterClientDiscovery: UntypedActor, IWithUnboundedStash, IWithTim
                     {
                         if(_verboseLogging && _log.IsInfoEnabled)
                             _log.Info("Cluster client failed to reconnect to all receptionists, rediscovering.");
-                        
+
                         // Kickoff discovery lookup
                         Self.Tell(DiscoverTick.Instance);
                         Become(Discovering);
+                    }
+                    else if (_contactPointSubscribers.Contains(terminated.ActorRef))
+                    {
+                        // A contact-point subscriber terminated — stop tracking it (auto-unsubscribe).
+                        _contactPointSubscribers = _contactPointSubscribers.Remove(terminated.ActorRef);
                     }
                     else
                     {
                         clusterClient.Forward(message);
                     }
                     break;
-                
+
+                case SubscribeContactPoints:
+                    // Track at the supervisor (so we can re-subscribe on the next child) and forward to the
+                    // current child so it registers the sender and replies with the initial snapshot.
+                    _contactPointSubscribers = _contactPointSubscribers.Add(Sender);
+                    Context.Watch(Sender);
+                    clusterClient.Forward(message);
+                    break;
+
+                case UnsubscribeContactPoints:
+                    _contactPointSubscribers = _contactPointSubscribers.Remove(Sender);
+                    Context.Unwatch(Sender);
+                    clusterClient.Forward(message);
+                    break;
+
                 default:
                     clusterClient.Forward(message);
                     break;

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.DotNet.verified.txt
@@ -5,6 +5,11 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
 namespace Akka.TestKit
 {
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.All, AllowMultiple=false, Inherited=false)]
+    public sealed class AutoDilateAttribute : System.Attribute
+    {
+        public AutoDilateAttribute() { }
+    }
     public abstract class AutoPilot
     {
         protected AutoPilot() { }
@@ -91,28 +96,28 @@ namespace Akka.TestKit
     {
         Akka.TestKit.EventFilterFactory And { get; }
         void Expect(int expectedCount, System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        void Expect(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
+        void Expect(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
         T Expect<T>(int expectedCount, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        T Expect<T>(int expectedCount, System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
+        T Expect<T>(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task ExpectAsync(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
         [System.ObsoleteAttribute("Use ExpectAsync<T>(expectedCount, TimeSpan, Func<Task<T>>) instead. This method o" +
             "nly exists to support backwards compatibility as of Akka.NET v1.5.")]
-        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task ExpectAsync(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
         void ExpectOne(System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        void ExpectOne(System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
+        void ExpectOne([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
         T ExpectOne<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        T ExpectOne<T>(System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
+        T ExpectOne<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.Task ExpectOneAsync(System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectOneAsync(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task ExpectOneAsync([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
         [System.ObsoleteAttribute("Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) inst" +
             "ead beginning in Akka.NET v1.5")]
         System.Threading.Tasks.Task ExpectOneAsync(System.Action action, System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task<T> ExpectOneAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
         T Mute<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
         void Mute(System.Action action, System.Threading.CancellationToken cancellationToken = null);
         Akka.TestKit.IUnmutableFilter Mute();
@@ -259,9 +264,9 @@ namespace Akka.TestKit
     {
         [System.ObsoleteAttribute("This field will be removed in future versions.")]
         public static readonly System.TimeSpan DefaultTimeout;
-        public TestBarrier(Akka.TestKit.TestKitBase testKit, int count, System.Nullable<System.TimeSpan> defaultTimeout = null) { }
+        public TestBarrier(Akka.TestKit.TestKitBase testKit, int count, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> defaultTimeout = null) { }
         public void Await() { }
-        public void Await(System.TimeSpan timeout) { }
+        public void Await([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout) { }
         public void Reset() { }
     }
     public class TestBreaker
@@ -362,20 +367,20 @@ namespace Akka.TestKit
         public Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath actorPath) { }
         public Akka.Actor.ActorSelection ActorSelection(string actorPath) { }
         public Akka.Actor.ActorSelection ActorSelection(Akka.Actor.IActorRef anchorRef, string actorPath) { }
-        public void AwaitAssert(System.Action assertion, System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitAssertAsync(System.Action assertion, System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitAssertAsync(System.Func<System.Threading.Tasks.Task> assertion, System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public void AwaitAssert(System.Action assertion, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitAssertAsync(System.Action assertion, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitAssertAsync(System.Func<System.Threading.Tasks.Task> assertion, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
         public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
         public bool AwaitConditionNoThrow(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task<bool> AwaitConditionNoThrowAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task<bool> AwaitConditionNoThrowAsync(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
@@ -393,66 +398,66 @@ namespace Akka.TestKit
         public virtual Akka.TestKit.TestLatch CreateTestLatch(int count = 1) { }
         public virtual Akka.TestKit.TestProbe CreateTestProbe(string name = null) { }
         public virtual Akka.TestKit.TestProbe CreateTestProbe(Akka.Actor.ActorSystem system, string name = null) { }
-        public System.TimeSpan Dilated(System.TimeSpan duration) { }
-        public T ExpectMsg<T>(System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Action<T> assert, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(T expected, System.Func<T, T, bool> comparer, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.TimeSpan Dilated([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan duration) { }
+        public T ExpectMsg<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(T message, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(System.Action<T> assert, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(T expected, System.Func<T, T, bool> comparer, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(params T[] messages) { }
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, params T[] messages) { }
-        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, params T[] messages) { }
+        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__158<T>))]
         public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__161<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(params Akka.TestKit.PredicateInfo[] predicates) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
-        public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.TimeSpan max, params Akka.TestKit.PredicateInfo[] predicates) { }
-        public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
+        public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, params Akka.TestKit.PredicateInfo[] predicates) { }
+        public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__168))]
         public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__171))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         public T ExpectMsgAnyOf<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask<T> ExpectMsgAnyOfAsync<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T> assert, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T expected, System.Func<T, T, bool> comparer, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T message, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T> assert, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T expected, System.Func<T, T, bool> comparer, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, T message, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsgFrom<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsgFrom<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, T message, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
         public void ExpectNoMsg(System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectNoMsg(System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = null) { }
+        public void ExpectNoMsg([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = null) { }
         public void ExpectNoMsg(int milliseconds, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(int milliseconds, System.Threading.CancellationToken cancellationToken = null) { }
-        public Akka.Actor.Terminated ExpectTerminated(Akka.Actor.IActorRef target, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<Akka.Actor.Terminated> ExpectTerminatedAsync(Akka.Actor.IActorRef target, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public object FishForMessage(System.Predicate<object> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public T FishForMessage<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public T FishForMessage<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<object> FishForMessageAsync(System.Predicate<object> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task FishUntilMessageAsync<T>(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public Akka.Actor.Terminated ExpectTerminated(Akka.Actor.IActorRef target, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<Akka.Actor.Terminated> ExpectTerminatedAsync(Akka.Actor.IActorRef target, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public object FishForMessage(System.Predicate<object> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
+        public T FishForMessage<T>(System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
+        public T FishForMessage<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<object> FishForMessageAsync(System.Predicate<object> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task FishUntilMessageAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.TimeSpan GetTimeoutOrDefault(System.Nullable<System.TimeSpan> timeout) { }
         public void IgnoreMessages(System.Func<object, bool> shouldIgnoreMessage) { }
         public void IgnoreMessages<TMsg>(System.Func<TMsg, bool> shouldIgnoreMessage) { }
@@ -469,27 +474,27 @@ namespace Akka.TestKit
         public System.Threading.Tasks.ValueTask<object> PeekOneAsync(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask<object> PeekOneAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.TimeSpan max, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__217))]
         public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__219))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, System.TimeSpan max, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         public object ReceiveOne(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask<object> ReceiveOneAsync(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Predicate<T> shouldContinue, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Func<object, T> filter, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Predicate<T> shouldContinue, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__208<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__210<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__212<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Func<object, T> filter, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__214<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Predicate<T> shouldContinue, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Predicate<T> shouldContinue, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         protected System.TimeSpan RemainingOr(System.TimeSpan duration) { }
-        public System.TimeSpan RemainingOrDilated(System.Nullable<System.TimeSpan> duration) { }
+        public System.TimeSpan RemainingOrDilated([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration) { }
         public void SetAutoPilot(Akka.TestKit.AutoPilot pilot) { }
         public virtual void Shutdown(System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
         protected virtual void Shutdown(Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
@@ -508,14 +513,14 @@ namespace Akka.TestKit
         public System.Threading.Tasks.Task<System.Collections.ArrayList> WaitForRadioSilenceAsync(System.Nullable<System.TimeSpan> max = null, System.Nullable<uint> maxMessages = null, System.Threading.CancellationToken cancellationToken = null) { }
         public Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef actorToWatch) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> WatchAsync(Akka.Actor.IActorRef actorToWatch) { }
-        public void Within(System.TimeSpan max, System.Action action, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public void Within(System.TimeSpan min, System.TimeSpan max, System.Action action, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Within<T>(System.TimeSpan max, System.Func<T> function, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Within<T>(System.TimeSpan min, System.TimeSpan max, System.Func<T> function, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan min, System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan min, System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public void Within([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Action action, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public void Within(System.TimeSpan min, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Action action, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T Within<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Func<T> function, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T Within<T>(System.TimeSpan min, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Func<T> function, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task WithinAsync([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan min, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task<T> WithinAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan min, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
     }
     public class TestKitExtension : Akka.Actor.ExtensionIdProvider<Akka.TestKit.TestKitSettings>
     {
@@ -669,26 +674,26 @@ namespace Akka.TestKit.Internal
         protected bool AwaitDone(System.TimeSpan timeout, System.Nullable<int> expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler, System.Threading.CancellationToken cancellationToken = null) { }
         protected System.Threading.Tasks.Task<bool> AwaitDoneAsync(System.TimeSpan timeout, System.Nullable<int> expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler, System.Threading.CancellationToken cancellationToken = null) { }
         public void Expect(int expectedCount, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public void Expect(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
+        public void Expect(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
         public T Expect<T>(int expectedCount, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Expect<T>(int expectedCount, System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
+        public T Expect<T>(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
         public void ExpectOne(System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectOne(System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
+        public void ExpectOne([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
         public T ExpectOne<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectOne<T>(System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectOne<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
         [System.ObsoleteAttribute("Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) inst" +
             "ead beginning in Akka.NET v1.5")]
         public System.Threading.Tasks.Task ExpectOneAsync(System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task ExpectOneAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectOneAsync(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task ExpectOneAsync([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task<T> ExpectOneAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
         protected static string GetMessageString(int number) { }
         protected T Intercept<T>(System.Func<T> func, Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> timeout, System.Nullable<int> expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler = null, System.Threading.CancellationToken cancellationToken = null) { }
         protected System.Threading.Tasks.Task<T> InterceptAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> timeout, System.Nullable<int> expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler = null, System.Threading.CancellationToken cancellationToken = null) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.Net.verified.txt
@@ -5,6 +5,11 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.TestKit
 {
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.All, AllowMultiple=false, Inherited=false)]
+    public sealed class AutoDilateAttribute : System.Attribute
+    {
+        public AutoDilateAttribute() { }
+    }
     public abstract class AutoPilot
     {
         protected AutoPilot() { }
@@ -91,28 +96,28 @@ namespace Akka.TestKit
     {
         Akka.TestKit.EventFilterFactory And { get; }
         void Expect(int expectedCount, System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        void Expect(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
+        void Expect(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
         T Expect<T>(int expectedCount, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        T Expect<T>(int expectedCount, System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
+        T Expect<T>(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task ExpectAsync(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
         [System.ObsoleteAttribute("Use ExpectAsync<T>(expectedCount, TimeSpan, Func<Task<T>>) instead. This method o" +
             "nly exists to support backwards compatibility as of Akka.NET v1.5.")]
-        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task ExpectAsync(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
         void ExpectOne(System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        void ExpectOne(System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
+        void ExpectOne([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
         T ExpectOne<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        T ExpectOne<T>(System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
+        T ExpectOne<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.Task ExpectOneAsync(System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectOneAsync(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task ExpectOneAsync([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
         [System.ObsoleteAttribute("Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) inst" +
             "ead beginning in Akka.NET v1.5")]
         System.Threading.Tasks.Task ExpectOneAsync(System.Action action, System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task<T> ExpectOneAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
         T Mute<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
         void Mute(System.Action action, System.Threading.CancellationToken cancellationToken = null);
         Akka.TestKit.IUnmutableFilter Mute();
@@ -259,9 +264,9 @@ namespace Akka.TestKit
     {
         [System.ObsoleteAttribute("This field will be removed in future versions.")]
         public static readonly System.TimeSpan DefaultTimeout;
-        public TestBarrier(Akka.TestKit.TestKitBase testKit, int count, System.Nullable<System.TimeSpan> defaultTimeout = null) { }
+        public TestBarrier(Akka.TestKit.TestKitBase testKit, int count, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> defaultTimeout = null) { }
         public void Await() { }
-        public void Await(System.TimeSpan timeout) { }
+        public void Await([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout) { }
         public void Reset() { }
     }
     public class TestBreaker
@@ -362,20 +367,20 @@ namespace Akka.TestKit
         public Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath actorPath) { }
         public Akka.Actor.ActorSelection ActorSelection(string actorPath) { }
         public Akka.Actor.ActorSelection ActorSelection(Akka.Actor.IActorRef anchorRef, string actorPath) { }
-        public void AwaitAssert(System.Action assertion, System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitAssertAsync(System.Action assertion, System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitAssertAsync(System.Func<System.Threading.Tasks.Task> assertion, System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public void AwaitAssert(System.Action assertion, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitAssertAsync(System.Action assertion, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitAssertAsync(System.Func<System.Threading.Tasks.Task> assertion, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
         public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
         public bool AwaitConditionNoThrow(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task<bool> AwaitConditionNoThrowAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task<bool> AwaitConditionNoThrowAsync(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
@@ -393,66 +398,66 @@ namespace Akka.TestKit
         public virtual Akka.TestKit.TestLatch CreateTestLatch(int count = 1) { }
         public virtual Akka.TestKit.TestProbe CreateTestProbe(string name = null) { }
         public virtual Akka.TestKit.TestProbe CreateTestProbe(Akka.Actor.ActorSystem system, string name = null) { }
-        public System.TimeSpan Dilated(System.TimeSpan duration) { }
-        public T ExpectMsg<T>(System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Action<T> assert, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(T expected, System.Func<T, T, bool> comparer, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.TimeSpan Dilated([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan duration) { }
+        public T ExpectMsg<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(T message, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(System.Action<T> assert, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(T expected, System.Func<T, T, bool> comparer, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(params T[] messages) { }
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, params T[] messages) { }
-        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, params T[] messages) { }
+        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__158<T>))]
         public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__161<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(params Akka.TestKit.PredicateInfo[] predicates) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
-        public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.TimeSpan max, params Akka.TestKit.PredicateInfo[] predicates) { }
-        public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
+        public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, params Akka.TestKit.PredicateInfo[] predicates) { }
+        public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__168))]
         public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__171))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         public T ExpectMsgAnyOf<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask<T> ExpectMsgAnyOfAsync<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T> assert, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T expected, System.Func<T, T, bool> comparer, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T message, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T> assert, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T expected, System.Func<T, T, bool> comparer, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, T message, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsgFrom<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsgFrom<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, T message, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
         public void ExpectNoMsg(System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectNoMsg(System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = null) { }
+        public void ExpectNoMsg([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = null) { }
         public void ExpectNoMsg(int milliseconds, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(int milliseconds, System.Threading.CancellationToken cancellationToken = null) { }
-        public Akka.Actor.Terminated ExpectTerminated(Akka.Actor.IActorRef target, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<Akka.Actor.Terminated> ExpectTerminatedAsync(Akka.Actor.IActorRef target, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public object FishForMessage(System.Predicate<object> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public T FishForMessage<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public T FishForMessage<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<object> FishForMessageAsync(System.Predicate<object> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task FishUntilMessageAsync<T>(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public Akka.Actor.Terminated ExpectTerminated(Akka.Actor.IActorRef target, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<Akka.Actor.Terminated> ExpectTerminatedAsync(Akka.Actor.IActorRef target, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public object FishForMessage(System.Predicate<object> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
+        public T FishForMessage<T>(System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
+        public T FishForMessage<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<object> FishForMessageAsync(System.Predicate<object> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task FishUntilMessageAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.TimeSpan GetTimeoutOrDefault(System.Nullable<System.TimeSpan> timeout) { }
         public void IgnoreMessages(System.Func<object, bool> shouldIgnoreMessage) { }
         public void IgnoreMessages<TMsg>(System.Func<TMsg, bool> shouldIgnoreMessage) { }
@@ -469,27 +474,27 @@ namespace Akka.TestKit
         public System.Threading.Tasks.ValueTask<object> PeekOneAsync(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask<object> PeekOneAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.TimeSpan max, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__217))]
         public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__219))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, System.TimeSpan max, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         public object ReceiveOne(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask<object> ReceiveOneAsync(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Predicate<T> shouldContinue, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Func<object, T> filter, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Predicate<T> shouldContinue, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__208<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__210<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__212<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Func<object, T> filter, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__214<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Predicate<T> shouldContinue, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Predicate<T> shouldContinue, [Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         protected System.TimeSpan RemainingOr(System.TimeSpan duration) { }
-        public System.TimeSpan RemainingOrDilated(System.Nullable<System.TimeSpan> duration) { }
+        public System.TimeSpan RemainingOrDilated([Akka.TestKit.AutoDilateAttribute()] System.Nullable<System.TimeSpan> duration) { }
         public void SetAutoPilot(Akka.TestKit.AutoPilot pilot) { }
         public virtual void Shutdown(System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
         protected virtual void Shutdown(Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
@@ -508,14 +513,14 @@ namespace Akka.TestKit
         public System.Threading.Tasks.Task<System.Collections.ArrayList> WaitForRadioSilenceAsync(System.Nullable<System.TimeSpan> max = null, System.Nullable<uint> maxMessages = null, System.Threading.CancellationToken cancellationToken = null) { }
         public Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef actorToWatch) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> WatchAsync(Akka.Actor.IActorRef actorToWatch) { }
-        public void Within(System.TimeSpan max, System.Action action, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public void Within(System.TimeSpan min, System.TimeSpan max, System.Action action, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Within<T>(System.TimeSpan max, System.Func<T> function, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Within<T>(System.TimeSpan min, System.TimeSpan max, System.Func<T> function, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan min, System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan min, System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public void Within([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Action action, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public void Within(System.TimeSpan min, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Action action, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T Within<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Func<T> function, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T Within<T>(System.TimeSpan min, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Func<T> function, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task WithinAsync([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan min, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task<T> WithinAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan min, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
     }
     public class TestKitExtension : Akka.Actor.ExtensionIdProvider<Akka.TestKit.TestKitSettings>
     {
@@ -669,26 +674,26 @@ namespace Akka.TestKit.Internal
         protected bool AwaitDone(System.TimeSpan timeout, System.Nullable<int> expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler, System.Threading.CancellationToken cancellationToken = null) { }
         protected System.Threading.Tasks.Task<bool> AwaitDoneAsync(System.TimeSpan timeout, System.Nullable<int> expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler, System.Threading.CancellationToken cancellationToken = null) { }
         public void Expect(int expectedCount, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public void Expect(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
+        public void Expect(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
         public T Expect<T>(int expectedCount, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Expect<T>(int expectedCount, System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
+        public T Expect<T>(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, [Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
         public void ExpectOne(System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectOne(System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
+        public void ExpectOne([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
         public T ExpectOne<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectOne<T>(System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectOne<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
         [System.ObsoleteAttribute("Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) inst" +
             "ead beginning in Akka.NET v1.5")]
         public System.Threading.Tasks.Task ExpectOneAsync(System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task ExpectOneAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectOneAsync(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task ExpectOneAsync([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task<T> ExpectOneAsync<T>([Akka.TestKit.AutoDilateAttribute()] System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
         protected static string GetMessageString(int number) { }
         protected T Intercept<T>(System.Func<T> func, Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> timeout, System.Nullable<int> expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler = null, System.Threading.CancellationToken cancellationToken = null) { }
         protected System.Threading.Tasks.Task<T> InterceptAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> timeout, System.Nullable<int> expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler = null, System.Threading.CancellationToken cancellationToken = null) { }

--- a/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="MultiNodeClusterSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -316,7 +316,7 @@ namespace Akka.Cluster.TestKit
             await EnterBarrierAsync(cancellationToken, roles.Select(r => r.Name).Aggregate((a, b) => a + "-" + b) + "-joined");
         }
 
-        public void JoinWithin(RoleName joinNode, TimeSpan? max = null, TimeSpan? interval = null)
+        public void JoinWithin(RoleName joinNode, [AutoDilate] TimeSpan? max = null, TimeSpan? interval = null)
         {
             if (max == null) max = RemainingOrDefault;
             if (interval == null) interval = TimeSpan.FromSeconds(1);
@@ -395,7 +395,7 @@ namespace Akka.Cluster.TestKit
         public void AwaitMembersUp(
             int numbersOfMembers,
             ImmutableHashSet<Address> canNotBePartOfMemberRing = null,
-            TimeSpan? timeout = null)
+            [AutoDilate] TimeSpan? timeout = null)
         {
             if (canNotBePartOfMemberRing == null)
                 canNotBePartOfMemberRing = ImmutableHashSet.Create<Address>();
@@ -420,7 +420,7 @@ namespace Akka.Cluster.TestKit
         public async Task AwaitMembersUpAsync(
             int numbersOfMembers,
             ImmutableHashSet<Address> canNotBePartOfMemberRing = null,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             CancellationToken cancellationToken = default)
         {
             canNotBePartOfMemberRing ??= ImmutableHashSet.Create<Address>();

--- a/src/core/Akka.Cluster.Tests.MultiNode/AutoDilateMetadataSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/AutoDilateMetadataSpec.cs
@@ -1,0 +1,60 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AutoDilateMetadataSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Linq;
+using System.Reflection;
+using Akka.Cluster.TestKit;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Cluster.Tests.MultiNode;
+
+public class AutoDilateMetadataSpec
+{
+    [Fact]
+    public void MultiNodeClusterSpec_should_mark_automatically_dilated_parameters()
+    {
+        AssertAutoDilated(nameof(MultiNodeClusterSpec.JoinWithin), "max",
+            "joinNode", "max", "interval");
+        AssertAutoDilated(nameof(MultiNodeClusterSpec.AwaitMembersUp), "timeout",
+            "numbersOfMembers", "canNotBePartOfMemberRing", "timeout");
+        AssertAutoDilated(nameof(MultiNodeClusterSpec.AwaitMembersUpAsync), "timeout",
+            "numbersOfMembers", "canNotBePartOfMemberRing", "timeout", "cancellationToken");
+    }
+
+    [Fact]
+    public void MultiNodeClusterSpec_should_not_mark_raw_interval_parameters()
+    {
+        var parameter = FindParameter(nameof(MultiNodeClusterSpec.JoinWithin), "interval",
+            "joinNode", "max", "interval");
+
+        Assert.False(parameter.IsDefined(typeof(AutoDilateAttribute), inherit: false));
+    }
+
+    private static void AssertAutoDilated(
+        string methodName,
+        string parameterName,
+        params string[] parameterNames)
+    {
+        var parameter = FindParameter(methodName, parameterName, parameterNames);
+        Assert.True(parameter.IsDefined(typeof(AutoDilateAttribute), inherit: false));
+    }
+
+    private static ParameterInfo FindParameter(
+        string methodName,
+        string parameterName,
+        params string[] parameterNames)
+    {
+        var method = typeof(MultiNodeClusterSpec)
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Single(candidate =>
+                candidate.Name == methodName &&
+                candidate.GetParameters().Select(parameter => parameter.Name).SequenceEqual(parameterNames));
+
+        return method.GetParameters().Single(parameter => parameter.Name == parameterName);
+    }
+}

--- a/src/core/Akka.Remote.Tests/Transport/ThrottlerManagerLifecycleSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/ThrottlerManagerLifecycleSpec.cs
@@ -1,0 +1,192 @@
+//-----------------------------------------------------------------------
+// <copyright file="ThrottlerManagerLifecycleSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Remote.Transport;
+using Akka.TestKit;
+using FluentAssertions;
+using Google.Protobuf;
+using Xunit;
+
+namespace Akka.Remote.Tests.Transport
+{
+    /// <summary>
+    /// Specs for how <see cref="ThrottlerManager"/> manages the lifecycle of its
+    /// <see cref="ThrottledAssociation"/> children.
+    ///
+    /// Uses a stub <see cref="Transport"/> so the throttler can be driven directly, without any
+    /// real network I/O in the picture.
+    /// </summary>
+    public class ThrottlerManagerLifecycleSpec : AkkaSpec
+    {
+        private static readonly Config Config = ConfigurationFactory.ParseString(@"
+            akka {
+              loglevel = DEBUG
+              actor.provider = ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
+              remote.dot-netty.tcp.hostname = ""localhost""
+              remote.dot-netty.tcp.port = 0
+            }");
+
+        public ThrottlerManagerLifecycleSpec(ITestOutputHelper output) : base(Config, output)
+        {
+        }
+
+        private static readonly Address LocalAddress = new("akka.test", "local", "localhost", 1234);
+        private static readonly Address RemoteAddress = new("akka.test", "remote", "localhost", 4321);
+
+        #region Test transport
+
+        private sealed class StubHandle : AssociationHandle
+        {
+            public StubHandle(Address localAddress, Address remoteAddress) : base(localAddress, remoteAddress)
+            {
+            }
+
+            public bool Disassociated { get; private set; }
+
+            public override bool Write(ByteString payload) => true;
+
+#pragma warning disable CS0672 // the base member is obsolete, but it is the abstract one we have to implement
+            public override void Disassociate()
+#pragma warning restore CS0672
+            {
+                Disassociated = true;
+            }
+        }
+
+        /// <summary>
+        /// Blows the throttler up the way the real thing does when the layer above it faults.
+        /// </summary>
+        private sealed class ThrowingAssociationEventListener : IAssociationEventListener
+        {
+            public void Notify(IAssociationEvent ev) => throw new ApplicationException("boom");
+        }
+
+        private sealed class StubTransport : Akka.Remote.Transport.Transport
+        {
+            public StubTransport(ActorSystem system)
+            {
+                System = system;
+                Config = ConfigurationFactory.Empty;
+                SchemeIdentifier = "test";
+                MaximumPayloadBytes = 32000;
+            }
+
+            public override Task<(Address, TaskCompletionSource<IAssociationEventListener>)> Listen()
+                => Task.FromResult((LocalAddress, new TaskCompletionSource<IAssociationEventListener>()));
+
+            public override bool IsResponsibleFor(Address remote) => true;
+
+            public override Task<AssociationHandle> Associate(Address remoteAddress)
+                => Task.FromResult<AssociationHandle>(new StubHandle(LocalAddress, remoteAddress));
+
+            public override Task<bool> Shutdown() => Task.FromResult(true);
+        }
+
+        #endregion
+
+        private IActorRef StartManager(IAssociationEventListener? associationListener = null)
+        {
+            var manager = Sys.ActorOf(Props.Create(() => new ThrottlerManager(new StubTransport(Sys))));
+
+            // move the manager into its `Ready` behavior
+            manager.Tell(new ListenUnderlying(LocalAddress,
+                Task.FromResult(associationListener ?? new ActorAssociationEventListener(TestActor))));
+            return manager;
+        }
+
+        private async Task<ThrottlerHandle> AssociateAsync(IActorRef manager)
+        {
+            var promise = new TaskCompletionSource<AssociationHandle>(TaskCreationOptions.RunContinuationsAsynchronously);
+            manager.Tell(new AssociateUnderlying(RemoteAddress, promise));
+            var handle = await promise.Task.WaitAsync(RemainingOrDefault);
+            return (ThrottlerHandle)handle;
+        }
+
+        [Fact(DisplayName = "ThrottlerManager should stop, not restart, an inbound throttler child that fails")]
+        public async Task Should_stop_failed_inbound_throttler_child()
+        {
+            var manager = StartManager(new ThrowingAssociationEventListener());
+
+            var inboundHandle = new StubHandle(LocalAddress, RemoteAddress);
+            manager.Tell(new InboundAssociation(inboundHandle));
+
+            // the throttler registers itself as the read handler as soon as it gets its `Handle` message
+            var listener = (ActorHandleEventListener)await inboundHandle.ReadHandlerSource.Task.WaitAsync(RemainingOrDefault);
+            var throttler = listener.Actor;
+            await WatchAsync(throttler);
+
+            // an ASSOCIATE PDU carries the origin address, so the throttler checks in with the manager,
+            // gets its throttle mode back, and hands the association up to the (throwing) listener
+            var associate = new AkkaPduProtobuffCodec(Sys).ConstructAssociate(new HandshakeInfo(RemoteAddress, 1));
+
+            // the default decider Restarts on this, which is what makes the association a black hole:
+            // the restarted FSM re-enters `WaitExposedHandle`, and the `Handle` message that gets it out
+            // of there is only ever sent once, when the child is created
+            await EventFilter.Exception<ApplicationException>().ExpectOneAsync(async () =>
+            {
+                listener.Notify(new InboundPayload(associate));
+                await ExpectTerminatedAsync(throttler);
+            });
+        }
+
+        [Fact(DisplayName = "ThrottlerManager should purge terminated throttlers from its handle table")]
+        public async Task Should_purge_terminated_throttler_from_handle_table()
+        {
+            var manager = StartManager();
+            var handle = await AssociateAsync(manager);
+            var throttler = handle.ThrottlerActor;
+
+            await WatchAsync(throttler);
+            throttler.Tell(PoisonPill.Instance);
+            await ExpectTerminatedAsync(throttler);
+
+            // the death watch notification is a system message enqueued before anything we send from
+            // here, so the manager has already processed it by the time it handles `SetThrottle`
+            var deadLetters = CreateTestProbe("dead-letters");
+            Sys.EventStream.Subscribe(deadLetters.Ref, typeof(DeadLetter));
+
+            manager.Tell(new SetThrottle(RemoteAddress, ThrottleTransportAdapter.Direction.Both, Blackhole.Instance),
+                TestActor);
+
+            await ExpectMsgAsync<SetThrottleAck>();
+
+            // a stale handle table entry shows up as the throttle mode dead-lettering to the dead child
+            await deadLetters.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+        }
+
+        [Fact(DisplayName = "ThrottledAssociation should disassociate rather than black hole payloads received before initialization")]
+        public async Task Should_disassociate_when_payload_arrives_before_handle()
+        {
+            // reproduces the state a restarted inbound throttler is left in: back in `WaitExposedHandle`,
+            // with the read handler of the previous incarnation still pointed at this actor
+            var originalHandle = new StubHandle(LocalAddress, RemoteAddress);
+            var association = Sys.ActorOf(Props.Create(() => new ThrottledAssociation(
+                TestActor,
+                new ActorAssociationEventListener(TestActor),
+                originalHandle,
+                true)));
+
+            await WatchAsync(association);
+
+            await EventFilter.Warning(contains: "received an InboundPayload before it was initialized").ExpectOneAsync(
+                async () =>
+                {
+                    association.Tell(new InboundPayload(ByteString.CopyFromUtf8("ping")));
+                    await ExpectTerminatedAsync(association);
+                });
+
+            originalHandle.Disassociated.Should().BeTrue("the association has to be torn down so remoting can re-establish it");
+        }
+    }
+}

--- a/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Dispatch.SysMsg;
+using Akka.Event;
 using Akka.Remote.Serialization;
 using Akka.Util;
 using Akka.Util.Internal;
@@ -345,6 +346,25 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
+        /// A <see cref="ThrottledAssociation"/> cannot recover its own state: an inbound throttler
+        /// only ever receives the <see cref="Handle"/> message that moves it out of
+        /// <see cref="ThrottledAssociation.ThrottlerState.WaitExposedHandle"/> once, when it is created.
+        /// Restarting one therefore leaves it parked in that state forever, silently discarding every
+        /// inbound packet on that association.
+        ///
+        /// Stopping the child instead surfaces the failure as a disassociation, which the remoting
+        /// layer above knows how to recover from. This mirrors <c>AkkaProtocolManager</c>, which uses
+        /// the same strategy for the same reason.
+        /// </summary>
+        private readonly SupervisorStrategy _supervisor = new OneForOneStrategy(_ => Directive.Stop);
+
+        /// <inheritdoc/>
+        protected override SupervisorStrategy SupervisorStrategy()
+        {
+            return _supervisor;
+        }
+
+        /// <summary>
         /// TBD
         /// </summary>
         /// <param name="message">TBD</param>
@@ -487,6 +507,21 @@ namespace Akka.Remote.Transport
                     SetMode(naked, chkin.ThrottlerHandle);
                     return;
                 }
+
+                case Terminated terminated:
+                {
+                    /*
+                     * A throttler child stopped for a reason other than ForceDisassociate[Explicitly]
+                     * (crash, PoisonPill, Blackhole-induced disassociation, transport shutdown).
+                     *
+                     * Its entry has to come out of the table for the same reason described in the
+                     * ForceDisassociate handler above: messaging a terminated handle from SetThrottle
+                     * fails Tasks all the way back up to the EndpointManager, and the table would
+                     * otherwise grow for the lifetime of the transport.
+                     */
+                    _handleTable.RemoveAll(tuple => tuple.Item2.ThrottlerActor.Equals(terminated.ActorRef));
+                    return;
+                }
             }
         }
 
@@ -559,10 +594,15 @@ namespace Akka.Remote.Transport
             bool inbound)
         {
             var managerRef = Self;
-            return new ThrottlerHandle(originalHandle, Context.ActorOf(
+            var throttlerActor = Context.ActorOf(
                 RARP.For(Context.System).ConfigureDispatcher(
-                Props.Create(() => new ThrottledAssociation(managerRef, listener, originalHandle, inbound)).WithDeploy(Deploy.Local)),
-                "throttler" + NextId()));
+                    Props.Create(() => new ThrottledAssociation(managerRef, listener, originalHandle, inbound))
+                        .WithDeploy(Deploy.Local)),
+                "throttler" + NextId());
+
+            // watch so we can purge the handle table when this association goes away
+            Context.Watch(throttlerActor);
+            return new ThrottlerHandle(originalHandle, throttlerActor);
         }
 
         #endregion
@@ -1055,6 +1095,8 @@ namespace Akka.Remote.Transport
         /// </summary>
         private readonly AkkaPduProtobuffCodec _codec;
 
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -1085,6 +1127,26 @@ namespace Akka.Remote.Transport
                             .Using(
                                 new ExposedHandle(handle.ThrottlerHandle));
                 }
+
+                if (@event.FsmEvent is InboundPayload)
+                {
+                    /*
+                     * Unreachable during a healthy startup: nothing can deliver an InboundPayload to us
+                     * until we complete OriginalHandle.ReadHandlerSource above, which is the same step
+                     * that leaves this state.
+                     *
+                     * Getting one here means this actor was restarted - the read handler from the previous
+                     * incarnation still points at this ActorRef, but the ThrottlerManager only ever sends
+                     * Handle once, at creation. Staying put would silently discard every inbound packet for
+                     * the life of the association, so tear it down instead and let remoting re-associate.
+                     */
+                    _log.Warning(
+                        "Throttler for [{0}] received an InboundPayload before it was initialized - most likely restarted. Disassociating so the association can be re-established.",
+                        OriginalHandle.RemoteAddress);
+                    OriginalHandle.Disassociate("throttler received inbound data before it was initialized", _log);
+                    return Stop();
+                }
+
                 return null;
             });
 

--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/AutoDilateMetadataTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/AutoDilateMetadataTests.cs
@@ -1,0 +1,134 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AutoDilateMetadataTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Reflection;
+using Akka.TestKit.Internal;
+using Xunit;
+
+namespace Akka.TestKit.Tests.TestKitBaseTests;
+
+public class AutoDilateMetadataTests
+{
+    [Fact]
+    public void AutoDilateAttribute_should_be_parameter_only_metadata()
+    {
+        var usage = typeof(AutoDilateAttribute).GetCustomAttribute<AttributeUsageAttribute>();
+
+        Assert.NotNull(usage);
+        Assert.Equal(AttributeTargets.Parameter, usage.ValidOn);
+        Assert.False(usage.AllowMultiple);
+        Assert.False(usage.Inherited);
+    }
+
+    [Fact]
+    public void AutoDilateAttribute_should_only_mark_duration_parameters()
+    {
+        var annotatedParameters = typeof(TestKitBase).Assembly
+            .GetTypes()
+            .SelectMany(type => type
+                .GetMembers(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public |
+                            BindingFlags.NonPublic)
+                .OfType<MethodBase>())
+            .SelectMany(method => method.GetParameters())
+            .Where(HasAutoDilateAttribute)
+            .ToArray();
+
+        Assert.NotEmpty(annotatedParameters);
+        Assert.All(annotatedParameters, parameter =>
+            Assert.True(
+                parameter.ParameterType == typeof(TimeSpan) ||
+                parameter.ParameterType == typeof(TimeSpan?),
+                $"{parameter.Member.DeclaringType?.FullName}.{parameter.Member.Name} parameter " +
+                $"'{parameter.Name}' has unexpected type {parameter.ParameterType}."));
+    }
+
+    [Fact]
+    public void Automatically_dilated_TestKit_parameters_should_be_marked()
+    {
+        AssertAutoDilated(typeof(TestKitBase), nameof(TestKitBase.Dilated), "duration", "duration");
+        AssertAutoDilated(typeof(TestKitBase), nameof(TestKitBase.RemainingOrDilated), "duration", "duration");
+        AssertAutoDilated(typeof(TestKitBase), nameof(TestKitBase.AwaitAssert), "duration",
+            "assertion", "duration", "interval", "cancellationToken");
+        AssertAutoDilated(typeof(TestKitBase), nameof(TestKitBase.ReceiveWhile), "max",
+            "filter", "max", "idle", "msgs", "cancellationToken");
+        AssertAutoDilated(typeof(TestKitBase), nameof(TestKitBase.Within), "max",
+            "min", "max", "action", "hint", "epsilonValue", "cancellationToken");
+        AssertAutoDilated(typeof(TestKitBase), nameof(TestKitBase.FishUntilMessageAsync), "max",
+            "max", "cancellationToken");
+        AssertAutoDilated(typeof(IEventFilterApplier), nameof(IEventFilterApplier.ExpectOne), "timeout",
+            "timeout", "action", "cancellationToken");
+        AssertAutoDilated(typeof(InternalEventFilterApplier), nameof(InternalEventFilterApplier.ExpectOne),
+            "timeout", "timeout", "action", "cancellationToken");
+        AssertAutoDilated(typeof(TestBarrier), nameof(TestBarrier.Await), "timeout", "timeout");
+
+        var constructor = typeof(TestBarrier).GetConstructors()
+            .Single(ctor => HasParameterNames(ctor, "testKit", "count", "defaultTimeout"));
+        Assert.True(HasAutoDilateAttribute(constructor.GetParameters().Single(p => p.Name == "defaultTimeout")));
+    }
+
+    [Fact]
+    public void Raw_or_conditionally_dilated_TestKit_parameters_should_not_be_marked()
+    {
+        AssertNotAutoDilated(typeof(TestKitBase), nameof(TestKitBase.AwaitAssert), "interval",
+            "assertion", "duration", "interval", "cancellationToken");
+        AssertNotAutoDilated(typeof(TestKitBase), nameof(TestKitBase.ReceiveWhile), "idle",
+            "filter", "max", "idle", "msgs", "cancellationToken");
+        AssertNotAutoDilated(typeof(TestKitBase), nameof(TestKitBase.Within), "min",
+            "min", "max", "action", "hint", "epsilonValue", "cancellationToken");
+        AssertNotAutoDilated(typeof(TestKitBase), nameof(TestKitBase.Within), "epsilonValue",
+            "min", "max", "action", "hint", "epsilonValue", "cancellationToken");
+        AssertNotAutoDilated(typeof(TestKitBase), nameof(TestKitBase.ReceiveOne), "max",
+            "max", "cancellationToken");
+        AssertNotAutoDilated(typeof(TestKitBase), nameof(TestKitBase.AwaitConditionNoThrow), "max",
+            "conditionIsFulfilled", "max", "interval", "cancellationToken");
+        AssertNotAutoDilated(typeof(TestLatch), nameof(TestLatch.Ready), "timeout", "timeout");
+    }
+
+    private static void AssertAutoDilated(
+        Type declaringType,
+        string methodName,
+        string parameterName,
+        params string[] parameterNames)
+    {
+        var parameter = FindParameter(declaringType, methodName, parameterName, parameterNames);
+        Assert.True(HasAutoDilateAttribute(parameter));
+    }
+
+    private static void AssertNotAutoDilated(
+        Type declaringType,
+        string methodName,
+        string parameterName,
+        params string[] parameterNames)
+    {
+        var parameter = FindParameter(declaringType, methodName, parameterName, parameterNames);
+        Assert.False(HasAutoDilateAttribute(parameter));
+    }
+
+    private static ParameterInfo FindParameter(
+        Type declaringType,
+        string methodName,
+        string parameterName,
+        params string[] parameterNames)
+    {
+        var method = declaringType
+            .GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public |
+                        BindingFlags.NonPublic)
+            .Single(candidate =>
+                candidate.Name == methodName &&
+                HasParameterNames(candidate, parameterNames));
+
+        return method.GetParameters().Single(parameter => parameter.Name == parameterName);
+    }
+
+    private static bool HasParameterNames(MethodBase method, params string[] parameterNames)
+        => method.GetParameters().Select(parameter => parameter.Name).SequenceEqual(parameterNames);
+
+    private static bool HasAutoDilateAttribute(ParameterInfo parameter)
+        => parameter.IsDefined(typeof(AutoDilateAttribute), inherit: false);
+}

--- a/src/core/Akka.TestKit/AutoDilateAttribute.cs
+++ b/src/core/Akka.TestKit/AutoDilateAttribute.cs
@@ -1,0 +1,26 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AutoDilateAttribute.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+
+namespace Akka.TestKit;
+
+/// <summary>
+/// Marks a duration parameter whose value is automatically scaled by
+/// <see cref="TestKitSettings.TestTimeFactor"/>.
+/// </summary>
+/// <remarks>
+/// Callers should pass an undilated duration to parameters marked with this attribute.
+/// Passing a value that has already been scaled by <see cref="TestKitBase.Dilated(TimeSpan)"/>
+/// applies the configured time factor twice.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+public sealed class AutoDilateAttribute : Attribute
+{
+}

--- a/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/IEventFilterApplier.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="IEventFilterApplier.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -48,7 +48,7 @@ namespace Akka.TestKit
         /// <param name="timeout">The time to wait for a log event after executing <paramref name="action"/></param>
         /// <param name="action">The action.</param>
         /// <param name="cancellationToken"></param>
-        void ExpectOne(TimeSpan timeout, Action action, CancellationToken cancellationToken = default);
+        void ExpectOne([AutoDilate] TimeSpan timeout, Action action, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="action"/> and
@@ -59,7 +59,7 @@ namespace Akka.TestKit
         /// <param name="timeout">The time to wait for a log event after executing <paramref name="action"/></param>
         /// <param name="action">The action.</param>
         /// <param name="cancellationToken"></param>
-        Task ExpectOneAsync(TimeSpan timeout, Func<Task> action, CancellationToken cancellationToken = default);
+        Task ExpectOneAsync([AutoDilate] TimeSpan timeout, Func<Task> action, CancellationToken cancellationToken = default);
 
         [Obsolete(
             "Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) instead beginning in Akka.NET v1.5")]
@@ -113,7 +113,7 @@ namespace Akka.TestKit
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="action">The action.</param>
         /// <param name="cancellationToken"></param>
-        void Expect(int expectedCount, TimeSpan timeout, Action action, CancellationToken cancellationToken = default);
+        void Expect(int expectedCount, [AutoDilate] TimeSpan timeout, Action action, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="action"/> and expects the specified number
@@ -126,10 +126,10 @@ namespace Akka.TestKit
         /// <param name="expectedCount">The expected number of events</param>
         /// <param name="action">The action.</param>
         /// <param name="cancellationToken"></param>
-        Task ExpectAsync(int expectedCount, TimeSpan timeout, Func<Task> action, CancellationToken cancellationToken = default);
+        Task ExpectAsync(int expectedCount, [AutoDilate] TimeSpan timeout, Func<Task> action, CancellationToken cancellationToken = default);
         
         [Obsolete("Use ExpectAsync<T>(expectedCount, TimeSpan, Func<Task<T>>) instead. This method only exists to support backwards compatibility as of Akka.NET v1.5.")]
-        Task ExpectAsync(int expectedCount, TimeSpan timeout, Action action, CancellationToken cancellationToken = default);
+        Task ExpectAsync(int expectedCount, [AutoDilate] TimeSpan timeout, Action action, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="func"/> and
@@ -168,7 +168,7 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <param name="cancellationToken"></param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        T ExpectOne<T>(TimeSpan timeout, Func<T> func, CancellationToken cancellationToken = default);
+        T ExpectOne<T>([AutoDilate] TimeSpan timeout, Func<T> func, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="func"/> and
@@ -181,7 +181,7 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <param name="cancellationToken"></param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        Task<T> ExpectOneAsync<T>(TimeSpan timeout, Func<Task<T>> func, CancellationToken cancellationToken = default);
+        Task<T> ExpectOneAsync<T>([AutoDilate] TimeSpan timeout, Func<Task<T>> func, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="func"/> and expects the specified number
@@ -225,7 +225,7 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <param name="cancellationToken"></param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        T Expect<T>(int expectedCount, TimeSpan timeout, Func<T> func, CancellationToken cancellationToken = default);
+        T Expect<T>(int expectedCount, [AutoDilate] TimeSpan timeout, Func<T> func, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="func"/> and expects the specified number
@@ -240,7 +240,7 @@ namespace Akka.TestKit
         /// <param name="func">The function.</param>
         /// <param name="cancellationToken"></param>
         /// <returns>The returned value from <paramref name="func"/>.</returns>
-        Task<T> ExpectAsync<T>(int expectedCount, TimeSpan timeout, Func<Task<T>> func, CancellationToken cancellationToken = default);
+        Task<T> ExpectAsync<T>(int expectedCount, [AutoDilate] TimeSpan timeout, Func<Task<T>> func, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes <paramref name="func"/> and prevent events from being logged during the execution.

--- a/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="EventFilterApplier.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -74,7 +74,7 @@ namespace Akka.TestKit.Internal
         }
         
         public void ExpectOne(
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Action action,
             CancellationToken cancellationToken = default)
         {
@@ -86,7 +86,7 @@ namespace Akka.TestKit.Internal
         /// Async version of <see cref="ExpectOne(System.TimeSpan,System.Action,CancellationToken) "/>
         /// </summary>
         public async Task ExpectOneAsync(
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Func<Task> action,
             CancellationToken cancellationToken = default)
         {
@@ -143,7 +143,7 @@ namespace Akka.TestKit.Internal
         
         public void Expect(
             int expectedCount,
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Action action,
             CancellationToken cancellationToken = default)
         {
@@ -156,7 +156,7 @@ namespace Akka.TestKit.Internal
         /// </summary>
         public async Task ExpectAsync(
             int expectedCount,
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Func<Task> action,
             CancellationToken cancellationToken = default)
         {
@@ -169,7 +169,7 @@ namespace Akka.TestKit.Internal
                 ;
         }
 
-        public async Task ExpectAsync(int expectedCount, TimeSpan timeout, Action action, CancellationToken cancellationToken = default)
+        public async Task ExpectAsync(int expectedCount, [AutoDilate] TimeSpan timeout, Action action, CancellationToken cancellationToken = default)
         {
             await ExpectAsync(expectedCount, timeout, Wrapped, cancellationToken);
             return;
@@ -203,7 +203,7 @@ namespace Akka.TestKit.Internal
         }
         
         public T ExpectOne<T>(
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Func<T> func,
             CancellationToken cancellationToken = default)
         {
@@ -215,7 +215,7 @@ namespace Akka.TestKit.Internal
         /// Async version of ExpectOne
         /// </summary>
         public Task<T> ExpectOneAsync<T>(
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Func<Task<T>> func,
             CancellationToken cancellationToken = default)
         {
@@ -256,7 +256,7 @@ namespace Akka.TestKit.Internal
         
         public T Expect<T>(
             int expectedCount,
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Func<T> func,
             CancellationToken cancellationToken = default)
         {
@@ -270,7 +270,7 @@ namespace Akka.TestKit.Internal
         /// </summary>
         public Task<T> ExpectAsync<T>(
             int expectedCount,
-            TimeSpan timeout,
+            [AutoDilate] TimeSpan timeout,
             Func<Task<T>> func,
             CancellationToken cancellationToken = default)
         {

--- a/src/core/Akka.TestKit/TestBarrier.cs
+++ b/src/core/Akka.TestKit/TestBarrier.cs
@@ -36,7 +36,7 @@ namespace Akka.TestKit
         /// <param name="testKit">TBD</param>
         /// <param name="count">TBD</param>
         /// <param name="defaultTimeout">TBD</param>
-        public TestBarrier(TestKitBase testKit, int count, TimeSpan? defaultTimeout=null)
+        public TestBarrier(TestKitBase testKit, int count, [AutoDilate] TimeSpan? defaultTimeout=null)
         {
             _testKit = testKit;
             _count = count;
@@ -56,7 +56,7 @@ namespace Akka.TestKit
         /// TBD
         /// </summary>
         /// <param name="timeout">TBD</param>
-        public void Await(TimeSpan timeout)
+        public void Await([AutoDilate] TimeSpan timeout)
         {
             _barrier.SignalAndWait(_testKit.Dilated(timeout));
         }

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -513,7 +513,7 @@ namespace Akka.TestKit
         /// <param name="duration">The maximum.</param>
         /// <returns>A finite <see cref="TimeSpan"/> properly dilated</returns>
         /// <exception cref="ArgumentException">Thrown if <paramref name="duration"/> is infinite</exception>
-        public TimeSpan RemainingOrDilated(TimeSpan? duration)
+        public TimeSpan RemainingOrDilated([AutoDilate] TimeSpan? duration)
         {
             if(!duration.HasValue) return RemainingOrDefault;
             if(duration < TimeSpan.Zero) throw new ArgumentException("Must be positive TimeSpan", nameof(duration));
@@ -527,7 +527,7 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="duration">TBD</param>
         /// <returns>TBD</returns>
-        public TimeSpan Dilated(TimeSpan duration)
+        public TimeSpan Dilated([AutoDilate] TimeSpan duration)
         {
             if (duration < TimeSpan.Zero)
                 throw new ArgumentException("Must not be negative", nameof(duration));

--- a/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
@@ -34,14 +34,14 @@ namespace Akka.TestKit
         /// <param name="duration">The timeout.</param>
         /// <param name="interval">The interval to wait between executing the assertion.</param>
         /// <param name="cancellationToken"></param>
-        public void AwaitAssert(Action assertion, TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
+        public void AwaitAssert(Action assertion, [AutoDilate] TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
         {
             AwaitAssertAsync(assertion, duration, interval, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
         
         /// <inheritdoc cref="AwaitAssert(Action, TimeSpan?, TimeSpan?, CancellationToken)"/>
-        public async Task AwaitAssertAsync(Action assertion, TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
+        public async Task AwaitAssertAsync(Action assertion, [AutoDilate] TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
         {
             var intervalValue = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
             if(intervalValue == Timeout.InfiniteTimeSpan) intervalValue = TimeSpan.MaxValue;
@@ -91,7 +91,7 @@ namespace Akka.TestKit
         /// <param name="duration">The timeout.</param>
         /// <param name="interval">The interval to wait between executing the assertion.</param>
         /// <param name="cancellationToken"></param>
-        public async Task AwaitAssertAsync(Func<Task> assertion, TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
+        public async Task AwaitAssertAsync(Func<Task> assertion, [AutoDilate] TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
         {
             var intervalValue = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
             if(intervalValue == Timeout.InfiniteTimeSpan) intervalValue = TimeSpan.MaxValue;

--- a/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
@@ -72,13 +72,13 @@ namespace Akka.TestKit
         /// The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
         /// specified in config value "akka.test.timefactor".</param>
         /// <param name="cancellationToken"></param>
-        public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, CancellationToken cancellationToken = default)
+        public void AwaitCondition(Func<bool> conditionIsFulfilled, [AutoDilate] TimeSpan? max, CancellationToken cancellationToken = default)
         {
             AwaitConditionAsync(() => Task.FromResult(conditionIsFulfilled()), max, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
         
-        public async Task AwaitConditionAsync(Func<Task<bool>> conditionIsFulfilled, TimeSpan? max, CancellationToken cancellationToken = default)
+        public async Task AwaitConditionAsync(Func<Task<bool>> conditionIsFulfilled, [AutoDilate] TimeSpan? max, CancellationToken cancellationToken = default)
         {
             var maxDur = RemainingOrDilated(max);
             var interval = new TimeSpan(maxDur.Ticks / 10);
@@ -106,13 +106,13 @@ namespace Akka.TestKit
         /// specified in config value "akka.test.timefactor".</param>
         /// <param name="message">The message used if the timeout expires.</param>
         /// <param name="cancellationToken"></param>
-        public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, string message, CancellationToken cancellationToken = default)
+        public void AwaitCondition(Func<bool> conditionIsFulfilled, [AutoDilate] TimeSpan? max, string message, CancellationToken cancellationToken = default)
         {
             AwaitConditionAsync(conditionIsFulfilled, max, message, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
         
-        public async Task AwaitConditionAsync(Func<Task<bool>> conditionIsFulfilled, TimeSpan? max, string message, CancellationToken cancellationToken = default)
+        public async Task AwaitConditionAsync(Func<Task<bool>> conditionIsFulfilled, [AutoDilate] TimeSpan? max, string message, CancellationToken cancellationToken = default)
         {
             var maxDur = RemainingOrDilated(max);
             var interval = new TimeSpan(maxDur.Ticks / 10);
@@ -120,7 +120,7 @@ namespace Akka.TestKit
             await InternalAwaitConditionAsync(conditionIsFulfilled, maxDur, interval, (format, args) => AssertionsFail(format, args, message), logger, cancellationToken);
         }
         
-        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan? max, string message, CancellationToken cancellationToken = default)
+        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, [AutoDilate] TimeSpan? max, string message, CancellationToken cancellationToken = default)
         {
             Task<bool> Wrapped() => Task.FromResult(conditionIsFulfilled());
             await AwaitConditionAsync(Wrapped, max, message, cancellationToken);
@@ -154,13 +154,13 @@ namespace Akka.TestKit
         /// </param>
         /// <param name="message">The message used if the timeout expires.</param>
         /// <param name="cancellationToken"></param>
-        public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, TimeSpan? interval, string message = null, CancellationToken cancellationToken = default)
+        public void AwaitCondition(Func<bool> conditionIsFulfilled, [AutoDilate] TimeSpan? max, TimeSpan? interval, string message = null, CancellationToken cancellationToken = default)
         { 
             AwaitConditionAsync(conditionIsFulfilled, max, interval, message, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
         
-        public async Task AwaitConditionAsync(Func<Task<bool>> conditionIsFulfilled, TimeSpan? max, TimeSpan? interval, string message = null, CancellationToken cancellationToken = default)
+        public async Task AwaitConditionAsync(Func<Task<bool>> conditionIsFulfilled, [AutoDilate] TimeSpan? max, TimeSpan? interval, string message = null, CancellationToken cancellationToken = default)
         {
             var maxDur = RemainingOrDilated(max);
             var logger = _testState.TestKitSettings.LogTestKitCalls ? _testState.Log : null;
@@ -168,7 +168,7 @@ namespace Akka.TestKit
                 (format, args) => AssertionsFail(format, args, message), logger, cancellationToken);
         }
         
-        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, TimeSpan? max, TimeSpan? interval, string message = null, CancellationToken cancellationToken = default)
+        public async Task AwaitConditionAsync(Func<bool> conditionIsFulfilled, [AutoDilate] TimeSpan? max, TimeSpan? interval, string message = null, CancellationToken cancellationToken = default)
         {
             Task<bool> Wrapped() => Task.FromResult(conditionIsFulfilled());
             await AwaitConditionAsync(Wrapped, max, interval, message, cancellationToken);
@@ -186,7 +186,7 @@ namespace Akka.TestKit
         /// Between calls the thread sleeps. If <paramref name="interval"/> is not specified or <c>null</c> 100 ms is used.</para>
         /// </summary>
         /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
-        /// <param name="max">The maximum duration.</param>
+        /// <param name="max">The maximum duration. This value is not automatically dilated.</param>
         /// <param name="interval">Optional. The time between calls to <paramref name="conditionIsFulfilled"/> to check
         /// if the condition is fulfilled. Between calls the thread sleeps. If undefined, 100 ms is used
         /// </param>
@@ -213,10 +213,7 @@ namespace Akka.TestKit
         /// <summary>
         /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
         /// expires, whichever comes first.</para>
-        /// <para>If no timeout is given, take it from the innermost enclosing `within`
-        /// block.</para>
-        /// <para>Note that the timeout is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
-        /// specified in config value "akka.test.timefactor".</para>
+        /// <para>Note that the timeout is not automatically scaled using <see cref="Dilated(TimeSpan)"/>.</para>
         /// <para>The parameter <paramref name="interval"/> specifies the time between calls to <paramref name="conditionIsFulfilled"/>
         /// Between calls the thread sleeps. If <paramref name="interval"/> is undefined the thread only sleeps 
         /// one time, using the <paramref name="max"/> as duration, and then rechecks the condition and ultimately 
@@ -225,8 +222,7 @@ namespace Akka.TestKit
         /// instead set it to a relatively small value.</para>
         /// </summary>
         /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
-        /// <param name="max">The maximum duration. The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. 
-        /// scaled by the factor specified in config value "akka.test.timefactor".</param>
+        /// <param name="max">The maximum duration. This value is not automatically dilated.</param>
         /// <param name="interval">The time between calls to <paramref name="conditionIsFulfilled"/> to check
         /// if the condition is fulfilled. Between calls the thread sleeps. If undefined the thread only sleeps 
         /// one time, using the <paramref name="max"/>, and then rechecks the condition and ultimately 
@@ -252,10 +248,7 @@ namespace Akka.TestKit
         /// <summary>
         /// <para>Await until the given condition evaluates to <c>true</c> or the timeout
         /// expires, whichever comes first.</para>
-        /// <para>If no timeout is given, take it from the innermost enclosing `within`
-        /// block.</para>
-        /// <para>Note that the timeout is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. scaled by the factor 
-        /// specified in config value "akka.test.timefactor".</para>
+        /// <para>Note that the timeout is not automatically scaled using <see cref="Dilated(TimeSpan)"/>.</para>
         /// <para>The parameter <paramref name="interval"/> specifies the time between calls to <paramref name="conditionIsFulfilled"/>
         /// Between calls the thread sleeps. If <paramref name="interval"/> is undefined the thread only sleeps 
         /// one time, using the <paramref name="max"/> as duration, and then rechecks the condition and ultimately 
@@ -264,8 +257,7 @@ namespace Akka.TestKit
         /// instead set it to a relatively small value.</para>
         /// </summary>
         /// <param name="conditionIsFulfilled">The condition that must be fulfilled within the duration.</param>
-        /// <param name="max">The maximum duration. The value is <see cref="Dilated(TimeSpan)">dilated</see>, i.e. 
-        /// scaled by the factor specified in config value "akka.test.timefactor".</param>
+        /// <param name="max">The maximum duration. This value is not automatically dilated.</param>
         /// <param name="interval">The time between calls to <paramref name="conditionIsFulfilled"/> to check
         /// if the condition is fulfilled. Between calls the thread sleeps. If undefined the thread only sleeps 
         /// one time, using the <paramref name="max"/>, and then rechecks the condition and ultimately 

--- a/src/core/Akka.TestKit/TestKitBase_Expect.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Expect.cs
@@ -204,7 +204,7 @@ namespace Akka.TestKit
             CancellationToken cancellationToken = default)
         {
             return InternalExpectMsgAsync<T>(
-                    timeout: RemainingOrDilated(RemainingOrDilated(timeout)),
+                    timeout: RemainingOrDilated(timeout),
                     assert: (m, sender) =>
                     {
                         _assertions.AssertTrue(

--- a/src/core/Akka.TestKit/TestKitBase_Expect.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Expect.cs
@@ -36,7 +36,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         /// <returns>TBD</returns>
         public T ExpectMsg<T>(
-            TimeSpan? duration = null,
+            [AutoDilate] TimeSpan? duration = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -45,7 +45,7 @@ namespace Akka.TestKit
         
         /// <inheritdoc cref="ExpectMsg{T}(TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> ExpectMsgAsync<T>(
-            TimeSpan? duration = null, 
+            [AutoDilate] TimeSpan? duration = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -68,7 +68,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T ExpectMsg<T>(
             T message,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -79,7 +79,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ExpectMsg{T}(T, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> ExpectMsgAsync<T>(
             T message,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -108,7 +108,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T ExpectMsg<T>(
             Predicate<T> isMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null, 
             CancellationToken cancellationToken = default)
         {
@@ -119,7 +119,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ExpectMsg{T}(Predicate{T}, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> ExpectMsgAsync<T>(
             Predicate<T> isMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -152,7 +152,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T ExpectMsg<T>(
             Action<T> assert,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -163,7 +163,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ExpectMsg{T}(Action{T}, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> ExpectMsgAsync<T>(
             Action<T> assert,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -188,7 +188,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T ExpectMsg<T>(
             Func<T, IActorRef, bool> isMessageAndSender, 
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -199,7 +199,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ExpectMsg{T}(Func{T, IActorRef, bool}, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> ExpectMsgAsync<T>(
             Func<T, IActorRef, bool> isMessageAndSender,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -235,7 +235,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T ExpectMsg<T>(
             Action<T, IActorRef> assertMessageAndSender, 
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -246,7 +246,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ExpectMsg{T}(Action{T, IActorRef}, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> ExpectMsgAsync<T>(
             Action<T, IActorRef> assertMessageAndSender,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -272,7 +272,7 @@ namespace Akka.TestKit
         public T ExpectMsg<T>(
             T expected,
             Func<T, T, bool> comparer,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -284,7 +284,7 @@ namespace Akka.TestKit
         public ValueTask<T> ExpectMsgAsync<T>(
             T expected,
             Func<T, T, bool> comparer,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -310,7 +310,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public Terminated ExpectTerminated(
             IActorRef target,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -321,7 +321,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ExpectTerminated(IActorRef, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<Terminated> ExpectTerminatedAsync(
             IActorRef target,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -474,13 +474,13 @@ namespace Akka.TestKit
         /// </summary>
         /// <param name="duration">TBD</param>
         /// <param name="cancellationToken"></param>
-        public void ExpectNoMsg(TimeSpan duration, CancellationToken cancellationToken = default)
+        public void ExpectNoMsg([AutoDilate] TimeSpan duration, CancellationToken cancellationToken = default)
         {
             ExpectNoMsgAsync(duration, cancellationToken).GetAwaiter().GetResult();
         }
         
         /// <inheritdoc cref="ExpectNoMsg(TimeSpan, CancellationToken)"/>
-        public ValueTask ExpectNoMsgAsync(TimeSpan duration, CancellationToken cancellationToken = default)
+        public ValueTask ExpectNoMsgAsync([AutoDilate] TimeSpan duration, CancellationToken cancellationToken = default)
         {
             return InternalExpectNoMsgAsync(Dilated(duration), cancellationToken);
         }
@@ -596,7 +596,7 @@ namespace Akka.TestKit
         }
         
         public IReadOnlyCollection<T> ExpectMsgAllOf<T>(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             params T[] messages)
         {
             return ExpectMsgAllOf(max, messages, default(CancellationToken));
@@ -622,7 +622,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         /// <returns>The received messages in received order</returns>
         public IReadOnlyCollection<T> ExpectMsgAllOf<T>(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             IReadOnlyCollection<T> messages,
             CancellationToken cancellationToken = default)
         {
@@ -632,7 +632,7 @@ namespace Akka.TestKit
         }
         
         public async IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             IReadOnlyCollection<T> messages,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {

--- a/src/core/Akka.TestKit/TestKitBase_ExpectAllWithPredicates.cs
+++ b/src/core/Akka.TestKit/TestKitBase_ExpectAllWithPredicates.cs
@@ -44,13 +44,13 @@ public abstract partial class TestKitBase
         }
     }
 
-    public IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(TimeSpan max, params PredicateInfo[] predicates)
+    public IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates([AutoDilate] TimeSpan max, params PredicateInfo[] predicates)
     {
         using var cts = new CancellationTokenSource(RemainingOrDefault);
         return ExpectMsgAllOfMatchingPredicates(max, predicates, cts.Token);
     }
 
-    public IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(TimeSpan max,
+    public IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates([AutoDilate] TimeSpan max,
         IReadOnlyCollection<PredicateInfo> predicates, CancellationToken cancellationToken)
     {
         return ExpectMsgAllOfMatchingPredicatesAsync(max, predicates, cancellationToken)
@@ -59,7 +59,7 @@ public abstract partial class TestKitBase
     }
 
     public async IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(
-        TimeSpan max,
+        [AutoDilate] TimeSpan max,
         IReadOnlyCollection<PredicateInfo> predicates,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {

--- a/src/core/Akka.TestKit/TestKitBase_ExpectMsgFrom.cs
+++ b/src/core/Akka.TestKit/TestKitBase_ExpectMsgFrom.cs
@@ -34,7 +34,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T ExpectMsgFrom<T>(
             IActorRef sender,
-            TimeSpan? duration = null,
+            [AutoDilate] TimeSpan? duration = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -48,7 +48,7 @@ namespace Akka.TestKit
 
         public ValueTask<T> ExpectMsgFromAsync<T>(
             IActorRef sender,
-            TimeSpan? duration = null,
+            [AutoDilate] TimeSpan? duration = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -81,7 +81,7 @@ namespace Akka.TestKit
         public T ExpectMsgFrom<T>(
             IActorRef sender,
             T message,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -97,7 +97,7 @@ namespace Akka.TestKit
         public ValueTask<T> ExpectMsgFromAsync<T>(
             IActorRef sender,
             T message,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -131,7 +131,7 @@ namespace Akka.TestKit
         public T ExpectMsgFrom<T>(
             IActorRef sender,
             Predicate<T> isMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -147,7 +147,7 @@ namespace Akka.TestKit
         public ValueTask<T> ExpectMsgFromAsync<T>(
             IActorRef sender,
             Predicate<T> isMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -182,7 +182,7 @@ namespace Akka.TestKit
         public T ExpectMsgFrom<T>(
             Predicate<IActorRef> isSender, 
             Predicate<T> isMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -198,7 +198,7 @@ namespace Akka.TestKit
         public ValueTask<T> ExpectMsgFromAsync<T>(
             Predicate<IActorRef> isSender,
             Predicate<T> isMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -250,7 +250,7 @@ namespace Akka.TestKit
         public T ExpectMsgFrom<T>(
             IActorRef sender,
             Action<T> assertMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -266,7 +266,7 @@ namespace Akka.TestKit
         public ValueTask<T> ExpectMsgFromAsync<T>(
             IActorRef sender,
             Action<T> assertMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -297,7 +297,7 @@ namespace Akka.TestKit
         public T ExpectMsgFrom<T>(
             Action<IActorRef> assertSender, 
             Action<T> assertMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {
@@ -313,7 +313,7 @@ namespace Akka.TestKit
         public ValueTask<T> ExpectMsgFromAsync<T>(
             Action<IActorRef> assertSender, 
             Action<T> assertMessage,
-            TimeSpan? timeout = null,
+            [AutoDilate] TimeSpan? timeout = null,
             string hint = null,
             CancellationToken cancellationToken = default)
         {

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -33,7 +33,7 @@ namespace Akka.TestKit
         /// <returns>Returns the message that <paramref name="isMessage"/> matched</returns>
         public object FishForMessage(
             Predicate<object> isMessage,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             string hint = "",
             CancellationToken cancellationToken = default)
         {
@@ -44,7 +44,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="FishForMessage(Predicate{object}, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<object> FishForMessageAsync(
             Predicate<object> isMessage,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             string hint = "",
             CancellationToken cancellationToken = default)
         {
@@ -63,7 +63,7 @@ namespace Akka.TestKit
         /// <returns>Returns the message that <paramref name="isMessage"/> matched</returns>
         public T FishForMessage<T>(
             Predicate<T> isMessage,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             string hint = "",
             CancellationToken cancellationToken = default)
         {
@@ -74,7 +74,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="FishForMessage{T}(Predicate{T}, TimeSpan?, string, CancellationToken)"/>
         public ValueTask<T> FishForMessageAsync<T>(
             Predicate<T> isMessage,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             string hint = "",
             CancellationToken cancellationToken = default)
         {
@@ -95,7 +95,7 @@ namespace Akka.TestKit
         public T FishForMessage<T>(
             Predicate<T> isMessage,
             ArrayList allMessages,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             string hint = "",
             CancellationToken cancellationToken = default)
         {
@@ -107,7 +107,7 @@ namespace Akka.TestKit
         public async ValueTask<T> FishForMessageAsync<T>(
             Predicate<T> isMessage,
             ArrayList allMessages, 
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             string hint = "",
             CancellationToken cancellationToken = default)
         {
@@ -139,7 +139,7 @@ namespace Akka.TestKit
         /// <typeparam name="T">The type that the message is not supposed to be.</typeparam>
         /// <param name="max">Optional. The maximum wait duration. Defaults to <see cref="RemainingOrDefault"/> when unset.</param>
         /// <param name="cancellationToken"></param>
-        public async Task FishUntilMessageAsync<T>(TimeSpan? max = null, CancellationToken cancellationToken = default)
+        public async Task FishUntilMessageAsync<T>([AutoDilate] TimeSpan? max = null, CancellationToken cancellationToken = default)
         {
             var enumerable = ReceiveWhileAsync<object>(
                 max: max, 
@@ -485,7 +485,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         /// <returns>TBD</returns>
         public IReadOnlyList<T> ReceiveWhile<T>(
-            TimeSpan? max,
+            [AutoDilate] TimeSpan? max,
             Func<object, T> filter, 
             int msgs = int.MaxValue,
             CancellationToken cancellationToken = default)
@@ -497,7 +497,7 @@ namespace Akka.TestKit
 
         /// <inheritdoc cref="ReceiveWhile{T}(TimeSpan?, Func{object, T}, int, CancellationToken)"/>
         public async IAsyncEnumerable<T> ReceiveWhileAsync<T>(
-            TimeSpan? max,
+            [AutoDilate] TimeSpan? max,
             Func<object, T> filter,
             int msgs = int.MaxValue,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -526,7 +526,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         /// <returns>TBD</returns>
         public IReadOnlyList<T> ReceiveWhile<T>(
-            TimeSpan? max,
+            [AutoDilate] TimeSpan? max,
             TimeSpan? idle,
             Func<object, T> filter, 
             int msgs = int.MaxValue,
@@ -539,7 +539,7 @@ namespace Akka.TestKit
 
         /// <inheritdoc cref="ReceiveWhile{T}(TimeSpan?, TimeSpan?, Func{object, T}, int, CancellationToken)"/>
         public async IAsyncEnumerable<T> ReceiveWhileAsync<T>(
-            TimeSpan? max,
+            [AutoDilate] TimeSpan? max,
             TimeSpan? idle,
             Func<object, T> filter,
             int msgs = int.MaxValue,
@@ -570,7 +570,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public IReadOnlyList<T> ReceiveWhile<T>(
             Func<object, T> filter,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             TimeSpan? idle = null,
             int msgs = int.MaxValue,
             CancellationToken cancellationToken = default)
@@ -583,7 +583,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ReceiveWhile{T}(Func{object, T}, TimeSpan?, TimeSpan?, int, CancellationToken)"/>
         public async IAsyncEnumerable<T> ReceiveWhileAsync<T>(
             Func<object, T> filter,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             TimeSpan? idle = null,
             int msgs = int.MaxValue,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -663,7 +663,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public IReadOnlyList<T> ReceiveWhile<T>(
             Predicate<T> shouldContinue, 
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             TimeSpan? idle = null,
             int msgs = int.MaxValue,
             bool shouldIgnoreOtherMessageTypes = true, 
@@ -677,7 +677,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ReceiveWhile{T}(Predicate{T}, TimeSpan?, TimeSpan?, int, bool, CancellationToken)"/>
         public async IAsyncEnumerable<T> ReceiveWhileAsync<T>(
             Predicate<T> shouldContinue,
-            TimeSpan? max = null,
+            [AutoDilate] TimeSpan? max = null,
             TimeSpan? idle = null,
             int msgs = int.MaxValue,
             bool shouldIgnoreOtherMessageTypes = true,
@@ -789,7 +789,7 @@ namespace Akka.TestKit
         /// <returns>The received messages</returns>
         public IReadOnlyCollection<object> ReceiveN(
             int numberOfMessages,
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             CancellationToken cancellationToken = default)
         {
             return ReceiveNAsync(numberOfMessages, max, cancellationToken)
@@ -800,7 +800,7 @@ namespace Akka.TestKit
         /// <inheritdoc cref="ReceiveN(int, TimeSpan, CancellationToken)"/>
         public async IAsyncEnumerable<object> ReceiveNAsync(
             int numberOfMessages, 
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             max.EnsureIsPositiveFinite("max");

--- a/src/core/Akka.TestKit/TestKitBase_Within.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Within.cs
@@ -30,7 +30,7 @@ namespace Akka.TestKit
         /// <param name="epsilonValue">TBD</param>
         /// <param name="cancellationToken"></param>
         public void Within(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Action action,
             TimeSpan? epsilonValue = null,
             CancellationToken cancellationToken = default)
@@ -54,7 +54,7 @@ namespace Akka.TestKit
         /// that takes a <see cref="Func{Task}"/> instead of an <see cref="Action"/>
         /// </summary>
         public async Task WithinAsync(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Func<Task> actionAsync,
             TimeSpan? epsilonValue = null,
             CancellationToken cancellationToken = default)
@@ -88,7 +88,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         public void Within(
             TimeSpan min,
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Action action,
             string hint = null,
             TimeSpan? epsilonValue = null,
@@ -114,7 +114,7 @@ namespace Akka.TestKit
         /// </summary>
         public async Task WithinAsync(
             TimeSpan min,
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Func<Task> actionAsync,
             string hint = null,
             TimeSpan? epsilonValue = null,
@@ -148,7 +148,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         /// <returns>TBD</returns>
         public T Within<T>(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Func<T> function,
             TimeSpan? epsilonValue = null,
             CancellationToken cancellationToken = default)
@@ -177,7 +177,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         /// <returns>TBD</returns>
         public Task<T> WithinAsync<T>(
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Func<Task<T>> function,
             TimeSpan? epsilonValue = null,
             CancellationToken cancellationToken = default)
@@ -208,7 +208,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public T Within<T>(
             TimeSpan min,
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Func<T> function,
             string hint = null,
             TimeSpan? epsilonValue = null,
@@ -250,7 +250,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         public async Task<T> WithinAsync<T>(
             TimeSpan min,
-            TimeSpan max,
+            [AutoDilate] TimeSpan max,
             Func<Task<T>> function,
             string hint = null,
             TimeSpan? epsilonValue = null,

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -496,7 +496,11 @@ namespace Akka.Actor
         {
             while (true)
             {
-                switch (State)
+                // snapshot the state once per iteration - another thread can flip it at any time
+                // (i.e. a concurrent Stop() moving us from ActorPath to StoppedWithPath), so
+                // matching on the field and then re-reading it can observe two different values.
+                var state = State;
+                switch (state)
                 {
                     case null when UpdateState(null, Registering.Instance):
                     {
@@ -514,8 +518,8 @@ namespace Akka.Actor
                     }
                     case null:
                         continue;
-                    case ActorPath _:
-                        return State as ActorPath;
+                    case ActorPath path:
+                        return path;
                     case StoppedWithPath stoppedWithPath:
                         return stoppedWithPath.Path;
                     case Stopped _:


### PR DESCRIPTION
Backport of 5 merged dev PRs to v1.5 for the v1.5.71 maintenance release.

## Changes
- **#8426** — Fix ClusterClientDiscovery: preserve contact-point subscriptions across rediscovery
- **#8430** — Fix double-dilated timeout in `ExpectMsgAsync<T>(Func<T, IActorRef, bool>, ...)`
- **#8436** — Fix torn read in `PromiseActorRef.GetPath` that made `Path` return null
- **#8437** — Akka.Remote: stop, don't restart, failed throttler children (#8433, #8434)
- **#8441** — Add AutoDilate metadata to TestKit timeouts

## API approval
Includes the `AutoDilateAttribute` additions to `CoreAPISpec.ApproveTestKit.DotNet/Net.verified.txt` (new public type from #8441). Verified locally: all 15 net10.0 approval tests pass.

## Notes
- Supersedes #8443 (which had failing API-approval checks)
- Excluded from this backport: #8377 (needs LangVersion bump for netstandard2.0 — follow-up PR), #8445 (behavior change), #8465 (.NET 6 target incompatibility)