### PR TITLE
De-flake ClusterSingletonProxySpec, ClusterSingletonRestartSpec, and DistributedPubSubRestartSpec

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
@@ -56,8 +56,8 @@ public class DistributedPubSubRestartSpecConfig : MultiNodeConfig
                 akka.remote.transport-failure-detector.heartbeat-interval = 1s
                 akka.remote.transport-failure-detector.acceptable-heartbeat-pause = 5s
 
-                # No connection-timeout / retry-gate overrides - use the defaults, like the JVM spec
-                # and the sibling restart specs (a prior de-flake set connection-timeout = 5s, which
+                # No connection-timeout / retry-gate overrides - use the defaults, like the sibling
+                # restart specs (a prior de-flake set connection-timeout = 5s, which
                 # via the dot-netty handshake-timeout/connection-timeout conflation starved the
                 # re-association handshake; the default gives it the full 15s budget).
 
@@ -139,9 +139,12 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
         await ExpectMsgAsync("msg1", 10.Seconds());
         await EnterBarrierAsync("got-msg1");
 
-        // All nodes capture baseline DeltaCount before node-specific logic
-        Mediator.Tell(DeltaCount.Instance);
-        var oldDeltaCount = await ExpectMsgAsync<long>();
+        // All nodes capture the baseline DeltaCount before node-specific logic. Read it on a
+        // probe with an explicit bound: TestActor is subscribed to topic1, and every later
+        // DeltaCount read already moved off TestActor for that reason.
+        var baselineProbe = CreateTestProbe();
+        Mediator.Tell(DeltaCount.Instance, baselineProbe.Ref);
+        var oldDeltaCount = await baselineProbe.ExpectMsgAsync<long>(5.Seconds());
         await EnterBarrierAsync("old-delta-count");
 
         await RunOnAsync(async () =>
@@ -160,45 +163,52 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
             var thirdAddress = (await NodeAsync(_config.Third)).Address;
             await TestConductor.Shutdown(_config.Third).WaitAsync(30.Seconds());
 
-            // CLOSED-LOOP, self-verifying restart-kill (mirrors PR #8404 for the sibling
-            // RemoteNodeRestartDeathWatchSpec). This replaces a prior OPEN-LOOP resend
-            // (10 blind "shutdown" Tells over ~27s with no per-send verification). After the
-            // same-address restart, first's outbound endpoint to third is gated by the dead old
-            // incarnation's failing cluster heartbeats, so brand-new sends to the new incarnation
-            // collateral-drop to dead-letters for tens of seconds until a fresh association forms.
-            // An open-loop resend over that at-most-once, gated path has NO constant time bound:
-            // all blind shots can land inside the drop window, third never shuts down, and third's
-            // 120s WhenTerminated wait times out -> flake (five prior timeout/window tunings could
-            // not fix this because the drop window is unbounded).
+            // Await the association, then assert on it. After the same-address restart, first's
+            // outbound endpoint to third is still gated by the dead old incarnation, so a blind
+            // "shutdown" Tell drops to dead letters for as long as that gate lasts. Blind resends
+            // over an at-most-once gated path have no time bound.
             //
-            // Instead, retry the WHOLE Identify -> Tell -> observe-ack cycle: every iteration
-            // re-pokes the association, so recovery is no longer hostage to blind send timing.
-            // The exit condition is OBSERVABLE - first only leaves the loop once third's new
-            // /user/shutdown incarnation acks the kill (proof it was received). Generous, dilated
-            // window (45s) so many association cycles fit even on loaded CI agents.
+            // ResolveOne drives an Identify round trip, and that round trip IS the delivery
+            // confirmation: it only completes once traffic flows to the restarted incarnation and
+            // its /user/shutdown exists. Every retry re-pokes the association, and the final
+            // failure raises ActorNotFoundException naming the path that never resolved instead
+            // of a bare "expected ActorIdentity" timeout on a null Subject.
+            //
+            // Resolve and kill must stay in ONE retry. Splitting them - resolve to a ref, then
+            // send the kill outside the loop - fails on artery: the ordinary outbound stream
+            // restarts with backoff and does not resend, so the association can drop in the gap
+            // between a successful resolve and the next Tell. A local artery soak reproduced
+            // exactly that (resolve succeeded, then ~19s of "Still unable to reconnect Artery
+            // Control outbound connection ... Tcp command Connect ... failed" swallowed the kill
+            // and the ack never came). Keeping both inside the retry re-sends the kill against a
+            // freshly resolved ref on the next attempt.
+            //
+            // The 45s budget comes from arithmetic, not taste. Worst case first absorbs:
+            //   third comes back: WhenTerminated + fresh system + join + its 5s ExpectNoMsg  ~15s
+            //   first's endpoint: 15s associate timeout on the dead incarnation + 5s gate      20s
+            //   fresh handshake + Identify round trip + ack                                   ~5s
+            // = ~40s. It nests inside the 120s "end" barrier second is already parked on:
+            // 30s Shutdown cap + 45s here = 75s, leaving 45s of headroom.
+            var shutdownPath = new RootActorPath(thirdAddress) / "user" / "shutdown";
             await AwaitAssertAsync(async () =>
             {
-                // FRESH probe per attempt (JVM parity, DistributedPubSubRestartSpec.scala):
-                // reusing one probe livelocks because association establishment flushes the
-                // Identify messages buffered by the EndpointWriter as one burst of
-                // ActorIdentity(null) replies, and a reused probe then reads one STALE null per
-                // attempt forever - the backlog never drains even after /user/shutdown exists.
-                var probe = CreateTestProbe();
-                Sys.ActorSelection(new RootActorPath(thirdAddress) / "user" / "shutdown").Tell(new Identify(null), probe.Ref);
-                var subject = (await probe.ExpectMsgAsync<ActorIdentity>(2.Seconds())).Subject;
-                subject.Should().NotBeNull("third's restarted /user/shutdown must resolve before it can be killed");
+                // ResolveOne is not a TestKit call, so dilate its per-attempt bound by hand.
+                // Its temp actor is fresh per attempt, so no probe can carry a stale
+                // ActorIdentity(null) from the burst that flushes when the association comes up.
+                var target = await Sys.ActorSelection(shutdownPath).ResolveOne(Dilated(2.Seconds()));
 
-                // Subject resolved -> the association is live this iteration. Tell it "shutdown"
-                // and require the ack as proof of delivery. If the ack does not come back, the
-                // whole attempt fails and retries (fresh Identify + fresh Tell), re-poking the path.
-                subject.Tell("shutdown", probe.Ref);
-                await probe.ExpectMsgAsync<string>(msg => msg == "shutdown-ack", 3.Seconds());
+                // The resolve proved the association carries traffic. Kill the actor and require
+                // the ack: the Shutdown actor replies before it terminates, so the ack is proof
+                // that THIS incarnation received the message.
+                var killProbe = CreateTestProbe();
+                target.Tell("shutdown", killProbe.Ref);
+                await killProbe.ExpectMsgAsync<string>(msg => msg == "shutdown-ack", 3.Seconds());
             }, 45.Seconds(), 1.Seconds());
 
             await EnterBarrierAsync("end");
 
-            // Use a probe to isolate the DeltaCount query from any stray ActorIdentity replies
-            // still draining into per-attempt probes from the closed-loop retries above.
+            // Read DeltaCount on its own probe so the pub-sub subscription on TestActor cannot
+            // mix into this query.
             var deltaProbe = CreateTestProbe();
             Mediator.Tell(DeltaCount.Instance, deltaProbe.Ref);
             var deltaCount = await deltaProbe.ExpectMsgAsync<long>(5.Seconds());
@@ -208,7 +218,22 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
         await RunOnAsync(async () =>
         {
             var node3Address = Cluster.Get(Sys).SelfAddress;
-            await Sys.WhenTerminated.WaitAsync(30.Seconds());
+
+            // The fresh system below rebinds this exact host:port, so the old system has to
+            // release it first. Name that dependency on failure - a discarded or unexplained
+            // wait resurfaces later as a confusing bind error on the fresh system.
+            var terminationTimeout = 30.Seconds();
+            try
+            {
+                await Sys.WhenTerminated.WaitAsync(terminationTimeout);
+            }
+            catch (TimeoutException e)
+            {
+                throw new TimeoutException(
+                    $"Failed to stop [{Sys.Name}] within [{terminationTimeout}]. The fresh system " +
+                    $"cannot rebind [{node3Address}] until the old one releases it.", e);
+            }
+
             // Pin the fresh system to the SAME wire address for BOTH transports - under
             // AKKA_MNTR_TRANSPORT=artery the classic dot-netty key is inert and the fresh
             // system would bind a random artery canonical.port instead.
@@ -310,13 +335,15 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
 
     private async Task CountAsync(int expected)
     {
-        var probe = CreateTestProbe();
-        // Gossip-propagation check: registrations spread on the 500ms pub-sub gossip tick,
-        // so bound it explicitly instead of relying on the 3s single-expect default.
+        // Gossip-propagation check: registrations spread on the 500ms pub-sub gossip tick, so
+        // retry on that tick for 10s. Fresh probe and an explicit 1s bound per attempt - the
+        // reply is a local round trip, and inheriting the 3s single-expect default would spend
+        // the whole budget on three attempts and let a late reply be read as a stale count.
         await AwaitAssertAsync(async () =>
         {
+            var probe = CreateTestProbe();
             Mediator.Tell(Count.Instance, probe.Ref);
-            (await probe.ExpectMsgAsync<int>()).Should().Be(expected);
+            (await probe.ExpectMsgAsync<int>(1.Seconds())).Should().Be(expected);
         }, 10.Seconds(), 500.Milliseconds());
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonProxySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonProxySpec.cs
@@ -27,26 +27,42 @@ namespace Akka.Cluster.Tools.Tests.Singleton
         }
         
         [Fact]
-        public void ClusterSingletonProxy_must_correctly_identify_the_singleton()
+        public async Task ClusterSingletonProxy_must_correctly_identify_the_singleton()
         {
             var seed = new ActorSys();
             seed.Cluster.Join(seed.Cluster.SelfAddress);
 
-            var testSystems =
-                Enumerable.Range(0, 4).Select(_ => new ActorSys(joinTo: seed.Cluster.SelfAddress))
-                .Concat(new[] {seed})
-                .ToList();
+            var testSystems = new List<ActorSys>();
+            for (var i = 0; i < 4; i++)
+                testSystems.Add(new ActorSys(joinTo: seed.Cluster.SelfAddress));
+            testSystems.Add(seed);
 
             try
             {
-                testSystems.ForEach(s => s.TestProxy("Hello"));
-                testSystems.ForEach(s => s.TestProxy("World"));
+                // Every node has to see the whole cluster Up before the oldest member - and therefore the
+                // singleton's home - is settled. The explicit interval matters: AwaitCondition polls at
+                // max/10, so a 30s bound would otherwise only look every 3s.
+                await AwaitConditionAsync(
+                    () => Task.FromResult(testSystems.All(s =>
+                        s.Cluster.State.Members.Count(m => m.Status == MemberStatus.Up) == testSystems.Count)),
+                    TimeSpan.FromSeconds(30),
+                    TimeSpan.FromMilliseconds(200));
+
+                // Then wait for each proxy to actually resolve it, rather than folding cluster formation,
+                // singleton startup and identification into the 25s message timeout below.
+                foreach (var s in testSystems)
+                    await s.AwaitSingletonIdentifiedAsync(TimeSpan.FromSeconds(30));
+
+                foreach (var s in testSystems)
+                    await s.TestProxyAsync("Hello");
+                foreach (var s in testSystems)
+                    await s.TestProxyAsync("World");
             }
             finally
             {
-                // force everything to cleanup
-                Task.WhenAll(testSystems.Select(s => s.Sys.Terminate()))
-                    .Wait(TimeSpan.FromSeconds(30));
+                // force everything to cleanup - the old Wait(30s) discarded its result, so on a slow
+                // agent five cluster systems could still be shutting down while the next test ran
+                await Task.WhenAll(testSystems.Select(s => s.Sys.Terminate()));
             }
         }
 
@@ -57,20 +73,21 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             seed.Cluster.Join(seed.Cluster.SelfAddress);
 
             var testSystem = new ActorSys(joinTo: seed.Cluster.SelfAddress, bufferSize: 0);
-            
-            // have to wait for cluster singleton to be ready, otherwise message will be rejected
-            await AwaitConditionAsync(
-                () => Task.FromResult(Cluster.Get(testSystem.Sys).State.Members.Count(m => m.Status == MemberStatus.Up) == 2),
-                TimeSpan.FromSeconds(30));
+
+            // Buffering is off here, so a message sent before the proxy has resolved the singleton is
+            // dropped, not queued - and TestProxyAsync sends once and then waits out its full 25s. Wait
+            // on the proxy's own result rather than on membership, which does not imply identification.
+            await testSystem.AwaitSingletonIdentifiedAsync(TimeSpan.FromSeconds(30));
 
             try
             {
-                testSystem.TestProxy("Hello");
+                await testSystem.TestProxyAsync("Hello");
             }
             finally
             {
-                // force everything to cleanup
-                Task.WhenAll(testSystem.Sys.Terminate()).Wait(TimeSpan.FromSeconds(30));
+                // force everything to cleanup - the seed was left running before, and this assembly runs
+                // its tests sequentially in one process, so it kept gossiping through everything after it
+                await Task.WhenAll(testSystem.Sys.Terminate(), seed.Sys.Terminate());
             }
         }
 
@@ -100,8 +117,12 @@ namespace Akka.Cluster.Tools.Tests.Singleton
                 testSystem.Sys.EventStream.Subscribe<ClusterSingletonProxy.IdentifySingletonResult>(testSystem
                     .TestActor);
                 testSystem.Cluster.Join(seed.Cluster.SelfAddress);
-                await AwaitConditionAsync(() =>
-                    Task.FromResult(testSystem.Cluster.State.Members.Count(m => m.Status == MemberStatus.Up) == 2));
+                // explicit bound: with none this inherited akka.test.single-expect-default (3s) and
+                // polled at a third of a second, which is not a lot of room for a two-node join
+                await AwaitConditionAsync(
+                    () => Task.FromResult(testSystem.Cluster.State.Members.Count(m => m.Status == MemberStatus.Up) == 2),
+                    TimeSpan.FromSeconds(30),
+                    TimeSpan.FromMilliseconds(200));
                 testSystem.IgnoreNoMessages();
                 
                 // proxy will emit IdentifySingletonTimedOut event locally if it could not find its associated singleton
@@ -182,13 +203,18 @@ namespace Akka.Cluster.Tools.Tests.Singleton
                 testSystem.Sys.EventStream.Subscribe<ClusterSingletonProxy.IdentifySingletonResult>(testSystem.TestActor);
                 testSystem.Cluster.Join(seed.Cluster.SelfAddress);
 
-                await AwaitAssertAsync(async () =>
-                {
-                    var result = await testSystem.ExpectMsgAsync<ClusterSingletonProxy.IdentifySingletonResult>();
-                    result.Result.Should().Be(ClusterSingletonProxy.IdentifyResult.Success);
-                });
-                
-                testSystem.TestProxy("hello");
+                // Fish rather than read-and-retry. This proxy publishes a Timeout result every 500ms until
+                // it resolves the singleton, so the queue holds Timeouts ahead of the Success; the retry
+                // loop that used to be here consumed one per attempt and got roughly one attempt anyway,
+                // because AwaitAssertAsync with no bound and testSystem.ExpectMsgAsync with no bound each
+                // resolved to the same 3s default and they belong to different TestKit instances, so the
+                // budgets do not nest.
+                await testSystem.FishForMessageAsync<ClusterSingletonProxy.IdentifySingletonResult>(
+                    r => r.Result == ClusterSingletonProxy.IdentifyResult.Success,
+                    TimeSpan.FromSeconds(30),
+                    "waiting for the singleton proxy to identify the singleton");
+
+                await testSystem.TestProxyAsync("hello");
 
                 // timeout event should not fire
                 await testSystem.ExpectNoMsgAsync(1.Seconds());
@@ -207,12 +233,10 @@ namespace Akka.Cluster.Tools.Tests.Singleton
                 // First seed node which homed the singleton left the cluster
                 await seed.Sys.Terminate();
                 
-                await AwaitAssertAsync(async () =>
-                    {
-                        var result = await testSystem.ExpectMsgAsync<ClusterSingletonProxy.IdentifySingletonResult>();
-                        result.Result.Should().Be(ClusterSingletonProxy.IdentifyResult.Timeout);
-                    },
-                    TimeSpan.FromSeconds(30));
+                await testSystem.FishForMessageAsync<ClusterSingletonProxy.IdentifySingletonResult>(
+                    r => r.Result == ClusterSingletonProxy.IdentifyResult.Timeout,
+                    TimeSpan.FromSeconds(30),
+                    "waiting for the singleton proxy to report the lost singleton");
 
                 // Proxy will emit IdentifySingletonTimedOut event locally because it lost the singleton reference
                 // and no nodes are eligible to home the singleton
@@ -236,6 +260,8 @@ namespace Akka.Cluster.Tools.Tests.Singleton
         
         private class ActorSys : TestKit.Xunit.TestKit
         {
+            private readonly TestProbe _identifyProbe;
+
             public Cluster Cluster { get; }
 
             public ActorSys(string name = "ClusterSingletonProxySystem", Address joinTo = null, int bufferSize = 1000, string config = null, bool startSingleton = true, ITestOutputHelper output = null)
@@ -262,23 +288,43 @@ namespace Akka.Cluster.Tools.Tests.Singleton
                     });
                 }
 
