### PR TITLE
Artery test-mode: disarm the unknown-origin gate when the last blackhole heals

### DIFF
--- a/src/core/Akka.Remote.Tests/Artery/ArteryBlackholeEndToEndSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryBlackholeEndToEndSpec.cs
@@ -120,6 +120,54 @@ namespace Akka.Remote.Tests.Artery
             }
         }
 
+        [Fact(DisplayName = "after an A<->B blackhole is fully healed, a brand-new peer C (never seen before) can still complete its handshake and exchange traffic")]
+        public async Task Should_Allow_New_Peer_Handshake_After_Unrelated_Heal()
+        {
+            var remoteSysB = ActorSystem.Create("blackhole-heal-residue-b", ArteryTestModeConfig);
+            var remoteSysC = ActorSystem.Create("blackhole-heal-residue-c", ArteryTestModeConfig);
+            try
+            {
+                remoteSysB.ActorOf(Props.Create(() => new Echo()), "echo");
+                remoteSysC.ActorOf(Props.Create(() => new Echo()), "echo");
+
+                var addressB = AddressOf(remoteSysB);
+                var selectionB = Sys.ActorSelection($"akka://{remoteSysB.Name}@127.0.0.1:{addressB.Port}/user/echo");
+
+                // 1. Establish A<->B, blackhole it, confirm the drop, then heal it. This is the
+                //    ONLY blackhole ever set on A's transport, and it is fully healed before C
+                //    ever contacts A.
+                await AwaitRoundTripAsync(selectionB, "b-before-blackhole");
+
+                var transport = TransportOf(Sys);
+                (await transport.ManagementCommand(new SetThrottle(addressB, ThrottleTransportAdapter.Direction.Both, Blackhole.Instance)))
+                    .Should().BeTrue();
+
+                var duringProbe = CreateTestProbe();
+                selectionB.Tell("b-during-blackhole", duringProbe.Ref);
+                await duringProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+
+                (await transport.ManagementCommand(new SetThrottle(addressB, ThrottleTransportAdapter.Direction.Both, Unthrottled.Instance)))
+                    .Should().BeTrue();
+                await AwaitRoundTripAsync(selectionB, "b-after-heal");
+
+                // 2. A has never talked to C before, so C is an unknown origin at A until their
+                //    handshake completes. If healing the A<->B blackhole left ANY residue in A's
+                //    SharedTestState, AnyBlackholePresent() would still report true and A's
+                //    InboundTestStage would drop every unknown-origin envelope except a
+                //    HandshakeReq -- including C's HandshakeRsp -- wedging C's association
+                //    forever even though nothing involving C was ever blackholed. A successful
+                //    round-trip here proves the heal left no such residue.
+                var addressC = AddressOf(remoteSysC);
+                var selectionC = Sys.ActorSelection($"akka://{remoteSysC.Name}@127.0.0.1:{addressC.Port}/user/echo");
+                await AwaitRoundTripAsync(selectionC, "c-handshake-after-heal");
+            }
+            finally
+            {
+                await remoteSysB.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(10));
+                await remoteSysC.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(10));
+            }
+        }
+
         [Fact(DisplayName = "blackhole(Send) applied on the REMOTE system drops traffic at ITS stages (inbound drop of our pings); PassThrough heals")]
         public async Task Should_Blackhole_And_Heal_From_Remote_Side()
         {

--- a/src/core/Akka.Remote.Tests/Artery/InboundTestStageSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/InboundTestStageSpec.cs
@@ -24,11 +24,11 @@ namespace Akka.Remote.Tests.Artery
 {
     /// <summary>
     /// Stage-level tests for <see cref="InboundTestStage"/> (artery <c>advanced.test-mode</c>
-    /// failure injection, port of Pekko's <c>InboundTestStage</c>), including the load-bearing
-    /// pre-handshake special case: an unknown-origin <see cref="HandshakeReq"/> must pass while
-    /// any blackhole is present (or legitimate new associations would wedge), while every OTHER
-    /// unknown-origin envelope -- including a <see cref="HandshakeRsp"/>, verbatim Pekko -- is
-    /// dropped. Drives the stage directly with probes; no TCP.
+    /// failure injection), including the load-bearing pre-handshake special case: an
+    /// unknown-origin <see cref="HandshakeReq"/> must pass while any blackhole is present (or
+    /// legitimate new associations would wedge), while every OTHER unknown-origin envelope --
+    /// including a <see cref="HandshakeRsp"/> -- is dropped. Drives the stage directly with
+    /// probes; no TCP.
     /// </summary>
     public class InboundTestStageSpec : AkkaSpec
     {
@@ -113,7 +113,7 @@ namespace Akka.Remote.Tests.Artery
                 "dropping an unknown origin's HandshakeReq would wedge every legitimate NEW association while any blackhole is active");
         }
 
-        [Fact(DisplayName = "unknown origin + any blackhole present: every other envelope is dropped -- including a HandshakeRsp (verbatim Pekko)")]
+        [Fact(DisplayName = "unknown origin + any blackhole present: every other envelope is dropped -- including a HandshakeRsp")]
         public async Task Should_Drop_Unknown_Origin_NonReq_While_Blackholed()
         {
             var (state, _, pub, sub) = BuildHarness();
@@ -131,18 +131,22 @@ namespace Akka.Remote.Tests.Artery
             (await sub.ExpectNextAsync(TimeSpan.FromSeconds(3))).Message.Should().BeOfType<HandshakeReq>();
         }
 
-        [Fact(DisplayName = "unknown-origin gating STAYS active after a full heal (empty-set retention -- verbatim Pekko)")]
-        public async Task Should_Keep_Unknown_Origin_Gating_After_Heal()
+        [Fact(DisplayName = "unknown-origin gating LIFTS after a full heal: a fresh incarnation's envelopes pass again")]
+        public async Task Should_Lift_Unknown_Origin_Gating_After_Heal()
         {
             var (state, _, pub, sub) = BuildHarness();
             state.Blackhole(Local.Address, Peer.Address, ThrottleTransportAdapter.Direction.Both);
             state.PassThrough(Local.Address, Peer.Address, ThrottleTransportAdapter.Direction.Both);
 
-            await sub.RequestAsync(2);
-            await pub.SendNextAsync(Envelope("still-dropped", originUid: 999L));
-            await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+            // No blackhole is active anywhere on this transport any more, so a message from an
+            // unknown origin (e.g. a fresh incarnation of a peer, a new uid the handshake hasn't
+            // completed for yet) is no longer gated -- it must pass through untouched, exactly as
+            // if no blackhole had ever been set.
+            await sub.RequestAsync(1);
+            await pub.SendNextAsync(Envelope("passes-after-heal", originUid: 999L));
+            (await sub.ExpectNextAsync(TimeSpan.FromSeconds(3))).Message.Should().Be("passes-after-heal");
 
-            // Known origins are unaffected by the retained empty set.
+            // Known origins are unaffected either way.
             var (state2, context2, pub2, sub2) = BuildHarness();
             state2.Blackhole(Local.Address, Peer.Address, ThrottleTransportAdapter.Direction.Both);
             state2.PassThrough(Local.Address, Peer.Address, ThrottleTransportAdapter.Direction.Both);

--- a/src/core/Akka.Remote.Tests/Artery/SharedTestStateSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/SharedTestStateSpec.cs
@@ -18,10 +18,10 @@ namespace Akka.Remote.Tests.Artery
 {
     /// <summary>
     /// Pure state tests for <see cref="SharedTestState"/>, the blackhole map behind artery's
-    /// <c>advanced.test-mode</c> failure injection (port of Pekko's <c>SharedTestState</c>,
-    /// <c>TestStage.scala</c>). No actor system required. The direction/key-order assertions here
-    /// are the load-bearing ones: BOTH test stages check <c>(localAddress, remoteAddress)</c>, so
-    /// these directed entries are exactly what determines which node drops what.
+    /// <c>advanced.test-mode</c> failure injection. No actor system required. The
+    /// direction/key-order assertions here are the load-bearing ones: BOTH test stages check
+    /// <c>(localAddress, remoteAddress)</c>, so these directed entries are exactly what
+    /// determines which node drops what.
     /// </summary>
     public class SharedTestStateSpec
     {
@@ -48,7 +48,7 @@ namespace Akka.Remote.Tests.Artery
 
             state.IsBlackhole(B, A).Should().BeTrue();
             state.IsBlackhole(A, B).Should().BeFalse(
-                "Receive adds only (b -> a) -- neither of node a's own (a, b)-keyed stage checks matches it (verbatim Pekko semantics)");
+                "Receive adds only (b -> a) -- neither of node a's own (a, b)-keyed stage checks matches it");
         }
 
         [Fact(DisplayName = "Blackhole(a, b, Both) adds both directed pairs")]
@@ -86,19 +86,35 @@ namespace Akka.Remote.Tests.Artery
             state.IsBlackhole(B, A).Should().BeFalse();
         }
 
-        [Fact(DisplayName = "AnyBlackholePresent stays true after a full PassThrough heal (empty sets retained -- verbatim Pekko parity)")]
-        public void Should_Retain_Keys_After_Heal()
+        [Fact(DisplayName = "AnyBlackholePresent returns false again after a full PassThrough heal (no stale residue)")]
+        public void Should_Clear_AnyBlackholePresent_After_Full_Heal()
         {
             var state = new SharedTestState();
             state.AnyBlackholePresent().Should().BeFalse("pristine state has no entries");
 
             state.Blackhole(A, B, ThrottleTransportAdapter.Direction.Both);
+            state.AnyBlackholePresent().Should().BeTrue();
+
             state.PassThrough(A, B, ThrottleTransportAdapter.Direction.Both);
 
             state.IsBlackhole(A, B).Should().BeFalse();
-            state.AnyBlackholePresent().Should().BeTrue(
-                "Pekko's removeBlackhole keeps the (now empty) key in the map, so the unknown-origin " +
-                "inbound gating stays active for the remainder of the test run -- port this verbatim");
+            state.IsBlackhole(B, A).Should().BeFalse();
+            state.AnyBlackholePresent().Should().BeFalse(
+                "healing the only active pair must drop the now-empty key entirely, otherwise the " +
+                "unknown-origin inbound gate would stay on forever even though nothing is blackholed");
+        }
+
+        [Fact(DisplayName = "AnyBlackholePresent stays true while an unrelated pair is still blackholed")]
+        public void Should_Keep_AnyBlackholePresent_While_Other_Pair_Active()
+        {
+            var state = new SharedTestState();
+            state.Blackhole(A, B, ThrottleTransportAdapter.Direction.Both);
+            state.Blackhole(A, C, ThrottleTransportAdapter.Direction.Send);
+
+            state.PassThrough(A, B, ThrottleTransportAdapter.Direction.Both);
+
+            state.IsBlackhole(A, B).Should().BeFalse();
+            state.AnyBlackholePresent().Should().BeTrue("the unrelated (a -> c) pair is still active");
         }
 
         [Fact(DisplayName = "PassThrough on a pristine state is a harmless no-op")]
@@ -108,7 +124,7 @@ namespace Akka.Remote.Tests.Artery
             state.PassThrough(A, B, ThrottleTransportAdapter.Direction.Both);
 
             state.IsBlackhole(A, B).Should().BeFalse();
-            state.AnyBlackholePresent().Should().BeFalse("no key was ever added, so none is retained");
+            state.AnyBlackholePresent().Should().BeFalse("no key was ever added, so none is present");
         }
 
         [Fact(DisplayName = "concurrent adds from many threads all converge (CAS-loop correctness)")]

