### PR TITLE
Backport MNTR conductor reliability to v1.5 (#8431 barrier honesty + #8485 conductor fixes)

### DIFF
--- a/src/core/Akka.MultiNode.TestAdapter/Internal/MultiNodeTestRunner.cs
+++ b/src/core/Akka.MultiNode.TestAdapter/Internal/MultiNodeTestRunner.cs
@@ -298,7 +298,7 @@ namespace Akka.MultiNode.TestAdapter.Internal
                     }
                     else
                     {
-                        _sinkCoordinator.Tell(new NodeCompletedSpecWithFail(_test.Node, _test.Role, _test.DisplayName + " passed."));
+                        _sinkCoordinator.Tell(new NodeCompletedSpecWithFail(_test.Node, _test.Role, _test.DisplayName + " failed."));
                     }
                 };
                 opt.OutputDataReceived = OutputHandler;

--- a/src/core/Akka.Remote.TestKit.Tests/BarrierSpec.cs
+++ b/src/core/Akka.Remote.TestKit.Tests/BarrierSpec.cs
@@ -343,6 +343,28 @@ namespace Akka.Remote.TestKit.Tests
                 , nodeB), msg.Exception);
         }
 
+        [Fact(DisplayName = "BarrierCoordinator should fail an arrival from an unregistered client while waiting")]
+        public async Task A_BarrierCoordinator_must_fail_an_arrival_from_an_unregistered_client_while_waiting()
+        {
+            var barrier = GetBarrier();
+            var a = CreateTestProbe();
+            var b = CreateTestProbe();
+            var stranger = CreateTestProbe();
+            barrier.Tell(new Controller.NodeInfo(A, Address.Parse("akka://sys"), a.Ref));
+            barrier.Tell(new Controller.NodeInfo(B, Address.Parse("akka://sys"), b.Ref));
+            a.Send(barrier, new EnterBarrier("bar12", null, A));
+
+            // A client the coordinator holds no registration for cannot be counted towards the
+            // barrier, so it has to be told that rather than left hanging on its ask.
+            stranger.Send(barrier, new EnterBarrier("bar12", null, C));
+            await stranger.ExpectMsgAsync(new ToClient<BarrierResult>(new BarrierResult("bar12", false)));
+
+            // The stray arrival leaves the barrier itself alone.
+            b.Send(barrier, new EnterBarrier("bar12", null, B));
+            await a.ExpectMsgAsync(new ToClient<BarrierResult>(new BarrierResult("bar12", true)));
+            await b.ExpectMsgAsync(new ToClient<BarrierResult>(new BarrierResult("bar12", true)));
+        }
+
         //TODO: Controller tests.
 
         private IActorRef GetBarrier()

--- a/src/core/Akka.Remote.TestKit.Tests/ControllerSpec.cs
+++ b/src/core/Akka.Remote.TestKit.Tests/ControllerSpec.cs
@@ -7,9 +7,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
+using Akka.Util;
 using Xunit;
 
 namespace Akka.Remote.TestKit.Tests
@@ -47,6 +50,40 @@ namespace Akka.Remote.TestKit.Tests
                 c.Tell(PoisonPill.Instance);
                 ExpectMsg<Terminated>();
             }, TimeSpan.FromSeconds(20));
+        }
+
+        [Fact(DisplayName = "Controller should keep a re-registered node when its previous connection reports a disconnect")]
+        public async Task Controller_must_keep_a_re_registered_node_when_the_previous_connection_disconnects()
+        {
+            var address = Address.Parse("akka://sys");
+            var c = Sys.ActorOf(Props.Create(() => new Controller(1, new IPEndPoint(IPAddress.Loopback, 0))));
+            var oldConnection = CreateTestProbe();
+            var newConnection = CreateTestProbe();
+
+            oldConnection.Send(c, new Controller.NodeInfo(A, address, oldConnection.Ref));
+            await oldConnection.ExpectMsgAsync<ToClient<Done>>();
+
+            // Tear the node down the way TestConductor.Shutdown does, then let it come back on a
+            // fresh connection under the same role, the way StartNewSystem does.
+            c.Tell(new Terminate(A, new Left<bool, int>(true)));
+            await oldConnection.ExpectMsgAsync<ToClient<TerminateMsg>>();
+
+            newConnection.Send(c, new Controller.NodeInfo(A, address, newConnection.Ref));
+            await newConnection.ExpectMsgAsync<ToClient<Done>>();
+
+            // The connection that has already been replaced now reports its disconnect. It must
+            // not evict the registration that replaced it.
+            oldConnection.Send(c, new Controller.ClientDisconnected(A));
+
+            c.Tell(Controller.GetNodes.Instance);
+            var nodes = await ExpectMsgAsync<IEnumerable<RoleName>>();
+            Assert.Contains(A, nodes.ToList());
+
+            // The barrier coordinator has to still know the node as well, otherwise its arrivals
+            // are ignored and every later barrier stalls.
+            newConnection.Send(c, new EnterBarrier("after-restart", null, A));
+            var result = await newConnection.ExpectMsgAsync<ToClient<BarrierResult>>();
+            Assert.True(result.Msg.Success);
         }
     }
 }