+                // Subscribe before the proxy exists so its first result cannot be missed - the proxy
+                // publishes on the event stream from PreStart onwards.
+                _identifyProbe = CreateTestProbe("singleton-identify");
+                Sys.EventStream.Subscribe<ClusterSingletonProxy.IdentifySingletonResult>(_identifyProbe.Ref);
+
                 Proxy =
                     Sys.ActorOf(
                         ClusterSingletonProxy.Props(
                             "user/singletonmanager",
-                            ClusterSingletonProxySettings.Create(Sys).WithBufferSize(bufferSize)), 
+                            ClusterSingletonProxySettings.Create(Sys).WithBufferSize(bufferSize)),
                         $"singletonProxy-{Cluster.SelfAddress.Port ?? 0}");
             }
 
             public IActorRef Proxy { get; private set; }
 
-            public void TestProxy(string msg)
+            /// <summary>
+            /// Waits until this node's proxy has resolved the singleton. Membership alone does not prove
+            /// that: a proxy with no singleton reference buffers what it is sent, and with BufferSize 0
+            /// it drops it outright, so a send before this point can be lost with no trace.
+            /// The proxy also publishes Timeout results on a timer that starts with no initial delay,
+            /// so fish for the Success rather than reading the first result off the queue.
+            /// </summary>
+            public async Task AwaitSingletonIdentifiedAsync(TimeSpan max)
+            {
+                await _identifyProbe.FishForMessageAsync<ClusterSingletonProxy.IdentifySingletonResult>(
+                    r => r.Result == ClusterSingletonProxy.IdentifyResult.Success,
+                    max,
+                    "waiting for the singleton proxy to identify the singleton");
+            }
+
+            public async Task TestProxyAsync(string msg)
             {
                 var probe = CreateTestProbe();
                 probe.Send(Proxy, msg);
 
                 // 25 seconds to make sure the singleton was started up
-                probe.ExpectMsg("Got " + msg, TimeSpan.FromSeconds(25));
+                await probe.ExpectMsgAsync("Got " + msg, TimeSpan.FromSeconds(25));
             }
 
             private static readonly string _cfg = @"

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
@@ -38,49 +38,78 @@ namespace Akka.Cluster.Tools.Tests.Singleton
         {
             _sys1 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
             _sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+
+            // route the other systems' logs into the test output, the way ClusterSingletonRestart2Spec
+            // does - without them a CI failure here shows nothing about the cluster that caused it
+            InitializeLogger(_sys1);
+            InitializeLogger(_sys2);
         }
 
