### PR TITLE
MNTR: conductor keeps re-registered nodes; make RemoteReDeploymentSpec deterministic

### DIFF
--- a/src/core/Akka.Remote.TestKit.Tests/BarrierSpec.cs
+++ b/src/core/Akka.Remote.TestKit.Tests/BarrierSpec.cs
@@ -343,6 +343,28 @@ namespace Akka.Remote.TestKit.Tests
                 , nodeB), msg.Exception);
         }
 
+        [Fact(DisplayName = "BarrierCoordinator should fail an arrival from an unregistered client while waiting")]
+        public async Task A_BarrierCoordinator_must_fail_an_arrival_from_an_unregistered_client_while_waiting()
+        {
+            var barrier = GetBarrier();
+            var a = CreateTestProbe();
+            var b = CreateTestProbe();
+            var stranger = CreateTestProbe();
+            barrier.Tell(new Controller.NodeInfo(A, Address.Parse("akka://sys"), a.Ref));
+            barrier.Tell(new Controller.NodeInfo(B, Address.Parse("akka://sys"), b.Ref));
+            a.Send(barrier, new EnterBarrier("bar12", null, A));
+
+            // A client the coordinator holds no registration for cannot be counted towards the
+            // barrier, so it has to be told that rather than left hanging on its ask.
+            stranger.Send(barrier, new EnterBarrier("bar12", null, C));
+            await stranger.ExpectMsgAsync(new ToClient<BarrierResult>(new BarrierResult("bar12", false)));
+
+            // The stray arrival leaves the barrier itself alone.
+            b.Send(barrier, new EnterBarrier("bar12", null, B));
+            await a.ExpectMsgAsync(new ToClient<BarrierResult>(new BarrierResult("bar12", true)));
+            await b.ExpectMsgAsync(new ToClient<BarrierResult>(new BarrierResult("bar12", true)));
+        }
+
         //TODO: Controller tests.
 
         private IActorRef GetBarrier()

--- a/src/core/Akka.Remote.TestKit.Tests/ControllerSpec.cs
+++ b/src/core/Akka.Remote.TestKit.Tests/ControllerSpec.cs
@@ -7,9 +7,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
+using Akka.Util;
 using Xunit;
 
 namespace Akka.Remote.TestKit.Tests
@@ -47,6 +50,40 @@ namespace Akka.Remote.TestKit.Tests
                 c.Tell(PoisonPill.Instance);
                 ExpectMsg<Terminated>();
             }, TimeSpan.FromSeconds(20));
+        }
+
+        [Fact(DisplayName = "Controller should keep a re-registered node when its previous connection reports a disconnect")]
+        public async Task Controller_must_keep_a_re_registered_node_when_the_previous_connection_disconnects()
+        {
+            var address = Address.Parse("akka://sys");
+            var c = Sys.ActorOf(Props.Create(() => new Controller(1, new IPEndPoint(IPAddress.Loopback, 0))));
+            var oldConnection = CreateTestProbe();
+            var newConnection = CreateTestProbe();
+
+            oldConnection.Send(c, new Controller.NodeInfo(A, address, oldConnection.Ref));
+            await oldConnection.ExpectMsgAsync<ToClient<Done>>();
+
+            // Tear the node down the way TestConductor.Shutdown does, then let it come back on a
+            // fresh connection under the same role, the way StartNewSystem does.
+            c.Tell(new Terminate(A, new Left<bool, int>(true)));
+            await oldConnection.ExpectMsgAsync<ToClient<TerminateMsg>>();
+
+            newConnection.Send(c, new Controller.NodeInfo(A, address, newConnection.Ref));
+            await newConnection.ExpectMsgAsync<ToClient<Done>>();
+
+            // The connection that has already been replaced now reports its disconnect. It must
+            // not evict the registration that replaced it.
+            oldConnection.Send(c, new Controller.ClientDisconnected(A));
+
+            c.Tell(Controller.GetNodes.Instance);
+            var nodes = await ExpectMsgAsync<IEnumerable<RoleName>>();
+            Assert.Contains(A, nodes.ToList());
+
+            // The barrier coordinator has to still know the node as well, otherwise its arrivals
+            // are ignored and every later barrier stalls.
+            newConnection.Send(c, new EnterBarrier("after-restart", null, A));
+            var result = await newConnection.ExpectMsgAsync<ToClient<BarrierResult>>();
+            Assert.True(result.Msg.Success);
         }
     }
 }

--- a/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
+++ b/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
@@ -556,9 +556,17 @@ namespace Akka.Remote.TestKit
                     case EnterBarrier barrier:
                         if (barrier.Name != currentBarrier)
                             throw new WrongBarrierException(barrier.Name, Sender, barrier.Role, @event.StateData);
