### PR TITLE
fix: update Incrementalist to 1.2.2 for SDK 10.0.4xx compatibility

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": true
     },
     "incrementalist.cmd": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "commands": [
         "incrementalist"
       ],


### PR DESCRIPTION
CI is currently red on every PR: the hosted agents began preinstalling .NET SDK 10.0.400, and Incrementalist 1.2.1's bundled MSBuild assemblies cannot evaluate the 10.0.4xx SDK targets. It crashes opening the solution before anything compiles:

```
InvalidProjectFileException: The expression
"[Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformSDKLocation(Windows, 7.0)"
cannot be evaluated. Could not load type 'DebugTraceInterpolatedStringHandler'
from assembly 'Microsoft.Build.Framework, Version=15.1.0.0'.
/opt/hostedtoolcache/dotnet/sdk/10.0.400/Microsoft.Common.CurrentVersion.targets
```

First seen on build 130767. The failure is in Incrementalist's solution load, so it hits every job on every branch regardless of content.

Fix: bump the tool manifest to Incrementalist **1.2.2** (released 2026-08-18), which bundles MSBuild 18.9.6 and NuGet.Frameworks 7.9.0 to match the 10.0.4xx band - this exact failure is what that release addresses. Root-cause fix rather than pinning the SDK band, so CI keeps tracking current SDKs.

An earlier revision of this PR pinned `global.json` to the 10.0.1xx feature band instead; superseded by the tool bump.

Verified locally: `dotnet tool restore` resolves 1.2.2 and it loads the solution config cleanly. The real validation is this PR's own CI run, which executes 1.2.2 on the 10.0.400 hosted image.