--- a/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
+++ b/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
@@ -556,9 +556,17 @@ namespace Akka.Remote.TestKit
                     case EnterBarrier barrier:
                         if (barrier.Name != currentBarrier)
                             throw new WrongBarrierException(barrier.Name, Sender, barrier.Role, @event.StateData);
-                        var together = clients.Any(x => Equals(x.FSM, Sender))
-                            ? @event.StateData.Arrived.Add(Sender)
-                            : @event.StateData.Arrived;
+
+                        // An arrival from a client we hold no registration for can never be
+                        // counted towards this barrier, so failing it is the only honest answer.
+                        // Staying silent leaves that client blocked on an ask nothing will ever
+                        // complete: it reports a 60 second ask timeout long after the barrier
+                        // itself timed out on another node, which buries the real cause. Idle
+                        // already answers an unregistered sender this way.
+                        if (!clients.Any(x => Equals(x.FSM, Sender)))
+                            return Stay().Replying(new ToClient<BarrierResult>(new BarrierResult(barrier.Name, false)));
+
+                        var together = @event.StateData.Arrived.Add(Sender);
                         var enterDeadline = GetDeadline(barrier.Timeout);
                         //we only allow the deadlines to get shorter
                         if (enterDeadline.TimeLeft < @event.StateData.Deadline.TimeLeft)

--- a/src/core/Akka.Remote.TestKit/Conductor.cs
+++ b/src/core/Akka.Remote.TestKit/Conductor.cs
@@ -530,7 +530,10 @@ namespace Akka.Remote.TestKit
 
             OnTermination(_ =>
             {
-                _controller.Tell(new Controller.ClientDisconnected(_roleName));
+                // Name the sender explicitly. The controller compares it against the FSM it has
+                // registered for this role, which is how it tells a disconnect that belongs to
+                // this connection apart from one that a newer connection already replaced.
+                _controller.Tell(new Controller.ClientDisconnected(_roleName), Self);
                 _channel.CloseAsync();
             });
 