-                        var together = clients.Any(x => Equals(x.FSM, Sender))
-                            ? @event.StateData.Arrived.Add(Sender)
-                            : @event.StateData.Arrived;
+
+                        // An arrival from a client we hold no registration for can never be
+                        // counted towards this barrier, so failing it is the only honest answer.
+                        // Staying silent leaves that client blocked on an ask nothing will ever
+                        // complete: it reports a 60 second ask timeout long after the barrier
+                        // itself timed out on another node, which buries the real cause. Idle
+                        // already answers an unregistered sender this way.
+                        if (!clients.Any(x => Equals(x.FSM, Sender)))
+                            return Stay().Replying(new ToClient<BarrierResult>(new BarrierResult(barrier.Name, false)));
+
+                        var together = @event.StateData.Arrived.Add(Sender);
                         var enterDeadline = GetDeadline(barrier.Timeout);
                         //we only allow the deadlines to get shorter
                         if (enterDeadline.TimeLeft < @event.StateData.Deadline.TimeLeft)

--- a/src/core/Akka.Remote.TestKit/Conductor.cs
+++ b/src/core/Akka.Remote.TestKit/Conductor.cs
@@ -543,7 +543,10 @@ namespace Akka.Remote.TestKit
 
             OnTermination(_ =>
             {
-                _controller.Tell(new Controller.ClientDisconnected(_roleName));
+                // Name the sender explicitly. The controller compares it against the FSM it has
+                // registered for this role, which is how it tells a disconnect that belongs to
+                // this connection apart from one that a newer connection already replaced.
+                _controller.Tell(new Controller.ClientDisconnected(_roleName), Self);
                 _channel.CloseAsync();
             });
 

--- a/src/core/Akka.Remote.TestKit/Controller.cs
+++ b/src/core/Akka.Remote.TestKit/Controller.cs
@@ -307,6 +307,19 @@ namespace Akka.Remote.TestKit
             var clientDisconnected = message as ClientDisconnected;
             if (clientDisconnected != null && clientDisconnected.Name != null)
             {
+                // A ServerFSM can report its disconnect after the same role has already come back
+                // on a fresh channel, which is exactly what a node that calls StartNewSystem does.
+                // Removing the role by name alone would drop the live registration, and from then
+                // on the barrier coordinator ignores every arrival from that node, so the next
+                // barrier stalls until it times out. Only let a ServerFSM evict the registration
+                // it owns.
+                if (_nodes.TryGetValue(clientDisconnected.Name, out var registered)
+                    && !Equals(registered.FSM, Sender))
+                {
+                    _log.Debug("Ignoring disconnect of superseded connection for {0}", clientDisconnected.Name);
+                    return;
+                }
+
                 _nodes = _nodes.Remove(clientDisconnected.Name);
                 _barrier.Forward(clientDisconnected);
                 return;

--- a/src/core/Akka.Remote.TestKit/RemoteConnection.cs
+++ b/src/core/Akka.Remote.TestKit/RemoteConnection.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Remote.TestKit.Proto;
 using Akka.Remote.Transport.DotNetty;
@@ -126,9 +127,17 @@ namespace Akka.Remote.TestKit
 
         public static async Task ReleaseAll()
         {
-            Task tc = _clientPool?.ShutdownGracefullyAsync() ?? TaskEx.Completed;
-            Task ts = _serverPool?.ShutdownGracefullyAsync() ?? TaskEx.Completed;
-            await Task.WhenAll(tc, ts).ConfigureAwait(false);
+            // Detach the pools before shutting them down. A shut down event loop group cannot
+            // serve another connection, so leaving the fields set hands every later
+            // CreateConnection call a dead pool and the connection never completes.
+            var clientPool = Interlocked.Exchange(ref _clientPool, null);
+            var serverPool = Interlocked.Exchange(ref _serverPool, null);
+            var serverWorkerPool = Interlocked.Exchange(ref _serverWorkerPool, null);
+
+            Task tc = clientPool?.ShutdownGracefullyAsync() ?? TaskEx.Completed;
+            Task ts = serverPool?.ShutdownGracefullyAsync() ?? TaskEx.Completed;
+            Task tsw = serverWorkerPool?.ShutdownGracefullyAsync() ?? TaskEx.Completed;
+            await Task.WhenAll(tc, ts, tsw).ConfigureAwait(false);
         }
 
         #endregion

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteReDeploymentSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteReDeploymentSpec.cs
@@ -13,6 +13,7 @@ using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.Remote.Transport;
+using FluentAssertions;
 
 namespace Akka.Remote.Tests.MultiNode
 {
@@ -89,6 +90,12 @@ namespace Akka.Remote.Tests.MultiNode
 
             await RunOnAsync(async () =>
             {
+                // Read the address while `second` is still registered with the conductor. The
+                // replacement system has to come back on this exact address, otherwise the remote
+                // deployment `first` holds points at nothing and every later step fails for a
+                // reason that has nothing to do with re-deployment.
+                var addressBeforeRestart = (await NodeAsync(_config.Second)).Address;
+
                 await TestConductor.BlackholeAsync(_config.Second, _config.First, ThrottleTransportAdapter.Direction.Both);
                 await TestConductor.ShutdownAsync(_config.Second, true);
                 if (ExpectQuarantine)
@@ -105,16 +112,28 @@ namespace Akka.Remote.Tests.MultiNode
                 {
                     await ExpectNoMsgAsync(SleepAfterKill);
                 }
-                await AwaitAssertAsync(() => { Node(_config.Second); }, TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(100));
+                // The conductor parks an address query for a role it has no registration for and
+                // answers it the moment that role registers again, so awaiting this once is the
+                // handshake that the replacement node is back. Polling it instead queues further
+                // queries behind the first one, and the conductor client drops a query that
+                // arrives while another is still outstanding.
+                var addressAfterRestart = (await NodeAsync(_config.Second)).Address;
+                addressAfterRestart.Should().Be(addressBeforeRestart,
+                    "the replacement system on `second` must take over the address of the system it replaces");
             }, _config.First);
 
             ActorSystem tempSys = null;
 
             await RunOnAsync(async () =>
             {
+                var addressBeforeRestart = ((ExtendedActorSystem)Sys).Provider.DefaultAddress;
+
                 await Sys.WhenTerminated.WaitAsync(TimeSpan.FromSeconds(30));
                 await ExpectNoMsgAsync(SleepAfterKill);
-                tempSys = StartNewSystem();
+                tempSys = await StartNewSystemAsync();
+
+                ((ExtendedActorSystem)tempSys).Provider.DefaultAddress.Should().Be(addressBeforeRestart,
+                    "the replacement system must bind the address of the system it replaces");
             }, _config.Second);
 
             await EnterBarrierAsync("cable-cut");
@@ -129,16 +148,21 @@ namespace Akka.Remote.Tests.MultiNode
                 var firstEcho = await NodeAsync(_config.First) / "user" / "echo";
                 var sel = tempSys.ActorSelection(firstEcho);
                 var probe = CreateTestProbe(tempSys);
-                await probe.WithinAsync(TimeSpan.FromSeconds(15), async () =>
+
+                // Bound the retry loop here rather than nesting it inside a `within` block. A
+                // nested block that outruns its own budget loses the failure it was carrying, and
+                // the spec then walks into `ready-again` on an association that never came back:
+                // `first` reports a barrier timeout and `second` reports a 60 second barrier ask
+                // timeout, neither of which names the real problem. The 15 second budget also
+                // nests inside the 30 second barrier budget `first` spends waiting at
+                // `ready-again`.
+                await probe.AwaitAssertAsync(async () =>
                 {
-                    await probe.AwaitAssertAsync(async () =>
-                    {
-                        sel.Tell(new Identify("id-echo-again"), probe.Ref);
-                        var identity = await probe.ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(3));
-                        if (identity.Subject is null)
-                            throw new InvalidOperationException("echo on `first` not reachable yet");
-                    });
-                });
+                    sel.Tell(new Identify("id-echo-again"), probe.Ref);
+                    var identity = await probe.ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(2));
+                    if (identity.Subject is null)
+                        throw new InvalidOperationException("echo on `first` not reachable yet");
+                }, TimeSpan.FromSeconds(15), TimeSpan.FromMilliseconds(500));
             }, _config.Second);
 
             await EnterBarrierAsync("ready-again");