--- a/src/core/Akka.Remote/Artery/TestStage.cs
+++ b/src/core/Akka.Remote/Artery/TestStage.cs
@@ -22,18 +22,16 @@ namespace Akka.Remote.Artery
     /// INTERNAL API.
     ///
     /// Thread-safe mutable blackhole state shared among this transport's test stages
-    /// (<see cref="OutboundTestStage"/> / <see cref="InboundTestStage"/>), the port of Pekko's
-    /// <c>SharedTestState</c> (<c>remote/.../artery/TestStage.scala</c>). One instance per
+    /// (<see cref="OutboundTestStage"/> / <see cref="InboundTestStage"/>). One instance per
     /// <see cref="ArteryRemoting"/> transport, created ONLY when
     /// <c>akka.remote.artery.advanced.test-mode = on</c> (<see cref="ArterySettings.TestMode"/>) --
     /// with test-mode off neither this state nor any test stage exists at all.
     ///
     /// <para>
-    /// <b>Semantics (verbatim Pekko parity -- do not "fix").</b> The state is a map of directed
-    /// <c>from -&gt; {to}</c> blackhole pairs. BOTH the outbound and the inbound stage check the
-    /// SAME key order, <c>(localAddress, remoteAddress)</c> -- see
-    /// <c>TestStage.scala</c>'s <c>OutboundTestStage</c>/<c>InboundTestStage</c>. Consequences,
-    /// for a <c>SetThrottle</c> command applied on node <c>a</c> targeting node <c>b</c>:
+    /// <b>Semantics.</b> The state is a map of directed <c>from -&gt; {to}</c> blackhole pairs.
+    /// BOTH the outbound and the inbound stage check the SAME key order,
+    /// <c>(localAddress, remoteAddress)</c>. Consequences, for a <c>SetThrottle</c> command
+    /// applied on node <c>a</c> targeting node <c>b</c>:
     /// <list type="bullet">
     /// <item><description><c>Direction.Send</c> adds <c>(a -&gt; b)</c>, which matches BOTH of
     /// <c>a</c>'s checks -- so <c>a</c> drops its outbound to <c>b</c> AND its inbound from