-        public void Join(ActorSystem from, ActorSystem to)
+        public async Task JoinAsync(ActorSystem from, ActorSystem to)
         {
             from.ActorOf(ClusterSingletonManager.Props(Echo.Props,
                 PoisonPill.Instance,
                 ClusterSingletonManagerSettings.Create(from)), "echo");
 
-            Within(TimeSpan.FromSeconds(10), () =>
+            var fromCluster = Cluster.Get(from);
+            var toAddress = Cluster.Get(to).SelfAddress;
+
+            // The join is re-issued on every attempt because sys3 reuses sys1's host:port: the target
+            // refuses it until the previous incarnation has been downed and removed, and a single Join
+            // would then sit out akka.cluster.retry-unsuccessful-join-after (10s). Half a second between
+            // attempts covers a gossip round trip; the old 100ms cadence re-sent JoinTo ten times a
+            // second, and a JoinTo received while the daemon is still in TryingToJoin drops it back to
+            // Uninitialized and restarts the handshake (ClusterDaemon.cs:1273), so the retry itself was
+            // adding load to the daemon it was waiting on.
+            // Both assertions read one members snapshot - the original read Cluster.State twice and
+            // could see two different gossip versions inside a single attempt.
+            await AwaitAssertAsync(() =>
             {
-                AwaitAssert(() =>
-                {
-                    Cluster.Get(from).Join(Cluster.Get(to).SelfAddress);
-                    Cluster.Get(from).State.Members.Select(x => x.UniqueAddress).Should().Contain(Cluster.Get(from).SelfUniqueAddress);
-                    Cluster.Get(from)
-                        .State.Members.Select(x => x.Status)
-                        .ToImmutableHashSet()
-                        .Should()
-                        .Equal(ImmutableHashSet<MemberStatus>.Empty.Add(MemberStatus.Up));
-                });
-            });
+                fromCluster.Join(toAddress);
+                var members = fromCluster.State.Members;
+                members.Select(x => x.UniqueAddress).Should().Contain(fromCluster.SelfUniqueAddress);
+                members.Select(x => x.Status)
+                    .ToImmutableHashSet()
+                    .Should()
+                    .Equal(ImmutableHashSet<MemberStatus>.Empty.Add(MemberStatus.Up));
+            }, TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(500));
+        }
+
+        // Sends a message through the proxy until the singleton answers. The send is retried because the
+        // proxy buffers or drops traffic while it holds no singleton reference, but the probe is built
+        // once. CreateTestProbe blocks the caller until the probe's PreStart has run on the test-actor
+        // dispatcher (TestKitBase.cs:739) and replaces the calling thread's SynchronizationContext
+        // (TestKitBase.cs:194), so one per attempt puts a blocking wait, a context swap and a leaked
+        // system actor inside the retry loop - on a starved agent that wait is competing for the very
+        // thread that has to run the probe it is waiting for.
+        private async Task AwaitProxyReplyAsync(ActorSystem system, IActorRef proxy, string message, TimeSpan max)
+        {
+            var probe = CreateTestProbe(system);
+            await AwaitAssertAsync(async () =>
+            {
+                proxy.Tell(message, probe.Ref);
+                await probe.ExpectMsgAsync(message, TimeSpan.FromSeconds(1));
+            }, max);
         }
 
         [Fact]