### PR DESCRIPTION
Two commits, found by evidence from build 130782, where RemoteReDeploymentSlowMultiNetSpec failed identically on two transports at once.

**Conductor fix.** When a node restarts its ActorSystem mid-spec, the old connection's ServerFSM eventually dies and fires ClientDisconnected - which the controller matched by role name, evicting the freshly re-registered node. The barrier coordinator then silently dropped the evicted node's barrier arrivals: no reply at all, so the node burned its full 60s ask (barrier-timeout + query-timeout) while the other side's barrier expired at 30s. Fixes: disconnects are matched against the registered FSM identity, not the role name; an arrival from an unregistered client in Waiting now gets an explicit BarrierResult(false) instead of silence; ReleaseAll detaches the shared event-loop groups so a second conductor in one process gets a live pool. New tests prove both by revert: without the identity check the re-registered node vanishes from GetNodes, and without the reply the arrival hangs forever.

This affects every spec that restarts a node's ActorSystem, on both transports - the ReDeployment family was just the loudest.

**Spec fix.** RemoteReDeploymentSpec now asserts what it used to assume: the restarted system's address is snapshotted and compared, the address query uses the conductor's own parked-reply handshake instead of a poll that blocked the test thread, and the re-association probe is bounded so it nests inside the barrier budget rather than relying on the WithinAsync timeout path - which silently swallows the block's failure (tracked separately in #8483; this spec no longer depends on it).

Verified: Akka.Remote.TestKit.Tests green; ReDeployment MNTR 6/6 on classic and artery; full Akka.Remote MNTR suite 58/58 on the pre-rebase branch.