--- a/src/core/Akka.Remote.TestKit/Controller.cs
+++ b/src/core/Akka.Remote.TestKit/Controller.cs
@@ -307,6 +307,19 @@ namespace Akka.Remote.TestKit
             var clientDisconnected = message as ClientDisconnected;
             if (clientDisconnected != null && clientDisconnected.Name != null)
             {
+                // A ServerFSM can report its disconnect after the same role has already come back
+                // on a fresh channel, which is exactly what a node that calls StartNewSystem does.
+                // Removing the role by name alone would drop the live registration, and from then
+                // on the barrier coordinator ignores every arrival from that node, so the next
+                // barrier stalls until it times out. Only let a ServerFSM evict the registration
+                // it owns.
+                if (_nodes.TryGetValue(clientDisconnected.Name, out var registered)
+                    && !Equals(registered.FSM, Sender))
+                {
+                    _log.Debug("Ignoring disconnect of superseded connection for {0}", clientDisconnected.Name);
+                    return;
+                }
+
                 _nodes = _nodes.Remove(clientDisconnected.Name);
                 _barrier.Forward(clientDisconnected);
                 return;

--- a/src/core/Akka.Remote.TestKit/Player.cs
+++ b/src/core/Akka.Remote.TestKit/Player.cs
@@ -177,7 +177,9 @@ partial class TestConductor //Player trait in JVM version
             {
                 var askTimeout = barrierTimeout + Settings.QueryTimeout;
                 // Use async ask with cancellation token
-                var result = await _client.Ask(new ToServer<EnterBarrier>(new EnterBarrier(name, barrierTimeout, roleName)), askTimeout, cancellationToken);
+                // A failed barrier now faults this ask (see the Status.Failure note in ClientFSM), so the
+                // exception propagates to the caller instead of the spec silently continuing unsynchronized.
+                await _client.Ask(new ToServer<EnterBarrier>(new EnterBarrier(name, barrierTimeout, roleName)), askTimeout, cancellationToken);
             }
             catch (TaskCanceledException ex)
             {
@@ -421,7 +423,7 @@ internal class ClientFSM : FSM<ClientFSM.State, ClientFSM.Data>, ILoggingFSM
                     _log.Error("Received {0} instead of Done", @event.FsmEvent);
                     return GoTo(State.Failed);
                 case IServerOp:
-                    return Stay().Replying(new Failure(new IllegalStateException("not connected yet")));
+                    return Stay().Replying(new Status.Failure(new IllegalStateException("not connected yet")));
                 case StateTimeout:
                     _log.Error("connect timeout to TestConductor");
                     return GoTo(State.Failed);
@@ -475,17 +477,22 @@ internal class ClientFSM : FSM<ClientFSM.State, ClientFSM.Data>, ILoggingFSM
                     else
                     {
                         object response;
+                        // NOTE: these MUST be Status.Failure. The unqualified name `Failure` binds to the
+                        // inherited FSMBase.Failure (an FSM termination reason), which the ask completion
+                        // switch in FutureActorRef does not treat as a fault - it falls through to
+                        // `case T t: TrySetResult(t)`, so the ask completes SUCCESSFULLY and the caller
+                        // walks through a barrier that never synchronized.
                         if (barrierResult.Name != @event.StateData.RunningOp.Value.Item1)
                         {
                             response =
-                                new Failure(
+                                new Status.Failure(
                                     new Exception("wrong barrier " + barrierResult + " received while waiting for " +
                                                   @event.StateData.RunningOp.Value.Item1));
                         }
                         else if (!barrierResult.Success)
                         {
                             response =
-                                new Failure(
+                                new Status.Failure(
                                     new Exception("barrier failed:" + @event.StateData.RunningOp.Value.Item1));
                         }
                         else

--- a/src/core/Akka.Remote.TestKit/RemoteConnection.cs
+++ b/src/core/Akka.Remote.TestKit/RemoteConnection.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Remote.TestKit.Proto;
 using Akka.Remote.Transport.DotNetty;
@@ -126,9 +127,17 @@ namespace Akka.Remote.TestKit
 
         public static async Task ReleaseAll()
         {
-            Task tc = _clientPool?.ShutdownGracefullyAsync() ?? TaskEx.Completed;
-            Task ts = _serverPool?.ShutdownGracefullyAsync() ?? TaskEx.Completed;
-            await Task.WhenAll(tc, ts).ConfigureAwait(false);
+            // Detach the pools before shutting them down. A shut down event loop group cannot
+            // serve another connection, so leaving the fields set hands every later
+            // CreateConnection call a dead pool and the connection never completes.
+            var clientPool = Interlocked.Exchange(ref _clientPool, null);
+            var serverPool = Interlocked.Exchange(ref _serverPool, null);
+            var serverWorkerPool = Interlocked.Exchange(ref _serverWorkerPool, null);
+
+            Task tc = clientPool?.ShutdownGracefullyAsync() ?? TaskEx.Completed;
+            Task ts = serverPool?.ShutdownGracefullyAsync() ?? TaskEx.Completed;
+            Task tsw = serverWorkerPool?.ShutdownGracefullyAsync() ?? TaskEx.Completed;
+            await Task.WhenAll(tc, ts, tsw).ConfigureAwait(false);
         }
 
         #endregion


### PR DESCRIPTION
Backports the multi-node conductor reliability line from dev, so v1.5's own MNTR gate (which every backport PR runs through) reports failures honestly and survives node restarts. Two commits.

**Barrier honesty (#8431).** Three sites in Player.cs constructed a bare `new Failure(...)`, which inside an FSM subclass binds to FSMBase.Failure rather than Status.Failure - so the barrier ask completed successfully and the failure was silently swallowed. The asking node walked on unsynchronized, and the eventual breakage surfaced on some other node, at some other barrier, as an unrelated-looking flake. All three now reply Status.Failure, plus the discarded-ask cleanup, plus a one-line runner fix where a failed node's output was labeled "passed." The binding bug was demonstrated end-to-end against v1.5's own binaries during validation: the unqualified reply is FSMBase.Failure, the ask completes successfully with it, and the same reply as Status.Failure faults the ask with the real barrier error.

Deliberately not taken from the dev squash: the runner's node-hang kill backstop (dev's implementation needs Process.Kill(entireProcessTree:), which netstandard2.0 - v1.5's TestAdapter target - does not have; a parameterless Kill would orphan child node processes, which is worse than no backstop; needs a netstandard-safe follow-up), and dev-specific spec content.

**Conductor fixes (#8485).** When a node restarts its ActorSystem mid-spec, the old connection's ServerFSM death fired ClientDisconnected, which the controller matched by role name - evicting the freshly re-registered node - and the barrier coordinator then dropped the evicted node's arrivals with no reply at all, hanging it for its full ask timeout while the other nodes' barrier expired. Disconnects are now matched against the registered FSM identity, unregistered arrivals get an explicit BarrierResult(false), and ReleaseAll detaches the shared event-loop groups so a second conductor in one process gets a live pool. Cherry-picked clean, zero conflicts - v1.5's conductor had not drifted at any touched site.

**Validation on v1.5:** Akka.Remote.TestKit and the TestAdapter build at 0 warnings; Akka.Remote.TestKit.Tests all green including both ported tests; revert-proofs performed (reverting the identity check fails the re-registration test; reverting the coordinator reply hangs the arrival test on exactly the old symptom); ReDeployment MNTR specs 6/6, three consecutive runs.

**Expectation for this branch's MNTR lane:** with barrier failures now honest, latent spec failures the old code silently swallowed may start surfacing - attributed to the node that actually broke instead of the nodes downstream of it. That is the intended effect, and the same effect on dev is what made the rest of the de-flake campaign possible.