-        public void Restarting_cluster_node_with_same_hostname_and_port_must_handover_to_next_oldest()
+        public async Task Restarting_cluster_node_with_same_hostname_and_port_must_handover_to_next_oldest()
         {
-            Join(_sys1, _sys1);
-            Join(_sys2, _sys1);
+            await JoinAsync(_sys1, _sys1);
+            await JoinAsync(_sys2, _sys1);
 
             var proxy2 = _sys2.ActorOf(
                 ClusterSingletonProxy.Props("user/echo", ClusterSingletonProxySettings.Create(_sys2)), "proxy2");
 
-            Within(TimeSpan.FromSeconds(5), () =>
-            {
-                AwaitAssert(() =>
-                {
-                    var probe = CreateTestProbe(_sys2);
-                    proxy2.Tell("hello", probe.Ref);
-                    probe.ExpectMsg("hello", TimeSpan.FromSeconds(1));
-                });
-            });
+            await AwaitProxyReplyAsync(_sys2, proxy2, "hello", TimeSpan.FromSeconds(5));
 
-            Shutdown(_sys1);
+            // Await the graceful stop rather than TestKit's Shutdown helper. That one blocks the calling
+            // thread on Terminate().Wait(Dilated(5s)) and then silently force-stops the user guardian -
+            // which does not stop /system, so remoting keeps sys1's listener bound while sys3 is created
+            // on the same host:port below. dot-netty's tcp-reuse-addr is off-for-windows, so that rebind
+            // is exactly the kind of thing that fails on Windows and nowhere else. Terminate() runs
+            // CoordinatedShutdown to completion: the hand-over to sys2 finishes and the port is released.
+            await _sys1.Terminate();
             // it will be downed by the join attempts of the new incarnation
 
             // ReSharper disable once PossibleInvalidOperationException
@@ -88,45 +117,45 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             var sys3Config = ConfigurationFactory.ParseString(@"akka.remote.dot-netty.tcp.port=" + sys1Port)
                 .WithFallback(_sys1.Settings.Config);
             _sys3 = ActorSystem.Create(_sys1.Name, sys3Config);
+            InitializeLogger(_sys3);
 
-            Join(_sys3, _sys2);
+            await JoinAsync(_sys3, _sys2);
 
-            Within(TimeSpan.FromSeconds(5), () =>
+            // JoinAsync only proves sys3's own view. sys2 has to see sys3 reach Up as well, because
+            // sys2's singleton manager picks its hand-over target from its own member list. If sys2
+            // leaves while it still sees sys3 as Joining there is no target, and the cluster-exiting
+            // CoordinatedShutdown phase runs to its 10s timeout before sys2 can be removed - which is
+            // what puts the removal assertion below over its budget.
+            await AwaitAssertAsync(() =>
             {
-                AwaitAssert(() =>
+                foreach (var system in new[] { _sys2, _sys3 })
                 {
-                    var probe = CreateTestProbe(_sys2);
-                    proxy2.Tell("hello2", probe.Ref);
-                    probe.ExpectMsg("hello2", TimeSpan.FromSeconds(1));
-                });
-            });
+                    var members = Cluster.Get(system).State.Members;
+                    members.Select(x => x.Status)
+                        .ToImmutableHashSet()
+                        .Should()
+                        .Equal(ImmutableHashSet<MemberStatus>.Empty.Add(MemberStatus.Up));
+                    members.Count.Should().Be(2);
+                }
+            }, TimeSpan.FromSeconds(10));
+
+            await AwaitProxyReplyAsync(_sys2, proxy2, "hello2", TimeSpan.FromSeconds(5));
 
             Cluster.Get(_sys2).Leave(Cluster.Get(_sys2).SelfAddress);
 