@@ -42,29 +40,30 @@ namespace Akka.Remote.Artery
     /// at node <c>a</c> the observable effect is the same full cut.</description></item>
     /// <item><description><c>Direction.Receive</c> adds only <c>(b -&gt; a)</c>, which matches
     /// NEITHER of <c>a</c>'s <c>(a, b)</c>-keyed checks -- a Receive-only blackhole produces no
-    /// drops at the commanded node. This mirrors Pekko exactly; no in-tree multi-node spec uses
-    /// Receive-only over artery (the one that does, <c>TestConductorSpec</c>, is pinned to
-    /// classic remoting).</description></item>
+    /// drops at the commanded node. No in-tree multi-node spec uses Receive-only over artery (the
+    /// one that does, <c>TestConductorSpec</c>, is pinned to classic remoting).</description></item>
     /// </list>
     /// This is what lets the TestConductor route a <c>blackhole(a, b, Both)</c> command to node
     /// <c>a</c> ALONE and still produce a symmetric, both-sides-observable partition.
     /// </para>
     ///
     /// <para>
-    /// <b>Empty sets are retained (Pekko parity).</b> <see cref="PassThrough"/> removes the
-    /// destination from the key's set but keeps the (now possibly empty) key in the map, exactly
-    /// like Pekko's <c>removeBlackhole</c> (<c>blackholes.updated(from, destinations - to)</c>) --
-    /// so <see cref="AnyBlackholePresent"/> stays <see langword="true"/> once any blackhole has
-    /// ever been set, and <see cref="InboundTestStage"/>'s unknown-origin gating stays active for
-    /// the remainder of the test run.
+    /// <b>Healed pairs are fully removed.</b> <see cref="PassThrough"/> removes the destination
+    /// from the key's set, and once that leaves the key's set empty the key itself is dropped
+    /// from the map. That keeps <see cref="AnyBlackholePresent"/> in sync with reality: once every
+    /// blackhole a node has ever set has been healed, it returns <see langword="false"/> again and
+    /// <see cref="InboundTestStage"/>'s unknown-origin gate stops applying -- so a fresh incarnation
+    /// of a peer (a new uid, an unknown origin until its handshake completes) is not blocked by a
+    /// blackhole that no longer exists. While at least one blackhole is active anywhere on this
+    /// transport, the gate stays on so a still-blackholed peer cannot be routed around by forging a
+    /// new incarnation.
     /// </para>
     ///
     /// <para>
     /// <b>Threading.</b> Reads (<see cref="IsBlackhole"/> / <see cref="AnyBlackholePresent"/>, the
     /// per-element hot path when test-mode is on) are a single <c>Volatile.Read</c> of an
     /// immutable snapshot -- lock-free, allocation-free. Writes (rare: one per TestConductor
