### PR TITLE
Release Akka.NET v1.5.71

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -70,7 +70,7 @@
 **Akka.TestKit**
 * [Add AutoDilate metadata to TestKit timeouts](https://github.com/akkadotnet/akka.net/pull/8441): Adds AutoDilate dilation metadata to TestKit timeout expectations so dilated deadlines are correctly tracked and reported.
 * [Fix torn read in `PromiseActorRef.GetPath` that made `Path` return null](https://github.com/akkadotnet/akka.net/pull/8436): Fixes a torn read in `PromiseActorRef.GetPath` that could return `null` under concurrent access.
-* [Fix double-dilated timeout in `ExpectMsgAsync<T>(Func<T, IActorRef, bool>, ...)`](https://github.com/akkadotnet/akka.net/pull/8430): Fixes a bug where the overload of `ExpectMsgAsync` that takes a predicate could apply its timeout dilation twice, causing spurious timeout failures.
+* [Fix double-dilated timeout in `ExpectMsgAsync&lt;T&gt;(Func&lt;T, IActorRef, bool&gt;, ...)`](https://github.com/akkadotnet/akka.net/pull/8430): Fixes a bug where the overload of `ExpectMsgAsync` that takes a predicate could apply its timeout dilation twice, causing spurious timeout failures.
 
 **Akka.Cluster.Tools**
 * [Fix ClusterClientDiscovery: preserve contact-point subscriptions across rediscovery](https://github.com/akkadotnet/akka.net/pull/8426): Ensures `ClusterClientDiscovery` keeps its contact-point subscriptions alive across rediscovery cycles instead of dropping them.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.70</VersionPrefix>
+    <VersionPrefix>1.5.71</VersionPrefix>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>https://getakka.net/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -54,29 +54,37 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Akka.NET v1.5.70 is a maintenance release that adds a new "last-N" query offset to Akka.Persistence.Query, resolves two Akka.Streams reliability issues and improves `BroadcastHub` performance under high consumer counts, and fixes a consistent-hashing router bug that could wedge an entire cluster after a 32-bit hash collision.
+    <PackageReleaseNotes>Akka.NET v1.5.71 is a maintenance release that fixes a Cluster Sharding private-replicator recovery bug, hardens MultiNodeTestRunner conductor reliability, flushes graceful `Disassociate` PDUs before transport force-close on shutdown, and resolves a handful of TestKit, ClusterClientDiscovery, and DotNetty fixes.
 
-**Akka.Persistence.Query**
-* [Add `Offset.FromEnd(int count)` — "last-N events" query offset](https://github.com/akkadotnet/akka.net/pull/8245): Introduces `Offset.FromEnd(int count)`, a new query-input-only offset type that begins a read journal query at the Nth event from the end of history rather than from the beginning. The offset is resolved at stream materialization into a concrete `Sequence` start position; no interface changes or wire-format changes are required. Includes opt-in TCK spec (`FromEndOffsetSpec`) for plugin authors.
+**Akka.Cluster.Sharding**
+* [Fix Cluster Sharding private replicator recovery](https://github.com/akkadotnet/akka.net/pull/8480): Fixes a bug where a Cluster Sharding private replicator could fail to recover its state, leaving shard state inconsistent after a coordinated shutdown / recovery cycle. Adds a `ClusterShardingReplicatorResiliencySpec` covering the recovery path.
 
-**Akka.Streams Bug Fixes**
-* [Fix: async enumerable source disposal ordering](https://github.com/akkadotnet/akka.net/pull/8265): Fixes a race in `Source.From(IAsyncEnumerable&lt;T&gt;)` where the underlying enumerator could be disposed before all elements were delivered to downstream, causing `ObjectDisposedException` on high-throughput pipelines.
-* [Fix: `ChannelSink` drops final element on backpressure](https://github.com/akkadotnet/akka.net/pull/8291) - Fixes [#8285](https://github.com/akkadotnet/akka.net/issues/8285): `ChannelSink` was discarding the last element in a sequence whenever the downstream `Channel&lt;T&gt;` applied backpressure during completion. The sink now correctly delivers all elements before signaling completion.
+**Akka.Remote**
+* [Backport #8421 to v1.5: flush graceful `Disassociate` PDUs before transport force-close on shutdown](https://github.com/akkadotnet/akka.net/pull/8487): Ensures in-flight graceful `Disassociate` control messages are flushed to the wire before the transport force-closes the connection on shutdown, preventing an abrupt teardown from silently dropping them.
+* [Akka.Remote: stop, don't restart, failed throttler children](https://github.com/akkadotnet/akka.net/pull/8437) - Fixes [#8433](https://github.com/akkadotnet/akka.net/issues/8433) and [#8434](https://github.com/akkadotnet/akka.net/issues/8434): A failing outbound-throttler child is now stopped rather than restarted, avoiding an unbounded restart loop that could stall remote message throughput.
+* [Clarify DotNetty hostname validation direction](https://github.com/akkadotnet/akka.net/pull/8464): Clarifies the direction of the DotNetty hostname validation check so it validates the expected peer identity instead of the local endpoint.
 
-**Akka.Streams Performance**
-* [Improve BroadcastHub high-consumer wheel performance](https://github.com/akkadotnet/akka.net/pull/8264): Reduces per-element cost in `BroadcastHub` when many consumers are attached by optimizing the internal consumer-wheel iteration, yielding measurable throughput improvements at high fan-out.
+**Akka.Remote.TestKit (MultiNodeTestRunner)**
+* [Backport MNTR conductor reliability to v1.5](https://github.com/akkadotnet/akka.net/pull/8488) - Backports [#8431](https://github.com/akkadotnet/akka.net/issues/8431) and [#8485](https://github.com/akkadotnet/akka.net/issues/8485): Hardens the MNTR `BarrierCoordinator`, `Conductor`, `Controller`, `Player`, and `RemoteConnection` against conductor-side races and disconnect handling, reducing multi-node spec flakiness.
 
-**Akka.Core Bug Fixes**
-* [Fix: consistent-hashing router could wedge cluster-wide after a 32-bit hash collision](https://github.com/akkadotnet/akka.net/pull/8294) - Fixes [#8031](https://github.com/akkadotnet/akka.net/issues/8031): When two virtual nodes collided in the 32-bit consistent-hash ring (increasingly likely at high routee counts, e.g. when the ring was rebuilt after a node was downed), `ConsistentHash.Create` threw `"An entry with the same key already exists"`. The consistent-hashing router swallowed the exception and returned `NoRoutee` for **every** subsequent message until a manual restart. The ring now linear-probes to the next free slot on a collision instead of throwing. This keeps the hash distribution unchanged and produces a byte-identical ring to prior versions whenever no collision occurs (safe for rolling upgrades), and also protects `Akka.Cluster.Tools`' `ClusterReceptionist`, which builds the same ring.
+**Akka.TestKit**
+* [Add AutoDilate metadata to TestKit timeouts](https://github.com/akkadotnet/akka.net/pull/8441): Adds AutoDilate dilation metadata to TestKit timeout expectations so dilated deadlines are correctly tracked and reported.
+* [Fix torn read in `PromiseActorRef.GetPath` that made `Path` return null](https://github.com/akkadotnet/akka.net/pull/8436): Fixes a torn read in `PromiseActorRef.GetPath` that could return `null` under concurrent access.
+* [Fix double-dilated timeout in `ExpectMsgAsync<T>(Func<T, IActorRef, bool>, ...)`](https://github.com/akkadotnet/akka.net/pull/8430): Fixes a bug where the overload of `ExpectMsgAsync` that takes a predicate could apply its timeout dilation twice, causing spurious timeout failures.
 
-2 contributors since release 1.5.69
+**Akka.Cluster.Tools**
+* [Fix ClusterClientDiscovery: preserve contact-point subscriptions across rediscovery](https://github.com/akkadotnet/akka.net/pull/8426): Ensures `ClusterClientDiscovery` keeps its contact-point subscriptions alive across rediscovery cycles instead of dropping them.
+
+**Tests**
+* [Make `ClusterShardingQueriesSpec` stats/region-state queries converge-then-assert (async)](https://github.com/akkadotnet/akka.net/pull/8311): Hardens `ClusterShardingQueriesSpec` by making its stats and region-state query assertions wait for convergence before asserting, reducing CI flakiness.
+
+1 contributor since release 1.5.70
 
 | COMMITS | LOC+ | LOC- | AUTHOR |
 | --- | --- | --- | --- |
-| 22 | 2274 | 332 | Aaron Stannard |
-| 1 | 97 | 4 | beminee |
+| 11 | 1376 | 468 | Aaron Stannard |
 
-To see the full set of changes in Akka.NET v1.5.70, [click here](https://github.com/akkadotnet/akka.net/milestone/153?closed=1).</PackageReleaseNotes>
+To see the full set of changes in Akka.NET v1.5.71, [click here](https://github.com/akkadotnet/akka.net/milestone/154?closed=1).</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup Label="Analyzers" Condition="'$(MSBuildProjectName)' != 'Akka'">
     <PackageReference Include="Akka.Analyzers" Version="$(AkkaAnalyzerVersion)" PrivateAssets="all" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,37 @@
+#### 1.5.71 August 26th, 2026 ####
+
+Akka.NET v1.5.71 is a maintenance release that fixes a Cluster Sharding private-replicator recovery bug, hardens MultiNodeTestRunner conductor reliability, flushes graceful `Disassociate` PDUs before transport force-close on shutdown, and resolves a handful of TestKit, ClusterClientDiscovery, and DotNetty fixes.
+
+**Akka.Cluster.Sharding**
+* [Fix Cluster Sharding private replicator recovery](https://github.com/akkadotnet/akka.net/pull/8480): Fixes a bug where a Cluster Sharding private replicator could fail to recover its state, leaving shard state inconsistent after a coordinated shutdown / recovery cycle. Adds a `ClusterShardingReplicatorResiliencySpec` covering the recovery path.
+
+**Akka.Remote**
+* [Backport #8421 to v1.5: flush graceful `Disassociate` PDUs before transport force-close on shutdown](https://github.com/akkadotnet/akka.net/pull/8487): Ensures in-flight graceful `Disassociate` control messages are flushed to the wire before the transport force-closes the connection on shutdown, preventing an abrupt teardown from silently dropping them.
+* [Akka.Remote: stop, don't restart, failed throttler children](https://github.com/akkadotnet/akka.net/pull/8437) - Fixes [#8433](https://github.com/akkadotnet/akka.net/issues/8433) and [#8434](https://github.com/akkadotnet/akka.net/issues/8434): A failing outbound-throttler child is now stopped rather than restarted, avoiding an unbounded restart loop that could stall remote message throughput.
+* [Clarify DotNetty hostname validation direction](https://github.com/akkadotnet/akka.net/pull/8464): Clarifies the direction of the DotNetty hostname validation check so it validates the expected peer identity instead of the local endpoint.
+
+**Akka.Remote.TestKit (MultiNodeTestRunner)**
+* [Backport MNTR conductor reliability to v1.5](https://github.com/akkadotnet/akka.net/pull/8488) - Backports [#8431](https://github.com/akkadotnet/akka.net/issues/8431) and [#8485](https://github.com/akkadotnet/akka.net/issues/8485): Hardens the MNTR `BarrierCoordinator`, `Conductor`, `Controller`, `Player`, and `RemoteConnection` against conductor-side races and disconnect handling, reducing multi-node spec flakiness.
+
+**Akka.TestKit**
+* [Add AutoDilate metadata to TestKit timeouts](https://github.com/akkadotnet/akka.net/pull/8441): Adds AutoDilate dilation metadata to TestKit timeout expectations so dilated deadlines are correctly tracked and reported.
+* [Fix torn read in `PromiseActorRef.GetPath` that made `Path` return null](https://github.com/akkadotnet/akka.net/pull/8436): Fixes a torn read in `PromiseActorRef.GetPath` that could return `null` under concurrent access.
+* [Fix double-dilated timeout in `ExpectMsgAsync<T>(Func<T, IActorRef, bool>, ...)`](https://github.com/akkadotnet/akka.net/pull/8430): Fixes a bug where the overload of `ExpectMsgAsync` that takes a predicate could apply its timeout dilation twice, causing spurious timeout failures.
+
+**Akka.Cluster.Tools**
+* [Fix ClusterClientDiscovery: preserve contact-point subscriptions across rediscovery](https://github.com/akkadotnet/akka.net/pull/8426): Ensures `ClusterClientDiscovery` keeps its contact-point subscriptions alive across rediscovery cycles instead of dropping them.
+
+**Tests**
+* [Make `ClusterShardingQueriesSpec` stats/region-state queries converge-then-assert (async)](https://github.com/akkadotnet/akka.net/pull/8311): Hardens `ClusterShardingQueriesSpec` by making its stats and region-state query assertions wait for convergence before asserting, reducing CI flakiness.
+
+1 contributor since release 1.5.70
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 11 | 1376 | 468 | Aaron Stannard |
+
+To see the full set of changes in Akka.NET v1.5.71, [click here](https://github.com/akkadotnet/akka.net/milestone/154?closed=1).
+
 #### 1.5.70 July 2nd, 2026 ####
 
 Akka.NET v1.5.70 is a maintenance release that adds a new "last-N" query offset to Akka.Persistence.Query, resolves two Akka.Streams reliability issues and improves `BroadcastHub` performance under high consumer counts, and fixes a consistent-hashing router bug that could wedge an entire cluster after a 32-bit hash collision.


### PR DESCRIPTION
## Release Akka.NET v1.5.71

Maintenance release sourced from the `v1.5` branch.

### Highlights
- Fix Cluster Sharding private replicator recovery (#8480)
- Backport #8421: flush graceful `Disassociate` PDUs before transport force-close (#8487)
- Backport MNTR conductor reliability to v1.5 (#8488)
- TestKit: AutoDilate metadata, torn-read fix in `PromiseActorRef.GetPath`, double-dilation fix
- ClusterClientDiscovery: preserve contact-point subscriptions across rediscovery
- DotNetty hostname validation direction clarification

Full release notes in `RELEASE_NOTES.md`.