-            Within(TimeSpan.FromSeconds(15), () =>
+            await AwaitAssertAsync(() =>
             {
-                AwaitAssert(() =>
-                {
-                    Cluster.Get(_sys3)
-                        .State.Members.Select(x => x.UniqueAddress)
-                        .Should()
-                        .Equal(Cluster.Get(_sys3).SelfUniqueAddress);
-                });
-            });
+                Cluster.Get(_sys3)
+                    .State.Members.Select(x => x.UniqueAddress)
+                    .Should()
+                    .Equal(Cluster.Get(_sys3).SelfUniqueAddress);
+            }, TimeSpan.FromSeconds(15));
 
             var proxy3 =
                 _sys3.ActorOf(ClusterSingletonProxy.Props("user/echo", ClusterSingletonProxySettings.Create(_sys3)),
                     "proxy3");
 
-            Within(TimeSpan.FromSeconds(5), () =>
-            {
-                AwaitAssert(() =>
-                {
-                    var probe = CreateTestProbe(_sys3);
-                    proxy3.Tell("hello3", probe.Ref);
-                    probe.ExpectMsg("hello3", TimeSpan.FromSeconds(1));
-                });
-            });
+            await AwaitProxyReplyAsync(_sys3, proxy3, "hello3", TimeSpan.FromSeconds(5));
         }
 
         protected override void AfterAll()