-    /// command) CAS-loop via <c>ImmutableInterlocked.Update</c>, the .NET analog of Pekko's
-    /// <c>AtomicReference</c> + <c>@tailrec</c> compareAndSet loops.
+    /// command) CAS-loop via <c>ImmutableInterlocked.Update</c>.
     /// </para>
     /// </summary>
     internal sealed class SharedTestState
@@ -73,8 +72,10 @@ namespace Akka.Remote.Artery
             ImmutableDictionary<Address, ImmutableHashSet<Address>>.Empty;
 
         /// <summary>
-        /// Whether ANY blackhole entry (including a healed key retaining an empty set -- see the
-        /// type-level "empty sets are retained" remarks) has ever been registered.
+        /// Whether any directed blackhole pair is currently active anywhere in the map. A key
+        /// whose destination set has been fully healed is removed rather than left empty (see the
+        /// type-level remarks), so this returns <see langword="false"/> once every blackhole this
+        /// transport ever set has been passed through.
         /// </summary>
         public bool AnyBlackholePresent() => !Volatile.Read(ref _blackholes).IsEmpty;
 
@@ -88,8 +89,8 @@ namespace Akka.Remote.Artery
 
         /// <summary>
         /// Enables blackholing between <paramref name="a"/> and <paramref name="b"/> in the given
