### PR TITLE
Backport #8421 to v1.5: flush graceful Disassociate PDUs before transport force-close on shutdown

### DIFF
--- a/src/core/Akka.Remote/Transport/TransportAdapters.cs
+++ b/src/core/Akka.Remote/Transport/TransportAdapters.cs
@@ -550,8 +550,21 @@ namespace Akka.Remote.Transport
         public override Task<bool> Shutdown()
         {
             var stopTask = manager.GracefulStop((RARP.For(System).Provider).RemoteSettings.FlushWait);
-            var transportStopTask = WrappedTransport.Shutdown();
-            return Task.WhenAll(stopTask, transportStopTask).ContinueWith(x => x.IsCompleted && !(x.IsFaulted || x.IsCanceled), TaskContinuationOptions.ExecuteSynchronously);
+
+            // Sequence the wrapped-transport teardown AFTER the manager (and its child association
+            // actors) have stopped. Those children write the graceful Disassociate PDU as part of
+            // their own shutdown; running WrappedTransport.Shutdown() concurrently (as this used to)
+            // let the underlying transport force-close the channel out from under a not-yet-flushed
+            // Disassociate. Peers then kept a "zombie" association until the transport failure
+            // detector tripped (up to acceptable-heartbeat-pause, 120s by default). The manager stop
+            // is bounded by flush-wait-on-shutdown, and the wrapped transport is torn down regardless
+            // of whether the manager stopped cleanly, so shutdown can never hang on this ordering.
+            var transportStopTask = stopTask.ContinueWith(_ => WrappedTransport.Shutdown(),
+                TaskContinuationOptions.ExecuteSynchronously).Unwrap();
+
+            return Task.WhenAll(stopTask, transportStopTask)
+                .ContinueWith(x => x.IsCompleted && !(x.IsFaulted || x.IsCanceled),
+                    TaskContinuationOptions.ExecuteSynchronously);
         }
     }
 


### PR DESCRIPTION
Clean cherry-pick of #8421 (dev squash a91839360) onto v1.5, whose copy of `ActorTransportAdapter.Shutdown()` was byte-identical to the pre-fix dev version.

`Shutdown()` previously stopped the adapter manager and tore down the wrapped transport concurrently, so the transport could force-close the channel before the child association actors' graceful Disassociate PDU reached the wire. Peers then held a zombie association until the transport failure detector tripped - up to `acceptable-heartbeat-pause`, 120s by default - on every graceful shutdown or rolling restart. The fix sequences the teardown: manager (and its Disassociate-writing children) first, wrapped transport after, each still bounded by `flush-wait-on-shutdown`. The wrapped transport is torn down even if the manager stop faults, and the returned task's never-throw semantics are unchanged.

v1.5 relevance: v1.5 is classic-remoting only, so this is the production shutdown path for every v1.5 cluster. On dev the fix was validated by two consecutive fully-green multi-node CI runs, including a complete clean run of the non-blocking artery lanes.

Validated on the v1.5 toolchain: `Akka.Remote` builds clean for netstandard2.0 and net6.0 at 0 warnings; transport-adapter suite 14/14 and the broader Transport filter 105/105 on net10.0. Single file touched; release-notes roll-up left to the next versioned release PR per convention.