### PR DESCRIPTION
Wave-1 de-flake batch: three flaky test families, test-only changes, no product code touched. No timeout was raised, no sleep or retry backoff added anywhere — every fix removes a structural race or a blocking wait.

## ClusterSingletonProxySpec (failed build 130872, Linux, ~36s in-test)

The identify test was synchronous end to end: `TestProxy` blocked on `ExpectMsg` for up to 25s per node while five in-process ActorSystems competed for the same starved thread pool, and nothing waited for the singleton to exist before sending — cluster formation, singleton startup, and identification all had to fit inside one message timeout.

- The test is now async, with two explicit gates: all five nodes see five members Up, then each proxy publishes `IdentifySingletonResult.Success`. The event-stream subscription is made before the proxy actor is created, so the result cannot be missed; the wait fishes for `Success` because the proxy also publishes `Timeout` results on a zero-initial-delay timer.
- The zero-buffering test gated on membership, then sent once into a proxy with `BufferSize = 0` — which drops what it cannot forward. Membership does not imply identification, so the only message could vanish silently. It now gates on the identification result, and terminates its seed system instead of leaving it gossiping through the rest of the assembly.
- Two waits in the timeout tests inherited `single-expect-default` (3s) on different TestKit instances, so their budgets did not nest and the retry loop got roughly one attempt against a queue pre-loaded with 500ms-cadence `Timeout` results. Both now fish with explicit 30s bounds.
- Teardown awaits `Task.WhenAll` — the old `Wait(30s)` discarded its result, letting five cluster systems keep shutting down into the next test.