-        /// direction (port of Pekko's <c>SharedTestState.blackhole</c>): <c>Send</c> adds
-        /// <c>(a -&gt; b)</c>, <c>Receive</c> adds <c>(b -&gt; a)</c>, <c>Both</c> adds both.
+        /// direction: <c>Send</c> adds <c>(a -&gt; b)</c>, <c>Receive</c> adds <c>(b -&gt; a)</c>,
+        /// <c>Both</c> adds both.
         /// </summary>
         public void Blackhole(Address a, Address b, ThrottleTransportAdapter.Direction direction)
         {
@@ -109,9 +110,9 @@ namespace Akka.Remote.Artery
         }
 
         /// <summary>
-        /// Reverses <see cref="Blackhole"/> for the given direction (port of Pekko's
-        /// <c>SharedTestState.passThrough</c>). The key itself is retained (possibly with an empty
-        /// set) -- see the type-level remarks.
+        /// Reverses <see cref="Blackhole"/> for the given direction. A key whose destination set
+        /// becomes empty as a result is removed from the map entirely -- see the type-level
+        /// remarks on <see cref="AnyBlackholePresent"/>.
         /// </summary>
         public void PassThrough(Address a, Address b, ThrottleTransportAdapter.Direction direction)
         {
@@ -143,31 +144,38 @@ namespace Akka.Remote.Artery
         private void RemoveBlackhole(Address from, Address to) =>
             ImmutableInterlocked.Update(
                 ref _blackholes,
-                static (map, pair) => map.TryGetValue(pair.From, out var destinations)
-                    ? map.SetItem(pair.From, destinations.Remove(pair.To))
-                    : map,
+                static (map, pair) =>
+                {
+                    if (!map.TryGetValue(pair.From, out var destinations))
+                        return map;
+
+                    var updated = destinations.Remove(pair.To);
+
+                    // Drop the key entirely once its destination set is empty so
+                    // AnyBlackholePresent() reflects reality instead of leaving stale residue
+                    // behind that keeps the unknown-origin gate on forever.
+                    return updated.IsEmpty ? map.Remove(pair.From) : map.SetItem(pair.From, updated);
+                },
                 (From: from, To: to));
     }
 
     /// <summary>
     /// INTERNAL API.
     ///
-    /// Outbound half of artery test-mode failure injection (port of Pekko's
-    /// <c>OutboundTestStage</c>, <c>TestStage.scala</c>): drops every outbound envelope while
+    /// Outbound half of artery test-mode failure injection: drops every outbound envelope while
     /// <c>(localAddress, remoteAddress)</c> is blackholed in the <see cref="SharedTestState"/>,
     /// passes everything through otherwise. Woven into the outbound pipelines ONLY when
-    /// <see cref="ArterySettings.TestMode"/> is on -- placement per stream (Pekko-faithful):
+    /// <see cref="ArterySettings.TestMode"/> is on -- placement per stream:
     /// <list type="bullet">
     /// <item><description>ordinary (single-lane and per-lane) and large streams: UPSTREAM of
-    /// <see cref="OutboundHandshakeStage"/> (Pekko <c>Association.scala</c>'s
-    /// <c>runOutboundOrdinaryMessagesStream</c>/<c>runOutboundLargeMessagesStream</c>) -- so the
-    /// handshake stage's own injected <see cref="HandshakeReq"/>s enter DOWNSTREAM of this stage
-    /// and are never dropped here;</description></item>
+    /// <see cref="OutboundHandshakeStage"/> -- so the handshake stage's own injected
+    /// <see cref="HandshakeReq"/>s enter DOWNSTREAM of this stage and are never dropped
+    /// here;</description></item>
     /// <item><description>control stream: DOWNSTREAM of <see cref="SystemMessageDeliveryStage"/>,
