### PR TITLE
Fix Cluster Sharding DData replicator recovery

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingReplicatorResiliencySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingReplicatorResiliencySpec.cs
@@ -1,0 +1,172 @@
+// -----------------------------------------------------------------------
+//  <copyright file="ClusterShardingReplicatorResiliencySpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.TestKit;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+
+namespace Akka.Cluster.Sharding.Tests;
+
+public class ClusterShardingReplicatorResiliencySpec : AkkaSpec
+{
+    private sealed record ShardEnvelope(string EntityId, string Message);
+
+    private sealed class EntityActor : ReceiveActor
+    {
+        public EntityActor()
+        {
+            Receive<string>(message => Sender.Tell(message));
+        }
+    }
+
+    private static readonly HashCodeMessageExtractor MessageExtractor = HashCodeMessageExtractor.Create(
+        10,
+        message => message is ShardEnvelope envelope ? envelope.EntityId : null,
+        message => message is ShardEnvelope envelope ? envelope.Message : message);
+
+    private static Config SpecConfig =>
+        ConfigurationFactory.ParseString(@"
+            akka.loglevel = DEBUG
+            akka.actor.provider = cluster
+            akka.remote.dot-netty.tcp.port = 0
+
+            akka.cluster.sharding.state-store-mode = ddata
+            akka.cluster.sharding.remember-entities = on
+            akka.cluster.sharding.remember-entities-store = ddata
+            akka.cluster.sharding.distributed-data.majority-min-cap = 1
+            akka.cluster.sharding.distributed-data.durable.keys = []")
+            .WithFallback(ClusterSharding.DefaultConfig());
+
+    public ClusterShardingReplicatorResiliencySpec(ITestOutputHelper helper)
+        : base(SpecConfig, output: helper)
+    {
+    }
+
+    protected override void AtStartup()
+    {
+        var cluster = Cluster.Get(Sys);
+        cluster.Join(cluster.SelfAddress);
+        AwaitAssert(() =>
+            cluster.ReadView.Members.Count(member => member.Status == MemberStatus.Up).Should().Be(1));
+    }
+
+    [Fact]
+    public async Task Private_replicator_should_recover_behind_its_stable_path_without_restarting_consumers()
+    {
+        const string typeName = "replicator-resiliency";
+        const string replicatorPath = "/system/sharding/replicator";
+        const string replicatorChildPath = replicatorPath + "/replicator";
+        const string firstEntityId = "entity-1";
+        var firstShardId = MessageExtractor.ShardId(firstEntityId);
+        var existingShardEntityId = Enumerable.Range(2, 100)
+            .Select(i => $"entity-{i}")
+            .First(id => MessageExtractor.ShardId(id) == firstShardId);
+        var newShardEntityId = Enumerable.Range(2, 100)
+            .Select(i => $"entity-{i}")
+            .First(id => MessageExtractor.ShardId(id) != firstShardId);
+        var region = ClusterSharding.Get(Sys).Start(
+            typeName,
+            Props.Create<EntityActor>(),
+            ClusterShardingSettings.Create(Sys),
+            MessageExtractor);
+
+        region.Tell(new ShardEnvelope(firstEntityId, "before"));
+        await ExpectMsgAsync("before");
+        var shard = LastSender.Path.Parent;
+
+        var coordinator = await Sys.ActorSelection(
+                $"/system/sharding/{typeName}Coordinator/singleton/coordinator")
+            .ResolveOne(3.Seconds());
+        var coordinatorWatcher = CreateTestProbe();
+        await coordinatorWatcher.WatchAsync(coordinator);
+        var shardWatcher = CreateTestProbe();
+        await shardWatcher.WatchAsync(await Sys.ActorSelection(shard).ResolveOne(3.Seconds()));
+
+        var supervisor = await Sys.ActorSelection(replicatorPath).ResolveOne(3.Seconds());
+        var firstReplicator = await Sys.ActorSelection(replicatorChildPath).ResolveOne(3.Seconds());
+        await WatchAsync(firstReplicator);
+        Sys.Stop(firstReplicator);
+        await ExpectTerminatedAsync(firstReplicator);
+
+        // Exercise an operation issued during the backoff window. The replacement's local
+        // availability signal must cause the coordinator to replay its interrupted write.
+        region.Tell(new ShardEnvelope(newShardEntityId, "after-new"));
+
+        IActorRef replacement = null;
+        await AwaitAssertAsync(async () =>
+        {
+            var currentSupervisor = await Sys.ActorSelection(replicatorPath).ResolveOne(1.Seconds());
+            currentSupervisor.Should().Be(supervisor);
+
+            replacement = await Sys.ActorSelection(replicatorChildPath).ResolveOne(1.Seconds());
+            replacement.Should().NotBe(firstReplicator);
+            replacement.Path.ToStringWithoutAddress().Should().Be(replicatorChildPath);
+        }, 10.Seconds());
+
+        (await ExpectMsgAsync<string>(15.Seconds())).Should().Be("after-new");
+
+        // Exercise the existing shard and its existing DData remember-entities store.
+        region.Tell(new ShardEnvelope(existingShardEntityId, "after-existing"));
+        await ExpectMsgAsync("after-existing");
+
+        await coordinatorWatcher.ExpectNoMsgAsync(500.Milliseconds());
+        await shardWatcher.ExpectNoMsgAsync(500.Milliseconds());
+    }
+}
+
+public class PersistentShardingReplicatorCompatibilitySpec : AkkaSpec
+{
+    private sealed class NoOpMessageExtractor : IMessageExtractor
+    {
+        public string EntityId(object message) => null;
+        public object EntityMessage(object message) => message;
+        public string ShardId(object message) => null;
+        public string ShardId(string entityId, object messageHint = null) => "1";
+    }
+
+    private static Config SpecConfig =>
+        ConfigurationFactory.ParseString(@"
+            akka.actor.provider = cluster
+            akka.remote.dot-netty.tcp.port = 0
+
+            akka.cluster.sharding.state-store-mode = persistence
+            akka.cluster.sharding.remember-entities = on
+            akka.cluster.sharding.remember-entities-store = ddata")
+            .WithFallback(ClusterSharding.DefaultConfig());
+
+    public PersistentShardingReplicatorCompatibilitySpec(ITestOutputHelper helper)
+        : base(SpecConfig, output: helper)
+    {
+    }
+
+    protected override void AtStartup()
+    {
+        var cluster = Cluster.Get(Sys);
+        cluster.Join(cluster.SelfAddress);
+        AwaitAssert(() =>
+            cluster.ReadView.Members.Count(member => member.Status == MemberStatus.Up).Should().Be(1));
+    }
+
+    [Fact]
+    public async Task Persistence_with_DData_remember_entities_setting_should_not_create_a_replicator()
+    {
+        ClusterSharding.Get(Sys).Start(
+            "persistent-compatibility",
+            Props.Empty,
+            ClusterShardingSettings.Create(Sys),
+            new NoOpMessageExtractor());
+
+        await Assert.ThrowsAsync<ActorNotFoundException>(() =>
+            Sys.ActorSelection("/system/sharding/replicator").ResolveOne(500.Milliseconds()));
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
@@ -314,15 +314,19 @@ namespace Akka.Cluster.Sharding
             {
                 // one replicator per role
                 var role = settings.Role ?? string.Empty;
-                if (_replicatorsByRole.TryGetValue(role, out var aref)) return aref;
-                else
-                {
-                    var name = string.IsNullOrEmpty(settings.Role) ? "replicator" : Uri.EscapeDataString(settings.Role) + "Replicator";
-                    var replicatorRef = Context.ActorOf(DistributedData.Replicator.Props(GetReplicatorSettings(settings)), name);
+                if (_replicatorsByRole.TryGetValue(role, out var replicator))
+                    return replicator;
 
-                    _replicatorsByRole = _replicatorsByRole.SetItem(role, replicatorRef);
-                    return replicatorRef;
-                }
+                var name = string.IsNullOrEmpty(settings.Role) ? "replicator" : Uri.EscapeDataString(settings.Role) + "Replicator";
+                var replicatorRef = Context.ActorOf(
+                    Akka.DistributedData.DistributedData.SupervisedReplicatorProps(
+                        GetReplicatorSettings(settings),
+                        childName: "replicator",
+                        useParentAsReplicaPath: true),
+                    name);
+
+                _replicatorsByRole = _replicatorsByRole.SetItem(role, replicatorRef);
+                return replicatorRef;
             }
             else
                 return Context.System.DeadLetters;

--- a/src/contrib/cluster/Akka.Cluster.Sharding/DDataShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/DDataShardCoordinator.cs
@@ -15,6 +15,7 @@ using Akka.Cluster.Sharding.Internal;
 using Akka.DistributedData;
 using Akka.Event;
 using Akka.Pattern;
+using ReplicatorStarted = Akka.DistributedData.Internal.ReplicatorStarted;
 
 namespace Akka.Cluster.Sharding
 {
@@ -169,6 +170,10 @@ namespace Akka.Cluster.Sharding
             {
                 switch (message)
                 {
+                    case ReplicatorStarted started when IsReplicator(started):
+                        GetCoordinatorState();
+                        return true;
+
                     case GetSuccess g when g.Key.Equals(_coordinatorStateKey):
                         var existingState = g.Get(_coordinatorStateKey).Value.WithRememberEntities(Settings.RememberEntities);
                         if (VerboseDebug)
@@ -269,6 +274,9 @@ namespace Akka.Cluster.Sharding
         {
             switch (message)
             {
+                case ReplicatorStarted started when IsReplicator(started):
+                    return true;
+
                 case StateInitialized _:
                     UnstashOneGetShardHomeRequest();
                     Stash.UnstashAll();
@@ -334,6 +342,11 @@ namespace Akka.Cluster.Sharding
             {
                 switch (message)
                 {
+                    case ReplicatorStarted started when IsReplicator(started):
+                        if (waitingForStateWrite)
+                            SendCoordinatorStateUpdate(evt);
+                        return true;
+
                     case UpdateSuccess m when m.Key.Equals(_coordinatorStateKey) && m.Request.Equals(evt):
                         if (!waitingForRememberShard)
                         {
@@ -519,7 +532,7 @@ namespace Akka.Cluster.Sharding
 
         private void Activate()
         {
-            Context.Become(msg => _baseImpl.Active(msg) || ReceiveLateRememberedEntities(msg));
+            Context.Become(msg => IsReplicatorStarted(msg) || _baseImpl.Active(msg) || ReceiveLateRememberedEntities(msg));
             Log.Info("{0}: ShardCoordinator was moved to the active state with [{1}] shards", TypeName, State.Shards.Count);
             if (VerboseDebug)
                 Log.Debug("{0}: Full ShardCoordinator initial state {1}", TypeName, State);
@@ -609,6 +622,12 @@ namespace Akka.Cluster.Sharding
                 reg => reg.WithValue(_selfUniqueAddress, s)));
         }
 
+        private bool IsReplicatorStarted(object message) =>
+            message is ReplicatorStarted started && IsReplicator(started);
+
+        private bool IsReplicator(ReplicatorStarted started) =>
+            _replicator.Equals(started.Replicator);
+
         private void RememberShardAllocated(string newShard)
         {
             Log.Debug("{0}: Remembering shard allocation [{1}]", TypeName, newShard);
@@ -658,11 +677,13 @@ namespace Akka.Cluster.Sharding
 
         protected override void PreStart()
         {
+            Context.System.EventStream.Subscribe(Self, typeof(ReplicatorStarted));
             _baseImpl.PreStart();
         }
 
         protected override void PostStop()
         {
+            Context.System.EventStream.Unsubscribe(Self, typeof(ReplicatorStarted));
             base.PostStop();
             _baseImpl.PostStop();
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Internal/DDataRememberEntitiesCoordinatorStore.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Internal/DDataRememberEntitiesCoordinatorStore.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Immutable;
 using Akka.Actor;
 using Akka.DistributedData;
+using Akka.DistributedData.Internal;
 using Akka.Event;
 
 namespace Akka.Cluster.Sharding.Internal
@@ -71,6 +72,11 @@ namespace Akka.Cluster.Sharding.Internal
         {
             switch (message)
             {
+                case ReplicatorStarted started when _replicator.Equals(started.Replicator):
+                    if (_allShards is null)
+                        GetAllShards();
+                    return true;
+
                 case RememberEntitiesCoordinatorStore.GetShards _:
                     if (_allShards != null)
                     {
@@ -128,6 +134,19 @@ namespace Akka.Cluster.Sharding.Internal
             }
             return false;
         }
+
+        protected override void PreStart()
+        {
+            Context.System.EventStream.Subscribe(Self, typeof(ReplicatorStarted));
+            base.PreStart();
+        }
+
+        protected override void PostStop()
+        {
+            Context.System.EventStream.Unsubscribe(Self, typeof(ReplicatorStarted));
+            base.PostStop();
+        }
+
         private void OnGotAllShards(IImmutableSet<ShardId> shardIds)
         {
             if (_coordinatorWaitingForShards != null)

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Internal/DDataRememberEntitiesShardStore.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Internal/DDataRememberEntitiesShardStore.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
 using Akka.DistributedData;
+using Akka.DistributedData.Internal;
 using Akka.Event;
 using Akka.Pattern;
 using Akka.Util;
@@ -186,6 +187,9 @@ namespace Akka.Cluster.Sharding.Internal
         {
             switch (message)
             {
+                case ReplicatorStarted started when _replicator.Equals(started.Replicator):
+                    return true;
+
                 case RememberEntitiesShardStore.GetEntities _:
                     // not supported, but we may get several if the shard timed out and retried
                     _log.Debug("Another get entities request after responding to one, not expected/supported, ignoring");
@@ -229,6 +233,10 @@ namespace Akka.Cluster.Sharding.Internal
             {
                 switch (message)
                 {
+                    case ReplicatorStarted started when _replicator.Equals(started.Replicator):
+                        LoadEntities(Enumerable.Range(0, numberOfKeys).Where(i => !gotKeys.Contains(i)));
+                        return true;
+
                     case GetSuccess g when g.Request is int i:
                         var key = _keys[i];
                         var ids2 = g.Get(key).Elements;
@@ -323,6 +331,11 @@ namespace Akka.Cluster.Sharding.Internal
                 {
                     switch (message)
                     {
+                        case ReplicatorStarted started when _replicator.Equals(started.Replicator):
+                            foreach (var (_, updateForEvents) in updatesLeft)
+                                _replicator.Tell(updateForEvents.Update);
+                            return true;
+
                         case UpdateSuccess m when m.Request is IImmutableSet<IEvt> evts:
                             _log.Debug("The DDataShard state was successfully updated for [{0}]", string.Join(", ", evts));
                             var remainingAfterThis = updatesLeft.Remove(evts);
@@ -384,11 +397,28 @@ namespace Akka.Cluster.Sharding.Internal
 
         private void LoadAllEntities()
         {
-            foreach (var i in Enumerable.Range(0, numberOfKeys))
+            LoadEntities(Enumerable.Range(0, numberOfKeys));
+        }
+
+        private void LoadEntities(IEnumerable<int> keyIndexes)
+        {
+            foreach (var i in keyIndexes)
             {
                 var key = _keys[i];
                 _replicator.Tell(Dsl.Get(key, _readMajority, i));
             }
+        }
+
+        protected override void PreStart()
+        {
+            Context.System.EventStream.Subscribe(Self, typeof(ReplicatorStarted));
+            base.PreStart();
+        }
+
+        protected override void PostStop()
+        {
+            Context.System.EventStream.Unsubscribe(Self, typeof(ReplicatorStarted));
+            base.PostStop();
         }
     }
 }

--- a/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorResiliencySpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorResiliencySpec.cs
@@ -115,6 +115,48 @@ namespace Akka.DistributedData.Tests
             await DurableStoreActorCrash();
         }
 
+        [Fact]
+        public async Task Parent_path_supervisor_should_interoperate_with_a_direct_replicator()
+        {
+            var settings = ReplicatorSettings.Create(Sys)
+                .WithGossipInterval(TimeSpan.FromSeconds(1))
+                .WithMaxDeltaElements(10);
+            var directReplicator = _sys1.ActorOf(Replicator.Props(settings), "mixedReplicator");
+            var supervisedReplicator = _sys2.ActorOf(
+                DistributedData.SupervisedReplicatorProps(
+                    settings,
+                    childName: "replicator",
+                    useParentAsReplicaPath: true),
+                "mixedReplicator");
+
+            await InitCluster();
+
+            var timeout = Dilated(5.Seconds());
+            var writeTwo = new WriteTo(2, timeout);
+            var sys1Probe = CreateTestProbe(_sys1);
+            var sys2Probe = CreateTestProbe(_sys2);
+
+            var directToSupervisedKey = new GSetKey<string>("direct-to-supervised");
+            directReplicator.Tell(
+                Dsl.Update(directToSupervisedKey, GSet<string>.Empty, writeTwo, set => set.Add("direct")),
+                sys1Probe.Ref);
+            await sys1Probe.ExpectMsgAsync<UpdateSuccess>(timeout);
+
+            supervisedReplicator.Tell(Dsl.Get(directToSupervisedKey, ReadLocal.Instance), sys2Probe.Ref);
+            var directToSupervised = await sys2Probe.ExpectMsgAsync<GetSuccess>(timeout);
+            directToSupervised.Get(directToSupervisedKey).Elements.Should().Contain("direct");
+
+            var supervisedToDirectKey = new GSetKey<string>("supervised-to-direct");
+            supervisedReplicator.Tell(
+                Dsl.Update(supervisedToDirectKey, GSet<string>.Empty, writeTwo, set => set.Add("supervised")),
+                sys2Probe.Ref);
+            await sys2Probe.ExpectMsgAsync<UpdateSuccess>(timeout);
+
+            directReplicator.Tell(Dsl.Get(supervisedToDirectKey, ReadLocal.Instance), sys1Probe.Ref);
+            var supervisedToDirect = await sys1Probe.ExpectMsgAsync<GetSuccess>(timeout);
+            supervisedToDirect.Get(supervisedToDirectKey).Elements.Should().Contain("supervised");
+        }
+
         public async Task DurableStoreActorCrash()
         {
             const string replicatorActorPath = "/user/replicatorSuper/replicator";

--- a/src/contrib/cluster/Akka.DistributedData/DistributedData.cs
+++ b/src/contrib/cluster/Akka.DistributedData/DistributedData.cs
@@ -86,15 +86,20 @@ namespace Akka.DistributedData
             {
                 var name = config.GetString("name", null);
                 Replicator = _settings.RestartReplicatorOnFailure 
-                    ? system.ActorOf(GetSupervisedReplicator(_settings, name), name+"Supervisor")
+                    ? system.ActorOf(SupervisedReplicatorProps(_settings, name), name+"Supervisor")
                     : system.ActorOf(Akka.DistributedData.Replicator.Props(_settings), name);
             }
         }
 
-        private static Props GetSupervisedReplicator(ReplicatorSettings settings, string name) => BackoffSupervisor.Props(
+        internal static Props SupervisedReplicatorProps(
+            ReplicatorSettings settings,
+            string childName,
+            bool useParentAsReplicaPath = false) => BackoffSupervisor.Props(
                         Backoff.OnStop(
-                                childProps: Akka.DistributedData.Replicator.Props(settings),
-                                childName: name,
+                                childProps: useParentAsReplicaPath
+                                    ? Akka.DistributedData.Replicator.PropsWithParentReplicaPath(settings)
+                                    : Akka.DistributedData.Replicator.Props(settings),
+                                childName: childName,
                                 minBackoff: TimeSpan.FromSeconds(3),
                                 maxBackoff: TimeSpan.FromSeconds(300),
                                 randomFactor: 0.2,

--- a/src/contrib/cluster/Akka.DistributedData/Internal/ReplicatorStarted.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Internal/ReplicatorStarted.cs
@@ -1,0 +1,14 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ReplicatorStarted.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+
+namespace Akka.DistributedData.Internal
+{
+    internal sealed record ReplicatorStarted(IActorRef Replicator)
+        : INoSerializationVerificationNeeded;
+}

--- a/src/contrib/cluster/Akka.DistributedData/ReadAggregator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/ReadAggregator.cs
@@ -15,8 +15,8 @@ namespace Akka.DistributedData
 {
     internal class ReadAggregator : ReadWriteAggregator
     {
-        internal static Props Props(IKey key, IReadConsistency consistency, object req, IImmutableList<Address> nodes, IImmutableSet<Address> unreachable, bool shuffle, DataEnvelope localValue, IActorRef replyTo) =>
-            Actor.Props.Create(() => new ReadAggregator(key, consistency, req, nodes, unreachable, shuffle, localValue, replyTo)).WithDeploy(Deploy.Local);
+        internal static Props Props(IKey key, IReadConsistency consistency, object req, IImmutableList<Address> nodes, IImmutableSet<Address> unreachable, bool shuffle, DataEnvelope localValue, IActorRef replyTo, ActorPath replicaPath) =>
+            Actor.Props.Create(() => new ReadAggregator(key, consistency, req, nodes, unreachable, shuffle, localValue, replyTo, replicaPath)).WithDeploy(Deploy.Local);
 
         private readonly IKey _key;
         private readonly IReadConsistency _consistency;
@@ -26,8 +26,8 @@ namespace Akka.DistributedData
 
         private DataEnvelope _result;
 
-        public ReadAggregator(IKey key, IReadConsistency consistency, object req, IImmutableList<Address> nodes, IImmutableSet<Address> unreachable, bool shuffle, DataEnvelope localValue, IActorRef replyTo)
-            : base(nodes, unreachable, consistency.Timeout, shuffle)
+        public ReadAggregator(IKey key, IReadConsistency consistency, object req, IImmutableList<Address> nodes, IImmutableSet<Address> unreachable, bool shuffle, DataEnvelope localValue, IActorRef replyTo, ActorPath replicaPath = null)
+            : base(nodes, unreachable, consistency.Timeout, shuffle, replicaPath)
         {
             _key = key;
             _consistency = consistency;

--- a/src/contrib/cluster/Akka.DistributedData/ReadWriteAggregator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/ReadWriteAggregator.cs
@@ -33,6 +33,7 @@ namespace Akka.DistributedData
 
         private readonly ICancelable _sendToSecondarySchedule;
         private readonly ICancelable _timeoutSchedule;
+        private readonly ActorPath _replicaPath;
 
         private ILoggingAdapter _log;
 
@@ -47,12 +48,18 @@ namespace Akka.DistributedData
 
         protected IImmutableSet<Address> Remaining;
 
-        protected ReadWriteAggregator(IImmutableList<Address> nodes, IImmutableSet<Address> unreachable, TimeSpan timeout, bool shuffle)
+        protected ReadWriteAggregator(
+            IImmutableList<Address> nodes,
+            IImmutableSet<Address> unreachable,
+            TimeSpan timeout,
+            bool shuffle,
+            ActorPath replicaPath)
         {
             Timeout = timeout;
             Nodes = nodes;
             Unreachable = unreachable;
             Shuffle = shuffle;
+            _replicaPath = replicaPath ?? Context.Parent.Path;
             Reachable = nodes.Except(unreachable).ToImmutableList();
             Remaining = Nodes.ToImmutableHashSet();
             _sendToSecondarySchedule = Context.System.Scheduler.ScheduleTellOnceCancelable((int)Timeout.TotalMilliseconds / 5, Self, SendToSecondary.Instance, Self);
@@ -95,7 +102,7 @@ namespace Akka.DistributedData
 
         protected virtual ActorSelection Replica(Address address)
         {
-            return Context.ActorSelection(Context.Parent.Path.ToStringWithAddress(address));
+            return Context.ActorSelection(_replicaPath.ToStringWithAddress(address));
         }
     }
 }

--- a/src/contrib/cluster/Akka.DistributedData/Replicator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Replicator.cs
@@ -262,8 +262,24 @@ namespace Akka.DistributedData
     /// </summary>
     internal sealed class Replicator : UntypedActor, IWithUnboundedStash
     {
+        private sealed class PublishReplicatorStarted : INoSerializationVerificationNeeded
+        {
+            public static readonly PublishReplicatorStarted Instance = new();
+
+            private PublishReplicatorStarted()
+            {
+            }
+        }
+
         public static Props Props(ReplicatorSettings settings) =>
-            Actor.Props.Create(() => new Replicator(settings)).WithDeploy(Deploy.Local).WithDispatcher(settings.Dispatcher);
+            Actor.Props.Create(() => new Replicator(settings, false))
+                .WithDeploy(Deploy.Local)
+                .WithDispatcher(settings.Dispatcher);
+
+        internal static Props PropsWithParentReplicaPath(ReplicatorSettings settings) =>
+            Actor.Props.Create(() => new Replicator(settings, true))
+                .WithDeploy(Deploy.Local)
+                .WithDispatcher(settings.Dispatcher);
 
         private static readonly Digest DeletedDigest = ByteString.Empty;
         private static readonly Digest LazyDigest = ByteString.CopyFrom(new byte[] { 0 });
@@ -272,6 +288,8 @@ namespace Akka.DistributedData
         private static readonly DataEnvelope DeletedEnvelope = new(DeletedData.Instance);
 
         private readonly ReplicatorSettings _settings;
+        private readonly ActorPath _replicaPath;
+        private readonly bool _publishReplicatorStarted;
 
         private readonly Cluster.Cluster _cluster;
         private readonly Address _selfAddress;
@@ -363,9 +381,11 @@ namespace Akka.DistributedData
         private int _count;
         private DateTime _startTime;
 
-        public Replicator(ReplicatorSettings settings)
+        public Replicator(ReplicatorSettings settings, bool useParentAsReplicaPath = false)
         {
             _settings = settings;
+            _replicaPath = useParentAsReplicaPath ? Context.Parent.Path : Self.Path;
+            _publishReplicatorStarted = useParentAsReplicaPath;
             _cluster = Cluster.Cluster.Get(Context.System);
             _selfAddress = _cluster.SelfAddress;
             _selfUniqueAddress = _cluster.SelfUniqueAddress;
@@ -447,6 +467,9 @@ namespace Akka.DistributedData
         {
             if (_hasDurableKeys) _durableStore.Tell(LoadAll.Instance);
 
+            if (_publishReplicatorStarted)
+                Self.Tell(PublishReplicatorStarted.Instance);
+
             // not using LeaderChanged/RoleLeaderChanged because here we need one node independent of data center
             _cluster.Subscribe(Self, ClusterEvent.SubscriptionInitialStateMode.InitialStateAsEvents,
                 typeof(ClusterEvent.IMemberEvent), typeof(ClusterEvent.IReachabilityEvent));
@@ -480,6 +503,10 @@ namespace Akka.DistributedData
         {
             switch (message)
             {
+                case PublishReplicatorStarted _:
+                    Context.System.EventStream.Publish(new ReplicatorStarted(Context.Parent));
+                    return true;
+
                 case LoadData load:
                     _count += load.Data.Count;
                     foreach (var entry in load.Data)
@@ -539,6 +566,10 @@ namespace Akka.DistributedData
         {
             switch (message)
             {
+                case PublishReplicatorStarted _:
+                    Context.System.EventStream.Publish(new ReplicatorStarted(Context.Parent));
+                    return true;
+
                 case IDestinationSystemUid msg:
                     if (msg.ToSystemUid.HasValue && msg.ToSystemUid != _selfUniqueAddress.Uid)
                     {
@@ -629,7 +660,7 @@ namespace Akka.DistributedData
             {
                 var excludeExiting = consistency is ReadMajorityPlus or ReadAll;
 
-                Context.ActorOf(ReadAggregator.Props(key, consistency, req, NodesForReadWrite(excludeExiting), _unreachable, !_settings.PreferOldest, localValue, Sender)
+                Context.ActorOf(ReadAggregator.Props(key, consistency, req, NodesForReadWrite(excludeExiting), _unreachable, !_settings.PreferOldest, localValue, Sender, _replicaPath)
                     .WithDispatcher(Context.Props.Dispatcher));
             }
         }
@@ -747,7 +778,7 @@ namespace Akka.DistributedData
                     var excludeExiting = consistency is WriteMajorityPlus or WriteAll;
 
                     var writeAggregator = Context.ActorOf(WriteAggregator
-                        .Props(key, writeEnvelope, writeDelta, consistency, request, NodesForReadWrite(excludeExiting), _unreachable, shuffle, Sender, durable)
+                        .Props(key, writeEnvelope, writeDelta, consistency, request, NodesForReadWrite(excludeExiting), _unreachable, shuffle, Sender, durable, _replicaPath)
                         .WithDispatcher(Context.Props.Dispatcher));
 
                     if (durable)
@@ -873,7 +904,7 @@ namespace Akka.DistributedData
                     var excludeExiting = consistency is WriteMajorityPlus or WriteAll;
 
                     var writeAggregator = Context.ActorOf(WriteAggregator
-                        .Props(key, DeletedEnvelope, null, consistency, request, NodesForReadWrite(excludeExiting), _unreachable, !_settings.PreferOldest, Sender, durable)
+                        .Props(key, DeletedEnvelope, null, consistency, request, NodesForReadWrite(excludeExiting), _unreachable, !_settings.PreferOldest, Sender, durable, _replicaPath)
                         .WithDispatcher(Context.Props.Dispatcher));
 
                     if (durable)
@@ -1137,7 +1168,7 @@ namespace Akka.DistributedData
             return null;
         }
 
-        private ActorSelection Replica(Address address) => Context.ActorSelection(Self.Path.ToStringWithAddress(address));
+        private ActorSelection Replica(Address address) => Context.ActorSelection(_replicaPath.ToStringWithAddress(address));
 
         private bool IsOtherDifferent(string key, Digest otherDigest)
         {

--- a/src/contrib/cluster/Akka.DistributedData/WriteAggregator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/WriteAggregator.cs
@@ -16,8 +16,8 @@ namespace Akka.DistributedData
 {
     internal class WriteAggregator : ReadWriteAggregator
     {
-        public static Props Props(IKey key, DataEnvelope envelope, Delta delta, IWriteConsistency consistency, object req, IImmutableList<Address> nodes, IImmutableSet<Address> unreachable, bool shuffle, IActorRef replyTo, bool durable) =>
-            Actor.Props.Create(() => new WriteAggregator(key, envelope, delta, consistency, req, nodes, unreachable, shuffle, replyTo, durable)).WithDeploy(Deploy.Local);
+        public static Props Props(IKey key, DataEnvelope envelope, Delta delta, IWriteConsistency consistency, object req, IImmutableList<Address> nodes, IImmutableSet<Address> unreachable, bool shuffle, IActorRef replyTo, bool durable, ActorPath replicaPath) =>
+            Actor.Props.Create(() => new WriteAggregator(key, envelope, delta, consistency, req, nodes, unreachable, shuffle, replyTo, durable, replicaPath)).WithDeploy(Deploy.Local);
 
         private readonly IKey _key;
         private readonly DataEnvelope _envelope;
@@ -33,8 +33,8 @@ namespace Akka.DistributedData
         private ImmutableHashSet<Address> _gotNackFrom;
 
         public WriteAggregator(IKey key, DataEnvelope envelope, Delta delta, IWriteConsistency consistency, object req, IImmutableList<Address> nodes,
-            IImmutableSet<Address> unreachable, bool shuffle, IActorRef replyTo, bool durable)
-            : base(nodes, unreachable, consistency.Timeout, shuffle)
+            IImmutableSet<Address> unreachable, bool shuffle, IActorRef replyTo, bool durable, ActorPath replicaPath = null)
+            : base(nodes, unreachable, consistency.Timeout, shuffle, replicaPath)
         {
             _selfUniqueAddress = Cluster.Cluster.Get(Context.System).SelfUniqueAddress;
             _key = key;


### PR DESCRIPTION
## Summary

- supervise Cluster Sharding's private role-scoped DData replicators with `BackoffSupervisor`
- keep `/system/sharding/<role>Replicator` as the stable client and peer endpoint
- make supervised replicator children and read/write aggregators target the supervisor's parent path for mixed-version compatibility
- replay operations interrupted during the backoff window without replacing consumer actor refs or tracking remember-entities providers

## Compatibility

The supervisor occupies the historical replicator path and forwards ordinary messages to its current child. During a rolling upgrade:

- older nodes send to the historical path and reach the new supervisor
- newer nodes target that same path and reach either an older direct replicator or a newer supervisor

Persistence state-store mode remains unchanged and does not create a private DData replicator, including when `remember-entities-store = ddata` is also configured.

## Validation

- `Akka.DistributedData.Tests`: 187 passed, 1 skipped
- focused mixed direct/supervised replication test passed
- focused sharding recovery and persistence compatibility tests passed repeatedly
- `Akka.Cluster.Sharding.Tests`: 193 passed; the unchanged timing-sensitive `RememberEntitiesStarterSpec` constant-strategy test failed
- both affected test projects build with 0 warnings and 0 errors
- Slopwatch and `git diff --check` passed

Fixes #8471

Supersedes #8480.