## ClusterSingletonRestartSpec (failed build 130838, Windows, 15s removal window)

- `Shutdown(_sys1)` waits 5s, then silently force-stops the user guardian — which does not stop `/system`, so remoting kept sys1's listener bound while sys3 was created on the same host:port. `tcp-reuse-addr = off-for-windows` makes that rebind a Windows-only failure, matching the Windows-only flake. Now `await _sys1.Terminate()`: the hand-over completes and the port is released.
- Each proxy assertion created a `TestProbe` inside its retry loop. `CreateTestProbe` blocks the caller until the probe's PreStart runs and swaps the calling thread's `SynchronizationContext` — a blocking wait on work that itself needs a pool thread, once per ~1.1s attempt, at four sites. One probe per phase now; only the send is retried.
- The reported 15s failure waits for sys2 to be fully Removed, which runs sys2's `cluster-exiting` phase — and that phase blocks on the singleton hand-over with a 10s timeout. `JoinAsync` only proves sys3's own view, so sys2 could still see sys3 as Joining when it left: no hand-over target, phase runs to timeout, removal misses the window. A mutual-convergence gate now requires both sys2 and sys3 to see the same two-member Up cluster before the `Leave`.
- Join retries moved from 100ms to 500ms: a `JoinTo` arriving while the daemon is in `TryingToJoin` drops it back to `Uninitialized` and restarts the handshake, so ten retries a second was load on the very daemon the test was waiting on. The join must still be re-issued — sys3 reuses sys1's address and is refused until the old incarnation is removed.