-    /// immediately before the encoder (Pekko <c>ArteryTransport.outboundControl</c>: "system
-    /// messages must not be dropped before the SystemMessageDelivery stage") -- a blackholed
-    /// system message is already recorded in the delivery stage's resend buffer, so it is
-    /// re-delivered once <c>PassThrough</c> heals the link.</description></item>
+    /// immediately before the encoder -- system messages must not be dropped before the
+    /// SystemMessageDelivery stage, so a blackholed system message is already recorded in the
+    /// delivery stage's resend buffer and is re-delivered once <c>PassThrough</c> heals the
+    /// link.</description></item>
     /// </list>
     /// </summary>
     internal sealed class OutboundTestStage : GraphStage<FlowShape<IOutboundEnvelope, IOutboundEnvelope>>
@@ -230,22 +238,23 @@ namespace Akka.Remote.Artery
     /// <summary>
     /// INTERNAL API.
     ///
-    /// Inbound half of artery test-mode failure injection (port of Pekko's
-    /// <c>InboundTestStage</c>, <c>TestStage.scala</c>). Woven into the inbound sink between the
-    /// deserializing <see cref="ArteryInboundProcessingStage"/> and
-    /// <see cref="InboundHandshakeStage"/> (Pekko: after <c>createDeserializer</c>, before
-    /// <c>InboundHandshake</c>) ONLY when <see cref="ArterySettings.TestMode"/> is on.
+    /// Inbound half of artery test-mode failure injection. Woven into the inbound sink between
+    /// the deserializing <see cref="ArteryInboundProcessingStage"/> and
+    /// <see cref="InboundHandshakeStage"/> ONLY when <see cref="ArterySettings.TestMode"/> is on.
     ///
     /// <para>
-    /// Per-envelope behavior (verbatim Pekko parity):
+    /// Per-envelope behavior:
     /// <list type="bullet">
     /// <item><description>origin uid resolves to a (handshake-completed) association: drop when
     /// <c>(localAddress, originAddress)</c> is blackholed, else pass;</description></item>
-    /// <item><description>origin unknown (handshake not completed) and any blackhole has ever been
-    /// present: let a <see cref="HandshakeReq"/> through (we cannot yet know whether ITS origin is
-    /// blackholed, and dropping it would wedge legitimate new associations), drop everything else
-    /// -- including a <see cref="HandshakeRsp"/>, exactly like Pekko;</description></item>
-    /// <item><description>origin unknown and no blackhole has ever been present: pass.</description></item>
+    /// <item><description>origin unknown (handshake not completed) and at least one blackhole is
+    /// currently active anywhere on this transport: let a <see cref="HandshakeReq"/> through (we
+    /// cannot yet know whether ITS origin is blackholed, and dropping it would wedge legitimate
+    /// new associations), drop everything else -- including a
+    /// <see cref="HandshakeRsp"/>;</description></item>
+    /// <item><description>origin unknown and no blackhole is currently active: pass. This includes
+    /// the case where every blackhole this transport ever set has since been healed -- a fresh
+    /// incarnation of a peer is not blocked by a blackhole that no longer exists.</description></item>
     /// </list>
     /// The lanes&gt;1 ordinary-connection lane path performs the SAME known-origin check inside
     /// <see cref="ArteryInboundProcessingStage"/> (its lane traffic bypasses this stage; its


### PR DESCRIPTION
Closes #8476.

Healing a blackhole removed the destination from its key's set but kept the (now empty) key in the map, so `AnyBlackholePresent()` stayed `true` for the rest of the run. While true, `InboundTestStage` drops every unknown-origin envelope except `HandshakeReq` - including `HandshakeRsp` - so a fresh incarnation of a peer (new uid = unknown origin) could be unable to complete a handshake after all blackholes were healed. That is precisely the shape of the restart specs in the multi-node suite: blackhole the victim, heal, victim restarts with a new uid.

The unknown-origin gate exists to keep mid-handshake traffic from sneaking past an active blackhole. Keeping it armed after the last heal serves no scenario the gate was built for, and breaks one that matters.

Fix: `RemoveBlackhole` drops a key once its destination set is empty, so `AnyBlackholePresent()` reflects whether any blackhole is actually active.

Tests: the two existing specs that asserted the residue as intended behavior are inverted to assert the corrected behavior (verified they catch a revert). New end-to-end spec in `ArteryBlackholeEndToEndSpec`: blackhole A-B over loopback TCP, heal, then a brand-new system C completes its handshake and exchanges traffic. All 255 Artery unit tests pass. Test-mode only; no production code path changes behavior.