## DistributedPubSubRestartSpec (failed build 130808)

The confirmed occurrence livelocked on a reused Identify probe: association establishment flushes the buffered Identifies as a burst of `ActorIdentity(null)`, and each retry then read one stale null forever — 80 attempts in 25s, none of them waiting.

- The restart-kill loop now uses `ActorSelection.ResolveOne` inside the retry: the Identify round trip is the delivery confirmation, its temp actor is fresh per attempt (structurally immune to the stale-null livelock), and final failure raises `ActorNotFoundException` naming the unresolved path instead of a bare timeout on a null `Subject`.
- Resolve and kill stay in one retry on purpose: splitting them lets the outbound stream drop the kill in the gap between a successful resolve and the `Tell`, with no resend — a local soak reproduced exactly that. The comment in the spec documents it so nobody re-splits it.
- The 45s bound is derived, not guessed: third's restart (~15s) + one association cycle (15s associate timeout + 5s gate) + handshake and ack (~5s) ≈ 40s, nesting inside the 120s `end` barrier with 45s of headroom.
- Baseline `DeltaCount` reads moved off `TestActor` (subscribed to `topic1`) onto probes with explicit bounds; `CountAsync` retries on the 500ms gossip tick with a fresh probe and a 1s bound per attempt instead of spending its 10s window on three 3s waits.

## Verification

| Check | Result |
|---|---|
| Proxy identify, `DOTNET_ThreadPool_ForceMaxWorkerThreads=3`, ×10 | 10/10 green, tail latency gone (12.6–13.7s vs 12.8–18.6s before) |
| Restart spec, same 3-thread cap, ×12 | 12/12 green |
| Both singleton classes, same cap, independent re-run | 5/5 green |
| Full `Akka.Cluster.Tools.Tests` | 98/98 green |
| DistributedPubSubRestartSpec, artery, ×6 + independent re-run | 7/7 green |
| DistributedPubSubRestartSpec, classic, ×3 | 3/3 green |
| Both projects at `-warnaserror` | 0 warnings, 0 errors |
