### PR TITLE
Artery: stop dropping the first ordinary message when the peer dialed first

### DIFF
--- a/src/core/Akka.Remote.Tests/Artery/ArteryHandshakeSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryHandshakeSpec.cs
@@ -102,7 +102,7 @@ namespace Akka.Remote.Tests.Artery
 
             // Simulate what InboundHandshakeStage does when the peer's HandshakeRsp arrives on
             // OUR inbound pipeline for the return direction.
-            registry.CompleteHandshake(remoteAddress, new UniqueAddress(remoteAddress, 222L));
+            registry.CompleteOutboundHandshake(remoteAddress, new UniqueAddress(remoteAddress, 222L));
 
             // Nothing re-triggers the stage directly; per the documented notification mechanism,
             // the retry timer (still running) is what notices completion and delivers the held
@@ -152,7 +152,7 @@ namespace Akka.Remote.Tests.Artery
             // slow to arrive.
             await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
 
-            registry.CompleteHandshake(remoteAddress, new UniqueAddress(remoteAddress, 222L));
+            registry.CompleteOutboundHandshake(remoteAddress, new UniqueAddress(remoteAddress, 222L));
 
             // The retry timer (still running) is what notices completion and releases the held
             // element - bounded by one retry interval; a legal idempotent retry HandshakeReq may
@@ -268,7 +268,7 @@ namespace Akka.Remote.Tests.Artery
             await pub.SendNextAsync(new OutboundEnvelope("user-message", null, null));
             await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
 
-            registry.CompleteHandshake(remoteAddress, new UniqueAddress(remoteAddress, 555L));
+            registry.CompleteOutboundHandshake(remoteAddress, new UniqueAddress(remoteAddress, 555L));
 
             var delivered = await sub.ExpectNextAsync(TimeSpan.FromSeconds(3));
             delivered.Message.Should().Be("user-message");
@@ -285,7 +285,7 @@ namespace Akka.Remote.Tests.Artery
 
             // Already-associated at PreStart (Completed immediately) -- exercises the
             // "ShouldReinjectForLiveness" path directly rather than the initial handshake path.
-            registry.CompleteHandshake(remoteAddress, new UniqueAddress(remoteAddress, 777L));
+            registry.CompleteOutboundHandshake(remoteAddress, new UniqueAddress(remoteAddress, 777L));
 
             var stage = new OutboundHandshakeStage(
                 context,

--- a/src/core/Akka.Remote.Tests/Artery/ArteryPeerDialedFirstSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryPeerDialedFirstSpec.cs
@@ -1,0 +1,327 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryPeerDialedFirstSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using Akka.Configuration;
+using Akka.Remote.Artery;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using Akka.Streams.TestKit;
+using Akka.TestKit;
+using Akka.TestKit.Extensions;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+
+namespace Akka.Remote.Tests.Artery
+{
+    /// <summary>
+    /// Regression coverage for issue #8496: Artery dropped the FIRST ordinary message on a
+    /// brand-new association whenever the peer dialed us first.
+    ///
+    /// <para>
+    /// <b>The defect.</b> <see cref="OutboundHandshakeStage"/>'s <c>PreStart</c> shortcut treated
+    /// "this association already has a <see cref="AssociationState.UniqueRemoteAddress"/>" as "our
+    /// handshake is done". That field is also set by the INBOUND direction — when WE handle the
+    /// peer's <see cref="HandshakeReq"/> — which proves we know the peer's uid but says nothing
+    /// about whether the peer knows OURS. So our first outbound ordinary stream skipped its own
+    /// <see cref="HandshakeReq"/>, and our first user message raced our <see cref="HandshakeRsp"/>
+    /// (sent on a DIFFERENT TCP connection) into the peer's unknown-origin gate — where it was
+    /// silently dropped, with no resend path for ordinary messages.
+    /// </para>
+    ///
+    /// <para>
+    /// Every test here drives the PRODUCTION path for both handshake directions (a real
+    /// <see cref="InboundHandshakeStage"/> fed a real <see cref="HandshakeReq"/>/
+    /// <see cref="HandshakeRsp"/>) rather than poking the registry directly, so the specs stay
+    /// honest about which direction actually completed.
+    /// </para>
+    /// </summary>
+    public class ArteryPeerDialedFirstSpec : AkkaSpec
+    {
+        public ArteryPeerDialedFirstSpec(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private static UniqueAddress NewLocal() => new(new Address("akka", "local-sys", "local-host", 2551), 111L);
+
+        private static Address NewRemote() => new("akka", "remote-sys", "remote-host", 2552);
+
+        private static IInboundEnvelope ControlInbound(IArteryControlMessage message, long originUid) =>
+            new InboundEnvelope(message, null, null, originUid, SerializerId: 0, Manifest: "test-manifest");
+
+        private static IInboundEnvelope OrdinaryInbound(object message, long originUid) =>
+            new InboundEnvelope(message, null, "akka://remote-sys@remote-host:2552/user/recipient", originUid,
+                SerializerId: 0, Manifest: "test-manifest");
+
+        #region Stage-level
+
+        [Fact(DisplayName = "OutboundHandshakeStage should send its OWN HandshakeReq when the association was created by an INBOUND handshake (peer dialed first), and hold user traffic until the peer answers")]
+        public async Task OutboundHandshakeStage_should_not_shortcut_on_an_inbound_only_association()
+        {
+            var registry = new AssociationRegistry();
+            var localAddress = NewLocal();
+            var remoteAddress = NewRemote();
+            var peer = new UniqueAddress(remoteAddress, 222L);
+
+            var materializer = ActorMaterializer.Create(Sys);
+
+            // The peer dialed US first: OUR InboundHandshakeStage handles ITS HandshakeReq, which
+            // both CREATES the association keyed by the peer's address and sets
+            // UniqueRemoteAddress. Nothing here proves the peer has registered OUR uid.
+            var inboundSentControl = new List<(Address To, object Message)>();
+            var inboundContext = new AssociationRegistryInboundContext(
+                registry, localAddress, (to, msg) => inboundSentControl.Add((to, msg)));
+            var (inPub, inSub) = this.SourceProbe<IInboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(new InboundHandshakeStage(inboundContext)), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IInboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await inSub.RequestAsync(1);
+            await inPub.SendNextAsync(ControlInbound(new HandshakeReq(peer, localAddress.Address), peer.Uid));
+            await AwaitConditionAsync(() => Task.FromResult(inboundSentControl.Count == 1), 3.Seconds());
+            inboundSentControl[0].Message.Should().BeOfType<HandshakeRsp>("we answer the peer's Req, which is what put the association in this state");
+            registry.AssociationFor(remoteAddress).CurrentState.UniqueRemoteAddress.Should().Be(peer);
+
+            // Now WE materialize our own outbound ORDINARY stream to that peer for the first time
+            // (forceReqOnStart: false -- this is a first materialization, not a reconnect).
+            var sentControl = new List<object>();
+            var outboundContext = new AssociationRegistryOutboundContext(
+                registry, localAddress, remoteAddress, sentControl.Add);
+            var stage = new OutboundHandshakeStage(
+                outboundContext,
+                retryInterval: TimeSpan.FromMilliseconds(200),
+                handshakeTimeout: TimeSpan.FromSeconds(30),
+                injectHandshakeInterval: TimeSpan.FromSeconds(30),
+                isControlStream: false,
+                forceReqOnStart: false);
+
+            var (outPub, outSub) = this.SourceProbe<IOutboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(stage), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IOutboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await outSub.RequestAsync(1);
+            await outPub.SendNextAsync(new OutboundEnvelope("user-message-1", null, null));
+
+            // THE REGRESSION: before the fix, the stage declared itself Completed at PreStart and
+            // released this element immediately, having sent no HandshakeReq of its own -- so the
+            // peer had no way of ever learning our uid, and dropped the message.
+            await outSub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+            await AwaitConditionAsync(() => Task.FromResult(sentControl.Count > 0), 3.Seconds());
+            sentControl.Should().AllBeOfType<HandshakeReq>("an association populated purely by an INBOUND handshake must not satisfy the PreStart shortcut");
+            ((HandshakeReq)sentControl[0]).From.Should().Be(localAddress);
+            ((HandshakeReq)sentControl[0]).To.Should().Be(remoteAddress);
+
+            // The peer answers OUR Req -- the only event that proves it has registered our uid.
+            await inSub.RequestAsync(1);
+            await inPub.SendNextAsync(ControlInbound(new HandshakeRsp(peer), peer.Uid));
+
+            var delivered = await outSub.ExpectNextAsync(TimeSpan.FromSeconds(5));
+            delivered.Message.Should().Be("user-message-1", "the held element is released once the peer answers our own HandshakeReq");
+        }
+
+        [Fact(DisplayName = "OutboundHandshakeStage should not treat the peer's own retried HandshakeReq as completion of OUR handshake")]
+        public async Task OutboundHandshakeStage_should_not_complete_on_the_peers_own_req_retry()
+        {
+            var registry = new AssociationRegistry();
+            var localAddress = NewLocal();
+            var remoteAddress = NewRemote();
+            var peer = new UniqueAddress(remoteAddress, 444L);
+
+            var materializer = ActorMaterializer.Create(Sys);
+
+            var inboundContext = new AssociationRegistryInboundContext(registry, localAddress, (_, _) => { });
+            var (inPub, inSub) = this.SourceProbe<IInboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(new InboundHandshakeStage(inboundContext)), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IInboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await inSub.RequestAsync(1);
+            await inPub.SendNextAsync(ControlInbound(new HandshakeReq(peer, localAddress.Address), peer.Uid));
+            await AwaitConditionAsync(
+                () => Task.FromResult(registry.AssociationFor(remoteAddress).CurrentState.UniqueRemoteAddress is not null),
+                3.Seconds());
+
+            var sentControl = new List<object>();
+            var stage = new OutboundHandshakeStage(
+                new AssociationRegistryOutboundContext(registry, localAddress, remoteAddress, sentControl.Add),
+                retryInterval: TimeSpan.FromMilliseconds(200),
+                handshakeTimeout: TimeSpan.FromSeconds(30),
+                injectHandshakeInterval: TimeSpan.FromSeconds(30),
+                isControlStream: false,
+                forceReqOnStart: false);
+
+            var (outPub, outSub) = this.SourceProbe<IOutboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(stage), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IOutboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await outSub.RequestAsync(1);
+            await outPub.SendNextAsync(new OutboundEnvelope("held-until-answered", null, null));
+            await AwaitConditionAsync(() => Task.FromResult(sentControl.Count > 0), 3.Seconds());
+
+            // The peer retries ITS OWN HandshakeReq -- it has not seen our HandshakeRsp yet. That
+            // re-registers the peer's uid here and advances the association's handshake generation,
+            // but proves nothing about whether the peer knows OUR uid, so our traffic stays held.
+            await inPub.SendNextAsync(ControlInbound(new HandshakeReq(peer, localAddress.Address), peer.Uid));
+            await outSub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+
+            // Only the peer's answer to OUR Req releases it.
+            await inPub.SendNextAsync(ControlInbound(new HandshakeRsp(peer), peer.Uid));
+
+            var delivered = await outSub.ExpectNextAsync(TimeSpan.FromSeconds(5));
+            delivered.Message.Should().Be("held-until-answered");
+        }
+
+        [Fact(DisplayName = "OutboundHandshakeStage should still skip the HandshakeReq on a fresh materialization once OUR OWN handshake has been answered (fast path preserved)")]
+        public async Task OutboundHandshakeStage_should_keep_the_fast_path_after_our_own_handshake_completed()
+        {
+            var registry = new AssociationRegistry();
+            var localAddress = NewLocal();
+            var remoteAddress = NewRemote();
+            var peer = new UniqueAddress(remoteAddress, 333L);
+
+            var materializer = ActorMaterializer.Create(Sys);
+
+            // A GENUINE local outbound handshake completion: the peer's HandshakeRsp -- which it
+            // only ever sends after registering the uid carried in a HandshakeReq of OURS --
+            // arrives on our inbound pipeline (e.g. on the control stream).
+            var inboundContext = new AssociationRegistryInboundContext(registry, localAddress, (_, _) => { });
+            var (inPub, inSub) = this.SourceProbe<IInboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(new InboundHandshakeStage(inboundContext)), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IInboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await inSub.RequestAsync(1);
+            await inPub.SendNextAsync(ControlInbound(new HandshakeRsp(peer), peer.Uid));
+            await AwaitConditionAsync(
+                () => Task.FromResult(registry.AssociationFor(remoteAddress).CurrentState.UniqueRemoteAddress is not null),
+                3.Seconds());
+
+            // A LATER stream (ordinary/large/an extra lane) materializes against that same
+            // association for the first time. It must NOT re-run the handshake.
+            var sentControl = new List<object>();
+            var outboundContext = new AssociationRegistryOutboundContext(
+                registry, localAddress, remoteAddress, sentControl.Add);
+            var stage = new OutboundHandshakeStage(
+                outboundContext,
+                retryInterval: TimeSpan.FromMilliseconds(200),
+                handshakeTimeout: TimeSpan.FromSeconds(30),
+                injectHandshakeInterval: TimeSpan.FromSeconds(30),
+                isControlStream: false,
+                forceReqOnStart: false);
+
+            var (outPub, outSub) = this.SourceProbe<IOutboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(stage), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IOutboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await outSub.RequestAsync(1);
+            await outPub.SendNextAsync(new OutboundEnvelope("flows-immediately", null, null));
+
+            var delivered = await outSub.ExpectNextAsync(TimeSpan.FromSeconds(5));
+            delivered.Message.Should().Be("flows-immediately", "traffic must not be gated a second time once the peer has answered our own Req");
+            sentControl.Should().BeEmpty("a redundant HandshakeReq on every later stream would cost an extra round trip per materialization");
+        }
+
+        [Fact(DisplayName = "InboundHandshakeStage should log a WARNING (not a DEBUG) when it drops an ordinary message from an unknown origin uid")]
+        public async Task InboundHandshakeStage_should_warn_when_dropping_an_unknown_origin_message()
+        {
+            var registry = new AssociationRegistry();
+            var context = new AssociationRegistryInboundContext(registry, NewLocal(), (_, _) => { });
+
+            var materializer = ActorMaterializer.Create(Sys);
+            var (pub, sub) = this.SourceProbe<IInboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(new InboundHandshakeStage(context)), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IInboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await sub.RequestAsync(1);
+
+            await EventFilter.Warning(contains: "unknown origin uid").ExpectOneAsync(async () =>
+            {
+                await pub.SendNextAsync(OrdinaryInbound("dropped-message", originUid: 987654321L));
+                await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+            });
+        }
+
+        #endregion
+
+        #region End-to-end
+
+        private static Config ArteryConfig() => ConfigurationFactory.ParseString("""
+            akka.actor.provider = "Akka.Remote.RemoteActorRefProvider, Akka.Remote"
+            akka.loglevel = DEBUG
+            akka.remote.artery.enabled = on
+            akka.remote.artery.canonical.hostname = "127.0.0.1"
+            akka.remote.artery.canonical.port = 0
+            """);
+
+        private sealed class Forwarder : ReceiveActor
+        {
+            public Forwarder(IActorRef target)
+            {
+                ReceiveAny(msg => target.Tell(msg, Sender));
+            }
+        }
+
+        [Fact(DisplayName = "Artery should deliver A's FIRST ordinary message to B when B dialed A first and A's HandshakeRsp never arrives")]
+        public async Task Artery_should_deliver_the_first_ordinary_message_when_the_peer_dialed_first()
+        {
+            // systemA never delivers its HandshakeRsp. That is the deterministic form of the race
+            // the issue describes: B's ONLY other way of learning A's uid is a HandshakeReq that A
+            // sends of its own accord. Before the fix A never sent one (its outbound ordinary
+            // stream short-circuited on the association B's own Req had created), so A's first
+            // message to B was dropped at B's unknown-origin gate and never resent.
+            var systemA = ActorSystem.Create("ArteryPeerDialedFirstA", ActorSystemSetup.Create(
+                BootstrapSetup.Create().WithConfig(ArteryConfig()),
+                new ArteryTransportSetup(dropOutboundControlMessage: msg => msg is HandshakeRsp)));
+            var systemB = ActorSystem.Create("ArteryPeerDialedFirstB", ArteryConfig());
+
+            try
+            {
+                var addressA = RARP.For(systemA).Provider.DefaultAddress;
+                var addressB = RARP.For(systemB).Provider.DefaultAddress;
+                var transportA = (ArteryRemoting)RARP.For(systemA).Provider.Transport;
+
+                var sinkProbeOnB = CreateTestProbe(systemB);
+                systemB.ActorOf(Props.Create(() => new Forwarder(sinkProbeOnB.Ref)), "sink");
+
+                // STEP 1 -- B dials A. B's control stream sends HandshakeReq(B), so A creates the
+                // association for B's address and records B's uid, purely from the INBOUND
+                // direction. (B's own user message stays held behind B's handshake; the test does
+                // not depend on it arriving.)
+                systemB.ActorSelection($"{addressA}/user/does-not-need-to-exist").Tell("b-dials-a", ActorRefs.NoSender);
+
+                // Deterministic ordering gate -- no sleeps: A has processed B's HandshakeReq.
+                await AwaitAssertAsync(
+                    () => transportA.Registry.AssociationFor(addressB).CurrentState.UniqueRemoteAddress
+                        .Should().NotBeNull("A must have recorded B's uid from B's inbound HandshakeReq before A sends anything"),
+                    10.Seconds());
+
+                // STEP 2 -- ONLY NOW does A send its first ordinary message to B.
+                systemA.ActorSelection($"{addressB}/user/sink").Tell("a-first-message", ActorRefs.NoSender);
+
+                await sinkProbeOnB.ExpectMsgAsync("a-first-message", 20.Seconds());
+            }
+            finally
+            {
+                await systemA.Terminate().AwaitWithTimeout(20.Seconds());
+                await systemB.Terminate().AwaitWithTimeout(20.Seconds());
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/core/Akka.Remote.Tests/Artery/ArteryPeerDialedFirstSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryPeerDialedFirstSpec.cs
@@ -235,6 +235,115 @@ namespace Akka.Remote.Tests.Artery
             sentControl.Should().BeEmpty("a redundant HandshakeReq on every later stream would cost an extra round trip per materialization");
         }
 
+        [Fact(DisplayName = "OutboundHandshakeStage should release held traffic as soon as the peer answers, without waiting for a retry tick")]
+        public async Task OutboundHandshakeStage_should_release_held_traffic_without_waiting_for_a_retry_tick()
+        {
+            // The retry interval is set FAR longer than the assertion window below, so this test
+            // can only pass if completion is PUSHED to the stage. Polling on the retry tick -- the
+            // stage's only wake-up while it holds an element and has stopped pulling -- would make
+            // the release land ~30s late; on a cluster join that same latency lands on the seed's
+            // Welcome to every peer (measured ~1.07s vs ~0.07s at the 1s production default).
+            var retryInterval = TimeSpan.FromSeconds(30);
+
+            var registry = new AssociationRegistry();
+            var localAddress = NewLocal();
+            var remoteAddress = NewRemote();
+            var peer = new UniqueAddress(remoteAddress, 555L);
+
+            var materializer = ActorMaterializer.Create(Sys);
+
+            var inboundContext = new AssociationRegistryInboundContext(registry, localAddress, (_, _) => { });
+            var (inPub, inSub) = this.SourceProbe<IInboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(new InboundHandshakeStage(inboundContext)), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IInboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            // The peer dialed us first.
+            await inSub.RequestAsync(1);
+            await inPub.SendNextAsync(ControlInbound(new HandshakeReq(peer, localAddress.Address), peer.Uid));
+            await AwaitConditionAsync(
+                () => Task.FromResult(registry.AssociationFor(remoteAddress).CurrentState.UniqueRemoteAddress is not null),
+                3.Seconds());
+
+            var sentControl = new List<object>();
+            var stage = new OutboundHandshakeStage(
+                new AssociationRegistryOutboundContext(registry, localAddress, remoteAddress, sentControl.Add),
+                retryInterval: retryInterval,
+                handshakeTimeout: TimeSpan.FromMinutes(2),
+                injectHandshakeInterval: TimeSpan.FromMinutes(2),
+                isControlStream: false,
+                forceReqOnStart: false);
+
+            var (outPub, outSub) = this.SourceProbe<IOutboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(stage), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IOutboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await outSub.RequestAsync(1);
+            await outPub.SendNextAsync(new OutboundEnvelope("held-until-answered", null, null));
+            await AwaitConditionAsync(() => Task.FromResult(sentControl.Count > 0), 5.Seconds());
+            await outSub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+
+            // The peer answers. Nothing else will re-enter the stage: it holds an element, so it
+            // is not pulling, and it has pushed nothing, so downstream demand is still outstanding.
+            await inSub.RequestAsync(1);
+            await inPub.SendNextAsync(ControlInbound(new HandshakeRsp(peer), peer.Uid));
+
+            var delivered = await outSub.ExpectNextAsync(TimeSpan.FromSeconds(3));
+            delivered.Message.Should().Be("held-until-answered");
+        }
+
+        [Fact(DisplayName = "OutboundHandshakeStage should deregister its handshake listener when the stream stops, and a later completion must be harmless")]
+        public async Task OutboundHandshakeStage_should_deregister_its_handshake_listener_on_stop()
+        {
+            var registry = new AssociationRegistry();
+            var localAddress = NewLocal();
+            var remoteAddress = NewRemote();
+            var peer = new UniqueAddress(remoteAddress, 666L);
+
+            var materializer = ActorMaterializer.Create(Sys);
+
+            var inboundContext = new AssociationRegistryInboundContext(registry, localAddress, (_, _) => { });
+            var (inPub, inSub) = this.SourceProbe<IInboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(new InboundHandshakeStage(inboundContext)), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IInboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await inSub.RequestAsync(1);
+            await inPub.SendNextAsync(ControlInbound(new HandshakeReq(peer, localAddress.Address), peer.Uid));
+            var association = registry.AssociationFor(remoteAddress);
+            await AwaitConditionAsync(
+                () => Task.FromResult(association.CurrentState.UniqueRemoteAddress is not null), 3.Seconds());
+
+            var stage = new OutboundHandshakeStage(
+                new AssociationRegistryOutboundContext(registry, localAddress, remoteAddress, _ => { }),
+                retryInterval: TimeSpan.FromSeconds(30),
+                handshakeTimeout: TimeSpan.FromMinutes(2),
+                injectHandshakeInterval: TimeSpan.FromMinutes(2),
+                isControlStream: false,
+                forceReqOnStart: false);
+
+            var (_, outSub) = this.SourceProbe<IOutboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(stage), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IOutboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await outSub.RequestAsync(1);
+            await AwaitConditionAsync(() => Task.FromResult(association.HandshakeListenerCount == 1), 5.Seconds(),
+                "a stream waiting on the handshake must be registered for the completion push");
+
+            // Outbound streams are restarted repeatedly against an association that outlives them,
+            // so a stopped stream must leave nothing behind.
+            outSub.Cancel();
+            await AwaitConditionAsync(() => Task.FromResult(association.HandshakeListenerCount == 0), 5.Seconds(),
+                "PostStop must deregister the listener");
+
+            // And a completion arriving after the stage is gone must not throw back into whichever
+            // inbound stream recorded it.
+            registry.CompleteOutboundHandshake(remoteAddress, peer);
+            association.CurrentState.OutboundHandshakeCompleted.Should().BeTrue();
+        }
+
         [Fact(DisplayName = "InboundHandshakeStage should log a WARNING (not a DEBUG) when it drops an ordinary message from an unknown origin uid")]
         public async Task InboundHandshakeStage_should_warn_when_dropping_an_unknown_origin_message()
         {

--- a/src/core/Akka.Remote.Tests/Artery/ArteryUnknownOriginDropWarningSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryUnknownOriginDropWarningSpec.cs
@@ -1,0 +1,138 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryUnknownOriginDropWarningSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Remote.Artery;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using Akka.Streams.TestKit;
+using Akka.TestKit;
+using Akka.TestKit.Configs;
+using Xunit;
+
+namespace Akka.Remote.Tests.Artery
+{
+    /// <summary>
+    /// The unknown-origin drop warning (issue #8496) is rate limited to one warning per 10s per
+    /// connection, with the drops in between folded into a suppressed count. The window is measured
+    /// on an injected <see cref="ITimeProvider"/>, so this spec crosses it with
+    /// <see cref="TestScheduler.Advance(TimeSpan)"/> instead of waiting 10 real seconds.
+    ///
+    /// <para>
+    /// It lives in its own spec class because virtualizing the scheduler also freezes the timers
+    /// the sibling handshake specs rely on.
+    /// </para>
+    /// </summary>
+    public class ArteryUnknownOriginDropWarningSpec : AkkaSpec
+    {
+        public ArteryUnknownOriginDropWarningSpec(ITestOutputHelper output)
+            : base(TestConfigs.TestSchedulerConfig, output)
+        {
+        }
+
+        private static UniqueAddress NewLocal() => new(new Address("akka", "local-sys", "local-host", 2551), 111L);
+
+        private static IInboundEnvelope OrdinaryInbound(object message, long originUid) =>
+            new InboundEnvelope(message, null, "akka://remote-sys@remote-host:2552/user/recipient", originUid,
+                SerializerId: 0, Manifest: "test-manifest");
+
+        [Fact(DisplayName = "InboundHandshakeStage should rate-limit its unknown-origin drop warning on the injected clock, and report what it suppressed")]
+        public async Task InboundHandshakeStage_should_rate_limit_the_unknown_origin_warning_on_virtual_time()
+        {
+            var scheduler = (TestScheduler)Sys.Scheduler;
+
+            var registry = new AssociationRegistry();
+            var context = new AssociationRegistryInboundContext(registry, NewLocal(), (_, _) => { });
+
+            var materializer = ActorMaterializer.Create(Sys);
+
+            // No explicit provider: the stage resolves the materializing system's scheduler, which
+            // under TestSchedulerConfig IS the virtual clock advanced below.
+            var (pub, sub) = this.SourceProbe<IInboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(new InboundHandshakeStage(context)), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IInboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await sub.RequestAsync(1);
+
+            // First drop of the window warns at once, with nothing suppressed yet.
+            await EventFilter.Warning(contains: "[0] further drop(s) suppressed").ExpectOneAsync(async () =>
+            {
+                await pub.SendNextAsync(OrdinaryInbound("first-drop", originUid: 101L));
+                await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+            });
+
+            // Still inside the window on the virtual clock, so this one only bumps the count.
+            await EventFilter.Warning(contains: "unknown origin uid").ExpectAsync(0, async () =>
+            {
+                await pub.SendNextAsync(OrdinaryInbound("suppressed-drop", originUid: 102L));
+                await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+            });
+
+            // Cross the 10s window without spending it: real time has barely moved, only the
+            // scheduler's Now has -- and Now is what the throttle reads.
+            scheduler.Advance(TimeSpan.FromSeconds(11));
+
+            // Warns again, accounting for the one it swallowed in between.
+            await EventFilter.Warning(contains: "[1] further drop(s) suppressed").ExpectOneAsync(async () =>
+            {
+                await pub.SendNextAsync(OrdinaryInbound("third-drop", originUid: 103L));
+                await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+            });
+        }
+
+        [Fact(DisplayName = "InboundHandshakeStage should prefer an explicitly injected ITimeProvider over the materializing system's scheduler")]
+        public async Task InboundHandshakeStage_should_prefer_an_explicit_time_provider()
+        {
+            var registry = new AssociationRegistry();
+            var context = new AssociationRegistryInboundContext(registry, NewLocal(), (_, _) => { });
+
+            // A clock that never moves: no matter how far the system scheduler advances, the
+            // window never elapses, so every later drop stays suppressed.
+            var frozen = new FrozenTimeProvider(DateTimeOffset.UtcNow);
+
+            var materializer = ActorMaterializer.Create(Sys);
+            var (pub, sub) = this.SourceProbe<IInboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(new InboundHandshakeStage(context, frozen)), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IInboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await sub.RequestAsync(1);
+
+            await EventFilter.Warning(contains: "unknown origin uid").ExpectOneAsync(async () =>
+            {
+                await pub.SendNextAsync(OrdinaryInbound("first-drop", originUid: 201L));
+                await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+            });
+
+            ((TestScheduler)Sys.Scheduler).Advance(TimeSpan.FromMinutes(5));
+
+            await EventFilter.Warning(contains: "unknown origin uid").ExpectAsync(0, async () =>
+            {
+                await pub.SendNextAsync(OrdinaryInbound("still-suppressed", originUid: 202L));
+                await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+            });
+        }
+
+        /// <summary>A clock frozen at construction -- proves the stage reads the provider it was given.</summary>
+        private sealed class FrozenTimeProvider : ITimeProvider
+        {
+            public FrozenTimeProvider(DateTimeOffset now)
+            {
+                Now = now;
+            }
+
+            public DateTimeOffset Now { get; }
+            public TimeSpan MonotonicClock => TimeSpan.Zero;
+            public TimeSpan HighResMonotonicClock => TimeSpan.Zero;
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/Artery/ArteryUnknownOriginDropWarningSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryUnknownOriginDropWarningSpec.cs
@@ -88,51 +88,5 @@ namespace Akka.Remote.Tests.Artery
                 await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
             });
         }
-
-        [Fact(DisplayName = "InboundHandshakeStage should prefer an explicitly injected ITimeProvider over the materializing system's scheduler")]
-        public async Task InboundHandshakeStage_should_prefer_an_explicit_time_provider()
-        {
-            var registry = new AssociationRegistry();
-            var context = new AssociationRegistryInboundContext(registry, NewLocal(), (_, _) => { });
-
-            // A clock that never moves: no matter how far the system scheduler advances, the
-            // window never elapses, so every later drop stays suppressed.
-            var frozen = new FrozenTimeProvider(DateTimeOffset.UtcNow);
-
-            var materializer = ActorMaterializer.Create(Sys);
-            var (pub, sub) = this.SourceProbe<IInboundEnvelope>()
-                .ViaMaterialized(Flow.FromGraph(new InboundHandshakeStage(context, frozen)), Keep.Left)
-                .ToMaterialized(this.SinkProbe<IInboundEnvelope>(), Keep.Both)
-                .Run(materializer);
-
-            await sub.RequestAsync(1);
-
-            await EventFilter.Warning(contains: "unknown origin uid").ExpectOneAsync(async () =>
-            {
-                await pub.SendNextAsync(OrdinaryInbound("first-drop", originUid: 201L));
-                await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
-            });
-
-            ((TestScheduler)Sys.Scheduler).Advance(TimeSpan.FromMinutes(5));
-
-            await EventFilter.Warning(contains: "unknown origin uid").ExpectAsync(0, async () =>
-            {
-                await pub.SendNextAsync(OrdinaryInbound("still-suppressed", originUid: 202L));
-                await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
-            });
-        }
-
-        /// <summary>A clock frozen at construction -- proves the stage reads the provider it was given.</summary>
-        private sealed class FrozenTimeProvider : ITimeProvider
-        {
-            public FrozenTimeProvider(DateTimeOffset now)
-            {
-                Now = now;
-            }
-
-            public DateTimeOffset Now { get; }
-            public TimeSpan MonotonicClock => TimeSpan.Zero;
-            public TimeSpan HighResMonotonicClock => TimeSpan.Zero;
-        }
     }
 }

--- a/src/core/Akka.Remote.Tests/Artery/AssociationStateSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/AssociationStateSpec.cs
@@ -94,6 +94,65 @@ namespace Akka.Remote.Tests.Artery
             newState.IsQuarantined(firstPeer.Uid).Should().BeFalse();
         }
 
+        [Fact(DisplayName = "Only CompleteOutboundHandshake should set OutboundHandshakeCompleted (issue #8496)")]
+        public void Only_CompleteOutboundHandshake_should_set_outbound_completed()
+        {
+            var peer = new UniqueAddress(RemoteAddress, 1L);
+
+            var fromPeersReq = AssociationState.Create().CompleteHandshake(peer);
+            fromPeersReq.UniqueRemoteAddress.Should().Be(peer, "the peer's own Req still registers its uid");
+            fromPeersReq.OutboundHandshakeCompleted.Should().BeFalse("the peer has learned nothing about US from its own Req");
+
+            AssociationState.Create().CompleteOutboundHandshake(peer).OutboundHandshakeCompleted
+                .Should().BeTrue("a Rsp is proof the peer registered our uid");
+        }
+
+        [Fact(DisplayName = "CompleteOutboundHandshake should flip OutboundHandshakeCompleted after an inbound-only handshake, then be an idempotent no-op")]
+        public void CompleteOutboundHandshake_should_flip_the_flag_then_be_idempotent()
+        {
+            var peer = new UniqueAddress(RemoteAddress, 1L);
+            var inboundOnly = AssociationState.Create().CompleteHandshake(peer);
+
+            var answered = inboundOnly.CompleteOutboundHandshake(peer);
+
+            answered.Should().NotBeSameAs(inboundOnly, "the false -> true flip is a real transition, not a no-op");
+            answered.Incarnation.Should().Be(inboundOnly.Incarnation, "the peer did not restart");
+            answered.OutboundHandshakeCompleted.Should().BeTrue();
+
+            answered.CompleteOutboundHandshake(peer).Should().BeSameAs(answered, "re-answering is an idempotent no-op");
+            answered.CompleteHandshake(peer).Should().BeSameAs(answered, "a later inbound Req must not clear what we already proved");
+        }
+
+        [Fact(DisplayName = "A new incarnation (peer restart) should reset OutboundHandshakeCompleted")]
+        public void New_incarnation_should_reset_outbound_completed()
+        {
+            var oldPeer = new UniqueAddress(RemoteAddress, 1L);
+            var newPeer = new UniqueAddress(RemoteAddress, 2L);
+            var answered = AssociationState.Create().CompleteOutboundHandshake(oldPeer);
+
+            var restarted = answered.CompleteHandshake(newPeer);
+
+            restarted.Incarnation.Should().Be(answered.Incarnation + 1);
+            restarted.OutboundHandshakeCompleted.Should().BeFalse(
+                "the RESTARTED peer has never answered a Req of ours -- what the previous incarnation knew about us died with it");
+
+            answered.CompleteOutboundHandshake(newPeer).OutboundHandshakeCompleted
+                .Should().BeTrue("unless the very message that changed the uid was itself a Rsp");
+        }
+
+        [Fact(DisplayName = "Quarantine should clear OutboundHandshakeCompleted")]
+        public void Quarantine_should_clear_outbound_completed()
+        {
+            var peer = new UniqueAddress(RemoteAddress, 1L);
+            var answered = AssociationState.Create().CompleteOutboundHandshake(peer);
+
+            var (quarantined, acted) = answered.Quarantine(peer.Uid);
+
+            acted.Should().BeTrue();
+            quarantined.OutboundHandshakeCompleted.Should().BeFalse();
+            quarantined.UniqueRemoteAddress.Should().Be(peer, "quarantine is uid-scoped -- it does not forget which uid it applies to");
+        }
+
         [Fact(DisplayName = "Quarantine should act on the current uid and mark it quarantined")]
         public void Quarantine_should_act_on_current_uid()
         {

--- a/src/core/Akka.Remote/Artery/ArteryInboundProcessingStage.cs
+++ b/src/core/Akka.Remote/Artery/ArteryInboundProcessingStage.cs
@@ -126,6 +126,11 @@ namespace Akka.Remote.Artery
         /// (task 10.2) -- matches Pekko's <c>maximum-large-frame-size</c>.
         /// </param>
         /// <param name="serialization">The receiving actor system's <see cref="Akka.Serialization.Serialization"/> extension.</param>
+        /// <param name="timeProvider">
+        /// Clock for the lane path's unknown-origin drop-warning rate limit -- see
+        /// <see cref="TimeProvider"/>. <see langword="null"/> resolves to the materializing
+        /// system's scheduler.
+        /// </param>
         /// <param name="inboundLanes">
         /// Number of inbound lanes ordinary-stream messages are fanned out across (see the
         /// type-level "Inbound lanes" remarks). <see langword="1"/> (the default -- and the
@@ -178,6 +183,7 @@ namespace Akka.Remote.Artery
             int maxFrameLength,
             int maxLargeFrameLength,
             Akka.Serialization.Serialization serialization,
+            ITimeProvider? timeProvider = null,
             int inboundLanes = 1,
             int inboundLaneBufferSize = 0,
             IInboundContext? inboundContext = null,
@@ -194,6 +200,7 @@ namespace Akka.Remote.Artery
             MaxFrameLength = maxFrameLength;
             MaxLargeFrameLength = maxLargeFrameLength;
             Serialization = serialization;
+            TimeProvider = timeProvider;
             InboundLanes = inboundLanes;
             InboundLaneBufferSize = inboundLaneBufferSize;
             InboundContext = inboundContext;
@@ -240,6 +247,14 @@ namespace Akka.Remote.Artery
         public int MaxLargeFrameLength { get; }
 
         public Akka.Serialization.Serialization Serialization { get; }
+
+        /// <summary>
+        /// Clock for the lane path's unknown-origin drop-warning rate limit, or
+        /// <see langword="null"/> to use the materializing system's scheduler. See
+        /// <see cref="InboundHandshakeStage.TimeProvider"/>, which owns the non-lane half of the
+        /// same warning.
+        /// </summary>
+        public ITimeProvider? TimeProvider { get; }
 
         /// <summary>See the constructor parameter of the same name.</summary>
         public int InboundLanes { get; }
@@ -337,8 +352,16 @@ namespace Akka.Remote.Artery
 
             private readonly ArteryInboundProcessingStage _stage;
             private readonly Queue<IInboundEnvelope> _pending = new();
-            private DateTime _lastUnknownOriginWarning = DateTime.MinValue;
+            /// <summary>
+            /// Clock reading at the last warning; <see langword="null"/> until the first one. Uses
+            /// <see cref="ITimeProvider.Now"/> -- the reading <c>TestScheduler</c> virtualizes.
+            /// </summary>
+            private DateTimeOffset? _lastUnknownOriginWarning;
+
             private long _suppressedUnknownOriginDrops;
+
+            /// <summary>Resolved once at <see cref="PreStart"/>; see <see cref="ArteryInboundProcessingStage.TimeProvider"/>.</summary>
+            private ITimeProvider _timeProvider = null!;
 
             private readonly byte[] _preambleBuffer = new byte[ArteryConnectionHeader.Length];
             private int _preambleFilled;
@@ -404,6 +427,13 @@ namespace Akka.Remote.Artery
                     };
                 }
             }
+
+            public override void PreStart() =>
+                _timeProvider = _stage.TimeProvider
+                                ?? (Materializer as ActorMaterializer)?.System.Scheduler
+                                ?? throw new InvalidOperationException(
+                                    "No ITimeProvider available: this stream was not materialized " +
+                                    "by an ActorMaterializer, so pass one to the stage explicitly.");
 
             public void OnPush()
             {
@@ -771,9 +801,9 @@ namespace Akka.Remote.Artery
                 // user-message dispatch per connection" holds for the lane path too.
                 if (!_stage.InboundContext!.IsKnownOrigin(decoded.Header.OriginUid))
                 {
-                    var now = DateTime.UtcNow;
-                    if (_lastUnknownOriginWarning == DateTime.MinValue ||
-                        now - _lastUnknownOriginWarning >= UnknownOriginWarnInterval)
+                    var now = _timeProvider.Now;
+                    if (_lastUnknownOriginWarning is not { } lastWarning ||
+                        now - lastWarning >= UnknownOriginWarnInterval)
                     {
                         Log.Warning(
                             "Dropping inbound lane-routed Artery message from unknown origin uid [{0}]: no completed handshake for this uid yet. " +

--- a/src/core/Akka.Remote/Artery/ArteryInboundProcessingStage.cs
+++ b/src/core/Akka.Remote/Artery/ArteryInboundProcessingStage.cs
@@ -328,8 +328,17 @@ namespace Akka.Remote.Artery
 
         private sealed class Logic : GraphStageLogic, IInHandler, IOutHandler
         {
+            /// <summary>
+            /// Rate limit for this connection's unknown-origin drop warnings -- the lane path's
+            /// half of the pair <see cref="InboundHandshakeStage"/> owns the other half of; see
+            /// that stage for the rationale.
+            /// </summary>
+            private static readonly TimeSpan UnknownOriginWarnInterval = TimeSpan.FromSeconds(10);
+
             private readonly ArteryInboundProcessingStage _stage;
             private readonly Queue<IInboundEnvelope> _pending = new();
+            private DateTime _lastUnknownOriginWarning = DateTime.MinValue;
+            private long _suppressedUnknownOriginDrops;
 
             private readonly byte[] _preambleBuffer = new byte[ArteryConnectionHeader.Length];
             private int _preambleFilled;
@@ -762,9 +771,22 @@ namespace Akka.Remote.Artery
                 // user-message dispatch per connection" holds for the lane path too.
                 if (!_stage.InboundContext!.IsKnownOrigin(decoded.Header.OriginUid))
                 {
-                    Log.Debug(
-                        "Dropping inbound lane-routed Artery message from unknown origin uid [{0}] (no completed handshake for this uid yet).",
-                        decoded.Header.OriginUid);
+                    var now = DateTime.UtcNow;
+                    if (_lastUnknownOriginWarning == DateTime.MinValue ||
+                        now - _lastUnknownOriginWarning >= UnknownOriginWarnInterval)
+                    {
+                        Log.Warning(
+                            "Dropping inbound lane-routed Artery message from unknown origin uid [{0}]: no completed handshake for this uid yet. " +
+                            "The message is LOST - ordinary messages are not resent. [{1}] further drop(s) suppressed since the last warning.",
+                            decoded.Header.OriginUid, _suppressedUnknownOriginDrops);
+                        _lastUnknownOriginWarning = now;
+                        _suppressedUnknownOriginDrops = 0;
+                    }
+                    else
+                    {
+                        _suppressedUnknownOriginDrops++;
+                    }
+
                     return true;
                 }
 

--- a/src/core/Akka.Remote/Artery/ArteryRemoting.cs
+++ b/src/core/Akka.Remote/Artery/ArteryRemoting.cs
@@ -827,10 +827,11 @@ namespace Akka.Remote.Artery
             // every Control/Large connection, still flows through them completely unchanged.
             var processingStage = _settings.InboundLanes > 1
                 ? new ArteryInboundProcessingStage(
-                    _settings.MaximumFrameSize, _settings.MaximumLargeFrameSize, System.Serialization,
+                    _settings.MaximumFrameSize, _settings.MaximumLargeFrameSize, System.Serialization, System.Scheduler,
                     _settings.InboundLanes, _settings.InboundLaneBufferSize, _inboundContext!, DispatchOrdinaryMessage,
                     _onInboundLanesInitialized, _testState)
-                : new ArteryInboundProcessingStage(_settings.MaximumFrameSize, _settings.MaximumLargeFrameSize, System.Serialization);
+                : new ArteryInboundProcessingStage(
+                    _settings.MaximumFrameSize, _settings.MaximumLargeFrameSize, System.Serialization, System.Scheduler);
 
             var decoded = Flow.Create<ReadOnlySequence<byte>>()
                 .Via(_killSwitch.Flow<ReadOnlySequence<byte>>())
@@ -864,7 +865,7 @@ namespace Akka.Remote.Artery
             // Ordinary, control and large connections all use this one sink, so one instance is
             // sufficient.
             var inboundSink = decoded
-                .Via(Flow.FromGraph(new InboundHandshakeStage(_inboundContext!)))
+                .Via(Flow.FromGraph(new InboundHandshakeStage(_inboundContext!, System.Scheduler)))
                 .Via(Flow.FromGraph(new InboundQuarantineCheckStage(_inboundContext!)))
                 .Via(Flow.FromGraph(new SystemMessageAckerStage(_inboundContext!)))
                 .To(Sink.ForEach<IInboundEnvelope>(DispatchInbound));

--- a/src/core/Akka.Remote/Artery/ArteryRemoting.cs
+++ b/src/core/Akka.Remote/Artery/ArteryRemoting.cs
@@ -1679,7 +1679,8 @@ namespace Akka.Remote.Artery
                 {
                     var handshakeStage = new OutboundHandshakeStage(
                         outboundContext, _settings.HandshakeRetryInterval, _settings.HandshakeTimeout,
-                        _settings.InjectHandshakeInterval, isControlStream: false, forceReqOnStart: isRestart);
+                        _settings.InjectHandshakeInterval, isControlStream: false, forceReqOnStart: isRestart,
+                        timeProvider: System.Scheduler);
 
                     var encodeStage = new ArteryEncodeStage(
                         System.Serialization, _localUniqueAddress.Uid, _laneEncodeBufferPools![i]);
@@ -1900,7 +1901,8 @@ namespace Akka.Remote.Artery
 
             var handshakeStage = new OutboundHandshakeStage(
                 outboundContext, _settings.HandshakeRetryInterval, _settings.HandshakeTimeout,
-                _settings.InjectHandshakeInterval, isControlStream: isControlStream, forceReqOnStart: isRestart);
+                _settings.InjectHandshakeInterval, isControlStream: isControlStream, forceReqOnStart: isRestart,
+                timeProvider: System.Scheduler);
 
             var host = remoteAddress.Host
                 ?? throw new RemoteTransportException($"Cannot open an Artery {streamId} outbound connection to [{remoteAddress}]: missing host.");

--- a/src/core/Akka.Remote/Artery/AssociationRegistry.cs
+++ b/src/core/Akka.Remote/Artery/AssociationRegistry.cs
@@ -1071,7 +1071,9 @@ namespace Akka.Remote.Artery
                     return (current, current);
                 }
 
-                if (Interlocked.CompareExchange(ref _state, updated, current) == current)
+                // ReferenceEquals, not ==: AssociationState is a record, so == would be
+                // compiler-generated VALUE equality and a lost CAS could masquerade as a won one.
+                if (ReferenceEquals(Interlocked.CompareExchange(ref _state, updated, current), current))
                 {
                     NotifyHandshakeStateChanged();
                     return (current, updated);
@@ -1107,7 +1109,8 @@ namespace Akka.Remote.Artery
                 if (ReferenceEquals(updated, current))
                     return true;
 
-                if (Interlocked.CompareExchange(ref _state, updated, current) == current)
+                // Reference comparison -- see the matching note in Transition.
+                if (ReferenceEquals(Interlocked.CompareExchange(ref _state, updated, current), current))
                     return true;
             }
         }

--- a/src/core/Akka.Remote/Artery/AssociationRegistry.cs
+++ b/src/core/Akka.Remote/Artery/AssociationRegistry.cs
@@ -996,14 +996,27 @@ namespace Akka.Remote.Artery
         /// snapshot, so <see cref="AssociationRegistry"/> can tell — without a separate,
         /// racy read — whether (and from what uid) an incarnation change just happened.
         /// </summary>
-        public (AssociationState Previous, AssociationState Updated) CompleteHandshake(UniqueAddress peer)
+        public (AssociationState Previous, AssociationState Updated) CompleteHandshake(UniqueAddress peer) =>
+            Transition(peer, static (state, p) => state.CompleteHandshake(p));
+
+        /// <summary>
+        /// As <see cref="CompleteHandshake"/>, but applying
+        /// <see cref="AssociationState.CompleteOutboundHandshake"/> -- the only path that sets
+        /// <see cref="AssociationState.OutboundHandshakeCompleted"/> (issue #8496).
+        /// </summary>
+        public (AssociationState Previous, AssociationState Updated) CompleteOutboundHandshake(UniqueAddress peer) =>
+            Transition(peer, static (state, p) => state.CompleteOutboundHandshake(p));
+
+        private (AssociationState Previous, AssociationState Updated) Transition(
+            UniqueAddress peer,
+            Func<AssociationState, UniqueAddress, AssociationState> transition)
         {
             Interlocked.Increment(ref _handshakeGeneration);
 
             while (true)
             {
                 var current = _state;
-                var updated = current.CompleteHandshake(peer);
+                var updated = transition(current, peer);
 
                 if (ReferenceEquals(updated, current))
                     return (current, current);
@@ -1137,7 +1150,27 @@ namespace Akka.Remote.Artery
         public AssociationState CompleteHandshake(Address remoteAddress, UniqueAddress peer)
         {
             var association = AssociationFor(remoteAddress);
-            var (previous, updated) = association.CompleteHandshake(peer);
+            return Complete(association, peer, association.CompleteHandshake(peer));
+        }
+
+        /// <summary>
+        /// As <see cref="CompleteHandshake"/>, but records that the peer answered a
+        /// <see cref="HandshakeReq"/> of OURS -- see
+        /// <see cref="AssociationState.OutboundHandshakeCompleted"/>. Called only from
+        /// <see cref="InboundHandshakeStage"/>'s <c>HandleRsp</c>.
+        /// </summary>
+        public AssociationState CompleteOutboundHandshake(Address remoteAddress, UniqueAddress peer)
+        {
+            var association = AssociationFor(remoteAddress);
+            return Complete(association, peer, association.CompleteOutboundHandshake(peer));
+        }
+
+        private AssociationState Complete(
+            Association association,
+            UniqueAddress peer,
+            (AssociationState Previous, AssociationState Updated) transition)
+        {
+            var (previous, updated) = transition;
 
             if (!ReferenceEquals(previous, updated) &&
                 previous.UniqueRemoteAddress is { } previousPeer &&

--- a/src/core/Akka.Remote/Artery/AssociationRegistry.cs
+++ b/src/core/Akka.Remote/Artery/AssociationRegistry.cs
@@ -991,6 +991,51 @@ namespace Akka.Remote.Artery
         public long HandshakeGeneration => Interlocked.Read(ref _handshakeGeneration);
 
         /// <summary>
+        /// Stages waiting for this association's handshake to advance, keyed by subscriber so a
+        /// stage can register and deregister exactly its own entry. See
+        /// <see cref="SubscribeHandshakeStateChanged"/>.
+        /// </summary>
+        private readonly ConcurrentDictionary<object, Action> _handshakeListeners = new();
+
+        /// <summary>
+        /// Registers <paramref name="listener"/>, invoked on EVERY completion this association
+        /// records -- either direction -- so a waiting <see cref="OutboundHandshakeStage"/> learns
+        /// about it immediately instead of finding out on its next retry tick (which cost the first
+        /// message on a fresh association up to a full <c>handshake-retry-interval</c>).
+        ///
+        /// <para>
+        /// Firing on BOTH directions, rather than only on <see cref="CompleteOutboundHandshake"/>,
+        /// is deliberate and safe: this is a "something changed, re-check" nudge, and every
+        /// subscriber re-verifies the association state against its OWN completion rule before
+        /// acting (<c>OutboundHandshakeStage.RefreshCompletionFromContext</c>). A wake that does not
+        /// satisfy that rule -- an inbound Req while an ordinary stream waits for its Rsp, or a
+        /// completion belonging to a NEWER incarnation than the subscriber registered against --
+        /// leaves the subscriber exactly as it was. The broader trigger costs one no-op callback and
+        /// removes the same latency for the control stream and for reconnects.
+        /// </para>
+        ///
+        /// <para>
+        /// Listeners are invoked on whichever thread completed the handshake (an inbound stream's
+        /// thread) and MUST NOT throw or block -- the only production subscriber hands over via
+        /// <c>GraphStageLogic.GetAsyncCallback</c>, which merely enqueues to the subscriber's own
+        /// interpreter (and is a documented no-op once that stage has stopped).
+        /// </para>
+        /// </summary>
+        public void SubscribeHandshakeStateChanged(object subscriber, Action listener) =>
+            _handshakeListeners[subscriber] = listener;
+
+        /// <summary>Reverses <see cref="SubscribeHandshakeStateChanged"/>. Unknown keys are ignored.</summary>
+        public void UnsubscribeHandshakeStateChanged(object subscriber) =>
+            _handshakeListeners.TryRemove(subscriber, out _);
+
+        /// <summary>
+        /// Number of live <see cref="SubscribeHandshakeStateChanged"/> subscribers. Exposed so a
+        /// test can assert that a stopped stream leaves no registration behind -- outbound streams
+        /// are restarted repeatedly against an association that outlives them.
+        /// </summary>
+        public int HandshakeListenerCount => _handshakeListeners.Count;
+
+        /// <summary>
         /// CAS loop applying <see cref="AssociationState.CompleteHandshake"/>. Returns both the
         /// snapshot immediately before this call's effective transition and the resulting
         /// snapshot, so <see cref="AssociationRegistry"/> can tell — without a separate,
@@ -1019,11 +1064,30 @@ namespace Akka.Remote.Artery
                 var updated = transition(current, peer);
 
                 if (ReferenceEquals(updated, current))
+                {
+                    // A no-op on the SNAPSHOT is still an event: the generation counter advanced,
+                    // and that is precisely what a restarted (ForceReqOnStart) stream waits for.
+                    NotifyHandshakeStateChanged();
                     return (current, current);
+                }
 
                 if (Interlocked.CompareExchange(ref _state, updated, current) == current)
+                {
+                    NotifyHandshakeStateChanged();
                     return (current, updated);
+                }
             }
+        }
+
+        /// <summary>
+        /// Nudges every <see cref="SubscribeHandshakeStateChanged"/> subscriber. Called AFTER the
+        /// state swap and the generation increment, so a woken subscriber always reads the snapshot
+        /// the notification belongs to.
+        /// </summary>
+        private void NotifyHandshakeStateChanged()
+        {
+            foreach (var listener in _handshakeListeners.Values)
+                listener();
         }
 
         /// <summary>

--- a/src/core/Akka.Remote/Artery/AssociationState.cs
+++ b/src/core/Akka.Remote/Artery/AssociationState.cs
@@ -34,8 +34,17 @@ namespace Akka.Remote.Artery
     /// explicit <see cref="Quarantine"/> call does that, and only for the <em>current</em> uid
     /// (a stale-uid quarantine request is ignored).
     /// </para>
+    /// <para>
+    /// <b>Compare snapshots by REFERENCE, never with <c>==</c>/<see cref="object.Equals(object)"/>.</b>
+    /// Being a record, this type has compiler-generated value equality — which is shallow over
+    /// <see cref="QuarantinedUids"/> (<see cref="ImmutableHashSet{T}"/> does not define structural
+    /// equality) and therefore means nothing useful here. Every caller that matters is asking
+    /// "is this the SAME snapshot I already had?", which is exactly what the transition methods
+    /// promise by returning <c>this</c> unchanged on a no-op, and what the CAS loops in
+    /// <see cref="Association"/> rely on.
+    /// </para>
     /// </summary>
-    internal sealed class AssociationState
+    internal sealed record AssociationState
     {
         private AssociationState(
             int incarnation,
@@ -61,13 +70,13 @@ namespace Akka.Remote.Artery
         /// <see cref="CompleteHandshake"/> observes a peer UID different from the current one
         /// (the remote system restarted under the same address).
         /// </summary>
-        public int Incarnation { get; }
+        public int Incarnation { get; init; }
 
         /// <summary>
         /// The peer's address + UID once the handshake has completed at least once for this
         /// incarnation; <c>null</c> while <c>Associating</c> (UID unknown).
         /// </summary>
-        public UniqueAddress? UniqueRemoteAddress { get; }
+        public UniqueAddress? UniqueRemoteAddress { get; init; }
 
         /// <summary>
         /// Whether THIS side's own <see cref="HandshakeReq"/> has been answered for the CURRENT
@@ -77,14 +86,14 @@ namespace Akka.Remote.Artery
         /// direction (the peer's own Req) sets that field too, and knowing the peer's uid says
         /// nothing about whether the peer knows OURS (issue #8496).
         /// </summary>
-        public bool OutboundHandshakeCompleted { get; }
+        public bool OutboundHandshakeCompleted { get; init; }
 
         /// <summary>
         /// The set of peer UIDs (for this association's remote address) that have been
         /// explicitly quarantined. A uid change alone does not add the superseded uid here —
         /// see the type-level remarks.
         /// </summary>
-        public ImmutableHashSet<long> QuarantinedUids { get; }
+        public ImmutableHashSet<long> QuarantinedUids { get; init; }
 
         /// <summary>
         /// Whether <paramref name="uid"/> has been quarantined.
@@ -117,16 +126,29 @@ namespace Akka.Remote.Artery
             {
                 if (current.Uid == peer.Uid)
                 {
+                    // Returning THIS (not a `with` copy) is load-bearing: the CAS loops in
+                    // Association detect "nothing to publish" by reference.
                     if (!answeredOurReq || OutboundHandshakeCompleted)
                         return this;
 
-                    return new AssociationState(Incarnation, peer, outboundHandshakeCompleted: true, QuarantinedUids);
+                    return this with { OutboundHandshakeCompleted = true };
                 }
 
-                return new AssociationState(Incarnation + 1, peer, answeredOurReq, QuarantinedUids);
+                // A different uid is a new incarnation; QuarantinedUids carries over untouched,
+                // which is what `with` does for every field this transition does not name.
+                return this with
+                {
+                    Incarnation = Incarnation + 1,
+                    UniqueRemoteAddress = peer,
+                    OutboundHandshakeCompleted = answeredOurReq
+                };
             }
 
-            return new AssociationState(Incarnation, peer, answeredOurReq, QuarantinedUids);
+            return this with
+            {
+                UniqueRemoteAddress = peer,
+                OutboundHandshakeCompleted = answeredOurReq
+            };
         }
 
         /// <summary>
@@ -147,7 +169,11 @@ namespace Akka.Remote.Artery
 
             // OutboundHandshakeCompleted is cleared with the incarnation it describes: this uid is
             // cut off, so no later stream may trust "the peer knows us" on its behalf.
-            return (new AssociationState(Incarnation, UniqueRemoteAddress, outboundHandshakeCompleted: false, QuarantinedUids.Add(uid)), true);
+            return (this with
+            {
+                OutboundHandshakeCompleted = false,
+                QuarantinedUids = QuarantinedUids.Add(uid)
+            }, true);
         }
     }
 }

--- a/src/core/Akka.Remote/Artery/AssociationState.cs
+++ b/src/core/Akka.Remote/Artery/AssociationState.cs
@@ -37,18 +37,24 @@ namespace Akka.Remote.Artery
     /// </summary>
     internal sealed class AssociationState
     {
-        private AssociationState(int incarnation, UniqueAddress? uniqueRemoteAddress, ImmutableHashSet<long> quarantinedUids)
+        private AssociationState(
+            int incarnation,
+            UniqueAddress? uniqueRemoteAddress,
+            bool outboundHandshakeCompleted,
+            ImmutableHashSet<long> quarantinedUids)
         {
             Incarnation = incarnation;
             UniqueRemoteAddress = uniqueRemoteAddress;
+            OutboundHandshakeCompleted = outboundHandshakeCompleted;
             QuarantinedUids = quarantinedUids;
         }
 
         /// <summary>
         /// The initial state for a freshly-materialized association: no peer UID known yet
-        /// (<c>Associating</c>), incarnation 1, no quarantined UIDs.
+        /// (<c>Associating</c>), incarnation 1, our own handshake unanswered, no quarantined UIDs.
         /// </summary>
-        public static AssociationState Create() => new(incarnation: 1, uniqueRemoteAddress: null, quarantinedUids: ImmutableHashSet<long>.Empty);
+        public static AssociationState Create() =>
+            new(incarnation: 1, uniqueRemoteAddress: null, outboundHandshakeCompleted: false, quarantinedUids: ImmutableHashSet<long>.Empty);
 
         /// <summary>
         /// Monotonically increasing incarnation counter. Starts at 1; incremented only when
@@ -62,6 +68,16 @@ namespace Akka.Remote.Artery
         /// incarnation; <c>null</c> while <c>Associating</c> (UID unknown).
         /// </summary>
         public UniqueAddress? UniqueRemoteAddress { get; }
+
+        /// <summary>
+        /// Whether THIS side's own <see cref="HandshakeReq"/> has been answered for the CURRENT
+        /// incarnation. Set ONLY by <see cref="CompleteOutboundHandshake"/>; a uid change resets it
+        /// and <see cref="Quarantine"/> clears it, so it never outlives the incarnation it
+        /// describes. <see cref="UniqueRemoteAddress"/> cannot stand in for it: the inbound
+        /// direction (the peer's own Req) sets that field too, and knowing the peer's uid says
+        /// nothing about whether the peer knows OURS (issue #8496).
+        /// </summary>
+        public bool OutboundHandshakeCompleted { get; }
 
         /// <summary>
         /// The set of peer UIDs (for this association's remote address) that have been
@@ -80,21 +96,37 @@ namespace Akka.Remote.Artery
         /// with <paramref name="peer"/>:
         /// <list type="bullet">
         /// <item><description><c>Associating</c> → <c>Associated</c>: adopts <paramref name="peer"/>, incarnation unchanged.</description></item>
-        /// <item><description>Same uid as the current <see cref="UniqueRemoteAddress"/>: no-op — returns <c>this</c> (reference-equal, so the CAS loop in <see cref="Association"/> can skip the compare-exchange).</description></item>
+        /// <item><description>Same uid as the current <see cref="UniqueRemoteAddress"/>: no-op — returns <c>this</c> (reference-equal, so the CAS loop in <see cref="Association"/> can skip the compare-exchange), except for the one-way <see cref="OutboundHandshakeCompleted"/> flip in <see cref="CompleteOutboundHandshake"/>.</description></item>
         /// <item><description>Different uid (remote restart): a new incarnation — <see cref="Incarnation"/> + 1, <see cref="UniqueRemoteAddress"/> replaced, <see cref="QuarantinedUids"/> carried over UNCHANGED (the old uid is deliberately not auto-quarantined).</description></item>
         /// </list>
         /// </summary>
-        public AssociationState CompleteHandshake(UniqueAddress peer)
+        public AssociationState CompleteHandshake(UniqueAddress peer) => Apply(peer, answeredOurReq: false);
+
+        /// <summary>
+        /// As <see cref="CompleteHandshake"/>, but for the ONE event that proves the peer has
+        /// registered our uid: a <see cref="HandshakeRsp"/>, which a peer only sends after handling
+        /// a <see cref="HandshakeReq"/> of ours. Sets <see cref="OutboundHandshakeCompleted"/> --
+        /// nothing else does. A same-uid call that only flips that flag still returns a NEW
+        /// snapshot (it is a real transition, not the documented no-op).
+        /// </summary>
+        public AssociationState CompleteOutboundHandshake(UniqueAddress peer) => Apply(peer, answeredOurReq: true);
+
+        private AssociationState Apply(UniqueAddress peer, bool answeredOurReq)
         {
             if (UniqueRemoteAddress is { } current)
             {
                 if (current.Uid == peer.Uid)
-                    return this;
+                {
+                    if (!answeredOurReq || OutboundHandshakeCompleted)
+                        return this;
 
-                return new AssociationState(Incarnation + 1, peer, QuarantinedUids);
+                    return new AssociationState(Incarnation, peer, outboundHandshakeCompleted: true, QuarantinedUids);
+                }
+
+                return new AssociationState(Incarnation + 1, peer, answeredOurReq, QuarantinedUids);
             }
 
-            return new AssociationState(Incarnation, peer, QuarantinedUids);
+            return new AssociationState(Incarnation, peer, answeredOurReq, QuarantinedUids);
         }
 
         /// <summary>
@@ -113,7 +145,9 @@ namespace Akka.Remote.Artery
             if (QuarantinedUids.Contains(uid))
                 return (this, true);
 
-            return (new AssociationState(Incarnation, UniqueRemoteAddress, QuarantinedUids.Add(uid)), true);
+            // OutboundHandshakeCompleted is cleared with the incarnation it describes: this uid is
+            // cut off, so no later stream may trust "the peer knows us" on its behalf.
+            return (new AssociationState(Incarnation, UniqueRemoteAddress, outboundHandshakeCompleted: false, QuarantinedUids.Add(uid)), true);
         }
     }
 }

--- a/src/core/Akka.Remote/Artery/IInboundContext.cs
+++ b/src/core/Akka.Remote/Artery/IInboundContext.cs
@@ -48,6 +48,15 @@ namespace Akka.Remote.Artery
         AssociationState CompleteHandshake(UniqueAddress peer);
 
         /// <summary>
+        /// As <see cref="CompleteHandshake"/>, but for a <see cref="HandshakeRsp"/> -- which the
+        /// peer only sends after registering the uid in a <see cref="HandshakeReq"/> of OURS. This
+        /// is the only call that records <see cref="AssociationState.OutboundHandshakeCompleted"/>,
+        /// the signal an ordinary/large outbound stream needs before releasing user traffic
+        /// (issue #8496).
+        /// </summary>
+        AssociationState CompleteOutboundHandshake(UniqueAddress peer);
+
+        /// <summary>
         /// Sends <paramref name="message"/> over the control channel to <paramref name="to"/>.
         /// Used by <see cref="InboundHandshakeStage"/> to reply with a <see cref="HandshakeRsp"/>.
         /// </summary>
@@ -128,6 +137,9 @@ namespace Akka.Remote.Artery
 
         /// <inheritdoc/>
         public AssociationState CompleteHandshake(UniqueAddress peer) => _registry.CompleteHandshake(peer.Address, peer);
+
+        /// <inheritdoc/>
+        public AssociationState CompleteOutboundHandshake(UniqueAddress peer) => _registry.CompleteOutboundHandshake(peer.Address, peer);
 
         /// <inheritdoc/>
         public void SendControl(Address to, object message) => _sendControl(to, message);

--- a/src/core/Akka.Remote/Artery/IOutboundContext.cs
+++ b/src/core/Akka.Remote/Artery/IOutboundContext.cs
@@ -61,6 +61,17 @@ namespace Akka.Remote.Artery
         AssociationState CompleteHandshake(UniqueAddress peer);
 
         /// <summary>
+        /// Registers <paramref name="listener"/> to be nudged whenever this association's handshake
+        /// state advances -- see <see cref="Artery.Association.SubscribeHandshakeStateChanged"/>.
+        /// This is how <see cref="OutboundHandshakeStage"/> learns about completion; the retry timer
+        /// only retransmits the <see cref="HandshakeReq"/>, it is not the detection path.
+        /// </summary>
+        void SubscribeHandshakeStateChanged(object subscriber, Action listener);
+
+        /// <summary>Reverses <see cref="SubscribeHandshakeStateChanged"/>.</summary>
+        void UnsubscribeHandshakeStateChanged(object subscriber);
+
+        /// <summary>
         /// Sends <paramref name="message"/> over the control channel to the remote peer this
         /// context is bound to.
         /// </summary>
@@ -152,6 +163,14 @@ namespace Akka.Remote.Artery
 
         /// <inheritdoc/>
         public AssociationState CompleteHandshake(UniqueAddress peer) => _registry.CompleteHandshake(RemoteAddress, peer);
+
+        /// <inheritdoc/>
+        public void SubscribeHandshakeStateChanged(object subscriber, Action listener) =>
+            _registry.AssociationFor(RemoteAddress).SubscribeHandshakeStateChanged(subscriber, listener);
+
+        /// <inheritdoc/>
+        public void UnsubscribeHandshakeStateChanged(object subscriber) =>
+            _registry.AssociationFor(RemoteAddress).UnsubscribeHandshakeStateChanged(subscriber);
 
         /// <inheritdoc/>
         public void SendControl(object message) => _sendControl(message);

--- a/src/core/Akka.Remote/Artery/InboundHandshakeStage.cs
+++ b/src/core/Akka.Remote/Artery/InboundHandshakeStage.cs
@@ -83,13 +83,28 @@ namespace Akka.Remote.Artery
     /// </summary>
     internal sealed class InboundHandshakeStage : GraphStage<FlowShape<IInboundEnvelope, IInboundEnvelope>>
     {
-        public InboundHandshakeStage(IInboundContext context)
+        /// <param name="context">See <see cref="Context"/>.</param>
+        /// <param name="timeProvider">
+        /// Clock for the unknown-origin drop-warning rate limit -- see <see cref="TimeProvider"/>.
+        /// <see langword="null"/> (the default) resolves to the materializing
+        /// <see cref="Akka.Actor.ActorSystem"/>'s scheduler when the stream starts.
+        /// </param>
+        public InboundHandshakeStage(IInboundContext context, ITimeProvider? timeProvider = null)
         {
             Context = context;
+            TimeProvider = timeProvider;
             Shape = new FlowShape<IInboundEnvelope, IInboundEnvelope>(In, Out);
         }
 
         public IInboundContext Context { get; }
+
+        /// <summary>
+        /// Explicit clock for the drop-warning throttle, or <see langword="null"/> to use the
+        /// materializing system's scheduler. Typed as the BASE <see cref="ITimeProvider"/> rather
+        /// than <see cref="IScheduler"/> so a virtual clock (<c>TestScheduler</c>) satisfies it and
+        /// a spec can drive the throttle window with <c>Advance</c> instead of waiting it out.
+        /// </summary>
+        public ITimeProvider? TimeProvider { get; }
 
         public Inlet<IInboundEnvelope> In { get; } = new("InboundHandshake.in");
         public Outlet<IInboundEnvelope> Out { get; } = new("InboundHandshake.out");
@@ -109,8 +124,17 @@ namespace Akka.Remote.Artery
             private static readonly TimeSpan UnknownOriginWarnInterval = TimeSpan.FromSeconds(10);
 
             private readonly InboundHandshakeStage _stage;
-            private DateTime _lastUnknownOriginWarning = DateTime.MinValue;
+            /// <summary>
+            /// Clock reading at the last warning; <see langword="null"/> until the first one.
+            /// Read via <see cref="ITimeProvider.Now"/> -- the only reading <c>TestScheduler</c>
+            /// virtualizes, so this is what makes the window testable without real waiting.
+            /// </summary>
+            private DateTimeOffset? _lastUnknownOriginWarning;
+
             private long _suppressedUnknownOriginDrops;
+
+            /// <summary>Resolved once at <see cref="PreStart"/>; see <see cref="InboundHandshakeStage.TimeProvider"/>.</summary>
+            private ITimeProvider _timeProvider = null!;
 
             public Logic(InboundHandshakeStage stage) : base(stage.Shape)
             {
@@ -118,6 +142,13 @@ namespace Akka.Remote.Artery
                 SetHandler(stage.In, this);
                 SetHandler(stage.Out, this);
             }
+
+            public override void PreStart() =>
+                _timeProvider = _stage.TimeProvider
+                                ?? (Materializer as ActorMaterializer)?.System.Scheduler
+                                ?? throw new InvalidOperationException(
+                                    "No ITimeProvider available: this stream was not materialized " +
+                                    "by an ActorMaterializer, so pass one to the stage explicitly.");
 
             public void OnPush()
             {
@@ -148,9 +179,9 @@ namespace Akka.Remote.Artery
 
                 if (!_stage.Context.IsKnownOrigin(envelope.OriginUid))
                 {
-                    var now = DateTime.UtcNow;
-                    if (_lastUnknownOriginWarning == DateTime.MinValue ||
-                        now - _lastUnknownOriginWarning >= UnknownOriginWarnInterval)
+                    var now = _timeProvider.Now;
+                    if (_lastUnknownOriginWarning is not { } lastWarning ||
+                        now - lastWarning >= UnknownOriginWarnInterval)
                     {
                         Log.Warning(
                             "Dropping inbound message [{0}] from unknown origin uid [{1}]: no completed handshake for this uid yet. " +

--- a/src/core/Akka.Remote/Artery/InboundHandshakeStage.cs
+++ b/src/core/Akka.Remote/Artery/InboundHandshakeStage.cs
@@ -38,11 +38,19 @@ namespace Akka.Remote.Artery
     /// — a lookup against the SHARED <see cref="AssociationRegistry"/> keyed by the envelope's own
     /// <see cref="IInboundEnvelope.OriginUid"/> (always present in the decoded header, regardless
     /// of which connection/stream carried the envelope). This is safe because the SENDING side's
-    /// <see cref="OutboundHandshakeStage"/> holds all ordinary/large traffic behind its own
-    /// handshake-completion gate, which — by construction — cannot complete before the RECEIVING
-    /// side has already processed the peer's <see cref="HandshakeReq"/> (registering the uid) and
-    /// sent its <see cref="HandshakeRsp"/>. So by the time a receiver's ordinary connection ever
-    /// delivers a real user envelope for some uid, that uid is already registered.
+    /// <see cref="OutboundHandshakeStage"/> holds all ordinary/large traffic until a
+    /// <see cref="HandshakeRsp"/> answers a <see cref="HandshakeReq"/> of ITS OWN — and the only
+    /// thing that sends a Rsp is <c>HandleReq</c> below, immediately after it registers the
+    /// requester's uid. So by the time a sender releases its first ordinary envelope, this side has
+    /// already registered that sender's uid.
+    ///
+    /// <para>
+    /// That construction does NOT follow from the sender merely having an association with a known
+    /// <see cref="AssociationState.UniqueRemoteAddress"/> — our own <see cref="HandshakeReq"/> sets
+    /// that field on the sender, and it tells the sender nothing about whether WE know its uid. The
+    /// outbound stage used to shortcut on exactly that (issue #8496); see
+    /// <see cref="AssociationState.OutboundHandshakeCompleted"/>.
+    /// </para>
     /// </para>
     ///
     /// <list type="bullet">
@@ -67,8 +75,9 @@ namespace Akka.Remote.Artery
     /// <see cref="IControlMessageSubscriber"/>s.
     /// </description></item>
     /// <item><description>
-    /// Any ordinary (non-control) envelope: dropped with a debug log while the origin is unknown;
-    /// passed through once known (per the registry-based check above).
+    /// Any ordinary (non-control) envelope: dropped while the origin is unknown — with a
+    /// rate-limited WARNING, since that drop is unrecoverable loss (ordinary messages are never
+    /// resent); passed through once known (per the registry-based check above).
     /// </description></item>
     /// </list>
     /// </summary>
@@ -91,7 +100,17 @@ namespace Akka.Remote.Artery
 
         private sealed class Logic : GraphStageLogic, IInHandler, IOutHandler
         {
+            /// <summary>
+            /// Minimum gap between unknown-origin drop warnings on this connection: the drop is
+            /// unrecoverable loss and must be visible, but a peer that restarted mid-flight can
+            /// produce a burst of them, so the rest are folded into a suppressed count. No
+            /// synchronization -- the stream runs one stage callback at a time.
+            /// </summary>
+            private static readonly TimeSpan UnknownOriginWarnInterval = TimeSpan.FromSeconds(10);
+
             private readonly InboundHandshakeStage _stage;
+            private DateTime _lastUnknownOriginWarning = DateTime.MinValue;
+            private long _suppressedUnknownOriginDrops;
 
             public Logic(InboundHandshakeStage stage) : base(stage.Shape)
             {
@@ -129,9 +148,22 @@ namespace Akka.Remote.Artery
 
                 if (!_stage.Context.IsKnownOrigin(envelope.OriginUid))
                 {
-                    Log.Debug(
-                        "Dropping inbound message [{0}] from unknown origin uid [{1}] (no completed handshake for this uid yet).",
-                        envelope.Message.GetType(), envelope.OriginUid);
+                    var now = DateTime.UtcNow;
+                    if (_lastUnknownOriginWarning == DateTime.MinValue ||
+                        now - _lastUnknownOriginWarning >= UnknownOriginWarnInterval)
+                    {
+                        Log.Warning(
+                            "Dropping inbound message [{0}] from unknown origin uid [{1}]: no completed handshake for this uid yet. " +
+                            "The message is LOST - ordinary messages are not resent. [{2}] further drop(s) suppressed since the last warning.",
+                            envelope.Message.GetType(), envelope.OriginUid, _suppressedUnknownOriginDrops);
+                        _lastUnknownOriginWarning = now;
+                        _suppressedUnknownOriginDrops = 0;
+                    }
+                    else
+                    {
+                        _suppressedUnknownOriginDrops++;
+                    }
+
                     Pull(_stage.In);
                     return;
                 }
@@ -161,7 +193,11 @@ namespace Akka.Remote.Artery
                 _stage.Context.SendControl(req.From.Address, new HandshakeRsp(_stage.Context.LocalAddress));
             }
 
-            private void HandleRsp(HandshakeRsp rsp) => _stage.Context.CompleteHandshake(rsp.From);
+            // CompleteOutboundHandshake, not CompleteHandshake: a Rsp is the only proof that the
+            // peer has registered OUR uid, which is what gates our ordinary outbound streams
+            // (issue #8496). Re-completing with the same uid stays an idempotent no-op, so the
+            // duplicate Rsps our own idempotent Req retries produce cost nothing.
+            private void HandleRsp(HandshakeRsp rsp) => _stage.Context.CompleteOutboundHandshake(rsp.From);
         }
     }
 }

--- a/src/core/Akka.Remote/Artery/OutboundHandshakeStage.cs
+++ b/src/core/Akka.Remote/Artery/OutboundHandshakeStage.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using System;
+using Akka.Event;
 using Akka.Streams;
 using Akka.Streams.Stage;
 
@@ -62,6 +63,11 @@ namespace Akka.Remote.Artery
     /// time, ~1s has just passed") — the task explicitly sanctions exactly this simplification
     /// ("track last-injection time; if a message flows and it's been &gt; inject-handshake-interval
     /// since the last injection, inject another ahead of it").</para>
+    ///
+    /// <para><b>Completion means "the PEER knows OUR uid" (issue #8496)</b> -- proven only by a
+    /// <see cref="HandshakeRsp"/> answering a <see cref="HandshakeReq"/> of ours, not by
+    /// <see cref="Artery.AssociationState.UniqueRemoteAddress"/> (which the INBOUND direction sets
+    /// too). See <c>Logic.CanSkipOwnHandshake</c>.</para>
     ///
     /// <para><b>Control-channel routing (task group 6, "Control Stream", task 6.3).</b> This
     /// SAME stage class is materialized on EVERY outbound stream (control, ordinary, and later
@@ -154,7 +160,8 @@ namespace Akka.Remote.Artery
         /// is an idempotent no-op (see <see cref="Artery.AssociationState.CompleteHandshake"/>) — it
         /// only costs one extra round trip. The G2 fast path is preserved for a stream's FIRST-ever
         /// materialization (<see langword="false"/>, the default), where "another stream on this
-        /// same association already completed the handshake" is a legitimate, still-current signal.
+        /// same association already completed OUR OWN handshake" is a legitimate, still-current
+        /// signal -- see <c>Logic.CanSkipOwnHandshake</c> for what counts as that, post-#8496.
         /// </para>
         /// </summary>
         public bool ForceReqOnStart { get; }
@@ -195,13 +202,23 @@ namespace Akka.Remote.Artery
 
             public override void PreStart()
             {
-                if (!_stage.ForceReqOnStart &&
-                    _stage.Context.AssociationState.UniqueRemoteAddress is { } already &&
-                    Equals(already.Address, _stage.Context.RemoteAddress))
+                var state = _stage.Context.AssociationState;
+
+                if (!_stage.ForceReqOnStart && CanSkipOwnHandshake(state))
                 {
                     _state = State.Completed;
                     _lastInject = DateTime.UtcNow;
                     return;
+                }
+
+                if (!_stage.ForceReqOnStart && !_stage.IsControlStream && !state.OutboundHandshakeCompleted &&
+                    state.UniqueRemoteAddress is not null)
+                {
+                    // Issue #8496's ordering, named so it is recognizable in the field.
+                    Log.Debug(
+                        "Outbound Artery stream to [{0}]: the peer's uid is known from an INBOUND handshake only, " +
+                        "so this stream sends its own HandshakeReq and holds traffic until the peer answers.",
+                        _stage.Context.RemoteAddress);
                 }
 
                 _handshakeGenerationBaseline = _stage.Context.HandshakeGeneration;
@@ -209,6 +226,36 @@ namespace Akka.Remote.Artery
                 ScheduleRepeatedly(RetryTimerKey, _stage.RetryInterval);
                 ScheduleOnce(TimeoutTimerKey, _stage.HandshakeTimeout);
             }
+
+            /// <summary>
+            /// May this materialization skip straight to <c>Completed</c> because another stream on
+            /// the same association already did the work?
+            ///
+            /// <para>
+            /// For an ORDINARY/LARGE/lane stream, only when the peer has answered a
+            /// <see cref="HandshakeReq"/> of OURS
+            /// (<see cref="Artery.AssociationState.OutboundHandshakeCompleted"/>). A known
+            /// <see cref="Artery.AssociationState.UniqueRemoteAddress"/> does not qualify -- the
+            /// peer's own inbound Req sets that, and it says nothing about whether the peer has
+            /// registered our uid, so trusting it let our first user message race our
+            /// <see cref="HandshakeRsp"/> into the peer's unknown-origin drop (issue #8496).
+            /// </para>
+            ///
+            /// <para>
+            /// The CONTROL stream keeps the older, weaker rule. That is safe -- the receiver's
+            /// unknown-origin gate only ever drops ORDINARY envelopes; every control envelope
+            /// (handshake, heartbeat, quarantine notice, system messages and their Ack/Nack) is
+            /// dispatched whether or not the origin uid is registered. And it is REQUIRED: the
+            /// <see cref="HandshakeRsp"/> we owe a peer is enqueued on that very control queue, so
+            /// if the control stream held its traffic until the peer answered OUR Req, two systems
+            /// that dial each other at the same instant would each sit holding the Rsp the other is
+            /// waiting for, and neither handshake could ever complete.
+            /// </para>
+            /// </summary>
+            private bool CanSkipOwnHandshake(AssociationState state) =>
+                state.UniqueRemoteAddress is { } already &&
+                Equals(already.Address, _stage.Context.RemoteAddress) &&
+                (_stage.IsControlStream || state.OutboundHandshakeCompleted);
 
             public void OnPull()
             {
@@ -332,8 +379,17 @@ namespace Akka.Remote.Artery
                 if (_state == State.Completed)
                     return;
 
-                if (_stage.Context.AssociationState.UniqueRemoteAddress is not { } remote ||
+                var state = _stage.Context.AssociationState;
+
+                if (state.UniqueRemoteAddress is not { } remote ||
                     !Equals(remote.Address, _stage.Context.RemoteAddress))
+                    return;
+
+                // Same control/ordinary split as CanSkipOwnHandshake, and load-bearing here too:
+                // the generation counter below is advanced by the peer's own inbound Req as well,
+                // so without this an ordinary stream would complete on the peer's Req retry that
+                // happens to land while we wait for our Rsp -- issue #8496 through the back door.
+                if (!_stage.IsControlStream && !state.OutboundHandshakeCompleted)
                     return;
 
                 // A materialization that reached ReqInProgress (either its own first-ever

--- a/src/core/Akka.Remote/Artery/OutboundHandshakeStage.cs
+++ b/src/core/Akka.Remote/Artery/OutboundHandshakeStage.cs
@@ -35,22 +35,27 @@ namespace Akka.Remote.Artery
     /// retry timer resends the <see cref="HandshakeReq"/> at <c>handshake-retry-interval</c>
     /// while incomplete, and a one-shot timeout timer fails the stage with
     /// <see cref="HandshakeTimeoutException"/> after <c>handshake-timeout</c> if the handshake
-    /// never completes (the association is expected to retry the outbound stream).</para>
+    /// never completes (the association is expected to retry the outbound stream). Neither timer
+    /// DETECTS completion -- see the notification-mechanism note below.</para>
     ///
-    /// <para><b>Handshake-completion notification mechanism (chosen &amp; documented, per the
-    /// task).</b> This stage does NOT use a <c>Task</c>/promise or a cross-stage async callback.
-    /// It polls <see cref="IOutboundContext.AssociationState"/> — a lock-free, CAS-published
-    /// snapshot (see <see cref="Artery.AssociationState"/>) that is safe to read from any thread —
-    /// at every event the stage's logic already processes: <c>OnPull</c>, <c>OnPush</c>, and the
-    /// retry timer tick. This works because the SAME <see cref="AssociationRegistry"/> backs both
-    /// this stage's <see cref="IOutboundContext"/> and the peer-facing
-    /// <see cref="AssociationRegistryInboundContext"/> that actually calls
-    /// <see cref="AssociationRegistry.CompleteHandshake"/> when a <see cref="HandshakeRsp"/>
-    /// arrives on the inbound pipeline for the return direction — the state IS the coordination
-    /// primitive, so no separate wakeup channel is needed for correctness. The retry timer (not
-    /// just event-driven polling) bounds the worst-case detection latency to one
-    /// <c>handshake-retry-interval</c> even if the stream is otherwise idle when completion
-    /// happens.</para>
+    /// <para><b>Handshake-completion notification mechanism.</b> Completion is PUSHED to this
+    /// stage, never polled for. On entering <c>ReqInProgress</c> the logic registers a
+    /// <c>GetAsyncCallback</c> with the association
+    /// (<see cref="IOutboundContext.SubscribeHandshakeStateChanged"/>); the inbound pipeline's
+    /// <see cref="AssociationRegistry.CompleteHandshake"/> /
+    /// <see cref="AssociationRegistry.CompleteOutboundHandshake"/> fires it, and the stage
+    /// re-verifies the association snapshot against its own completion rule before releasing
+    /// traffic. The stage still READS the CAS-published <see cref="Artery.AssociationState"/>
+    /// snapshot (safe from any thread) at <c>OnPull</c>/<c>OnPush</c>/the retry tick, but those are
+    /// opportunistic; none of them is the detection path.</para>
+    ///
+    /// <para><b>Why polling was not enough.</b> While the stage holds a user element it stops
+    /// pulling, and it has already pushed nothing, so NOTHING re-enters the logic: no <c>OnPull</c>
+    /// (downstream demand is still outstanding), no <c>OnPush</c>. The only remaining wake-up was
+    /// the retry tick, which made the first message on a freshly-gated association wait up to a
+    /// full <c>handshake-retry-interval</c> (1s by default) after the peer had already answered.
+    /// On a cluster join that is the seed's Welcome to every peer -- measured at ~1.07s versus
+    /// ~0.07s once the wake-up is push-based.</para>
     ///
     /// <para><b><c>inject-handshake-interval</c> (liveness re-injection — simplified per the
     /// task).</b> After completion, the stage tracks the timestamp it last injected a
@@ -176,6 +181,14 @@ namespace Akka.Remote.Artery
         private sealed class Logic : TimerGraphStageLogic, IInHandler, IOutHandler
         {
             private readonly OutboundHandshakeStage _stage;
+
+            /// <summary>
+            /// Non-null exactly while this logic is registered with the association for
+            /// handshake-state notifications (i.e. from <see cref="PreStart"/>'s
+            /// <c>ReqInProgress</c> branch until completion or <see cref="PostStop"/>).
+            /// </summary>
+            private Action? _handshakeStateChangedCallback;
+
             private State _state = State.Start;
             private IOutboundEnvelope? _pendingMessage;
             private DateTime _lastInject = DateTime.MinValue;
@@ -225,6 +238,60 @@ namespace Akka.Remote.Artery
                 _state = State.ReqInProgress;
                 ScheduleRepeatedly(RetryTimerKey, _stage.RetryInterval);
                 ScheduleOnce(TimeoutTimerKey, _stage.HandshakeTimeout);
+
+                // REGISTER, THEN RE-CHECK -- the ordering is load-bearing. A completion landing
+                // between the snapshot read at the top of this method and this registration would
+                // otherwise be missed entirely, and (once this stage is holding an element and has
+                // stopped pulling) nothing would re-enter the logic until the retry tick. Doing the
+                // re-check after registering means such a completion is either seen by the check or
+                // delivered by the callback -- never neither.
+                _handshakeStateChangedCallback = GetAsyncCallback(OnHandshakeStateChanged);
+                _stage.Context.SubscribeHandshakeStateChanged(this, _handshakeStateChangedCallback);
+                RefreshCompletionFromContext();
+            }
+
+            public override void PostStop()
+            {
+                // Streams here are restarted (RestartFlow/ScheduleOutboundRestart) against an
+                // association that long outlives them, so a leaked registration would accumulate.
+                // Invoking an already-stopped stage's async callback is itself harmless -- the
+                // interpreter drops async input for a completed logic -- so this is hygiene, not a
+                // correctness race.
+                UnsubscribeHandshakeStateChanged();
+            }
+
+            private void UnsubscribeHandshakeStateChanged()
+            {
+                if (_handshakeStateChangedCallback is null)
+                    return;
+
+                _handshakeStateChangedCallback = null;
+                _stage.Context.UnsubscribeHandshakeStateChanged(this);
+            }
+
+            /// <summary>
+            /// The association told us its handshake state advanced. Re-verify against THIS
+            /// stream's own completion rule (an ordinary stream waiting for its Rsp is not
+            /// satisfied by the peer's inbound Req, nor by a completion belonging to a newer
+            /// incarnation) and, if we are now complete, release exactly the way the retry-tick
+            /// path used to.
+            /// </summary>
+            private void OnHandshakeStateChanged()
+            {
+                RefreshCompletionFromContext();
+
+                if (_state != State.Completed)
+                    return;
+
+                if (_pendingMessage is { } held && IsAvailable(_stage.Out))
+                {
+                    _pendingMessage = null;
+                    Push(_stage.Out, held);
+                    return;
+                }
+
+                if (_pendingMessage is null && !IsClosed(_stage.In) && !HasBeenPulled(_stage.In))
+                    Pull(_stage.In);
             }
 
             /// <summary>
@@ -407,6 +474,7 @@ namespace Akka.Remote.Artery
                 _state = State.Completed;
                 CancelTimer(RetryTimerKey);
                 CancelTimer(TimeoutTimerKey);
+                UnsubscribeHandshakeStateChanged();
                 _lastInject = DateTime.UtcNow;
             }
 

--- a/src/core/Akka.Remote/Artery/OutboundHandshakeStage.cs
+++ b/src/core/Akka.Remote/Artery/OutboundHandshakeStage.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using System;
+using Akka.Actor;
 using Akka.Event;
 using Akka.Streams;
 using Akka.Streams.Stage;
@@ -36,26 +37,24 @@ namespace Akka.Remote.Artery
     /// while incomplete, and a one-shot timeout timer fails the stage with
     /// <see cref="HandshakeTimeoutException"/> after <c>handshake-timeout</c> if the handshake
     /// never completes (the association is expected to retry the outbound stream). Neither timer
-    /// DETECTS completion -- see the notification-mechanism note below.</para>
+    /// detects completion. See the next note.</para>
     ///
-    /// <para><b>Handshake-completion notification mechanism.</b> Completion is PUSHED to this
-    /// stage, never polled for. On entering <c>ReqInProgress</c> the logic registers a
-    /// <c>GetAsyncCallback</c> with the association
-    /// (<see cref="IOutboundContext.SubscribeHandshakeStateChanged"/>); the inbound pipeline's
-    /// <see cref="AssociationRegistry.CompleteHandshake"/> /
-    /// <see cref="AssociationRegistry.CompleteOutboundHandshake"/> fires it, and the stage
-    /// re-verifies the association snapshot against its own completion rule before releasing
-    /// traffic. The stage still READS the CAS-published <see cref="Artery.AssociationState"/>
-    /// snapshot (safe from any thread) at <c>OnPull</c>/<c>OnPush</c>/the retry tick, but those are
-    /// opportunistic; none of them is the detection path.</para>
+    /// <para><b>How the stage learns that the handshake completed.</b> The association pushes
+    /// the news. On entering <c>ReqInProgress</c> the logic registers a <c>GetAsyncCallback</c>
+    /// with the association (<see cref="IOutboundContext.SubscribeHandshakeStateChanged"/>). The
+    /// inbound pipeline calls <see cref="AssociationRegistry.CompleteHandshake"/> or
+    /// <see cref="AssociationRegistry.CompleteOutboundHandshake"/>, which fires that callback. The
+    /// stage then re-checks the association snapshot against its own completion rule before it
+    /// releases traffic. The stage also reads that snapshot at <c>OnPull</c>, <c>OnPush</c> and the
+    /// retry tick. Those reads are opportunistic. None of them is the detection path.</para>
     ///
-    /// <para><b>Why polling was not enough.</b> While the stage holds a user element it stops
-    /// pulling, and it has already pushed nothing, so NOTHING re-enters the logic: no <c>OnPull</c>
-    /// (downstream demand is still outstanding), no <c>OnPush</c>. The only remaining wake-up was
-    /// the retry tick, which made the first message on a freshly-gated association wait up to a
-    /// full <c>handshake-retry-interval</c> (1s by default) after the peer had already answered.
-    /// On a cluster join that is the seed's Welcome to every peer -- measured at ~1.07s versus
-    /// ~0.07s once the wake-up is push-based.</para>
+    /// <para><b>Why polling is not enough.</b> A gating stage holds one user element and stops
+    /// pulling. It has pushed nothing, so downstream demand is still outstanding. No <c>OnPull</c>
+    /// arrives and no <c>OnPush</c> arrives. That left the retry tick as the only wake-up, so the
+    /// first message on a gated association waited up to one <c>handshake-retry-interval</c>
+    /// (1s by default) after the peer had already answered. On a cluster join that message is the
+    /// seed's Welcome to every peer. Measured join-to-Welcome latency was ~1.07s with polling and
+    /// ~0.07s with the push wake-up.</para>
     ///
     /// <para><b><c>inject-handshake-interval</c> (liveness re-injection — simplified per the
     /// task).</b> After completion, the stage tracks the timestamp it last injected a
@@ -69,10 +68,10 @@ namespace Akka.Remote.Artery
     /// ("track last-injection time; if a message flows and it's been &gt; inject-handshake-interval
     /// since the last injection, inject another ahead of it").</para>
     ///
-    /// <para><b>Completion means "the PEER knows OUR uid" (issue #8496)</b> -- proven only by a
-    /// <see cref="HandshakeRsp"/> answering a <see cref="HandshakeReq"/> of ours, not by
-    /// <see cref="Artery.AssociationState.UniqueRemoteAddress"/> (which the INBOUND direction sets
-    /// too). See <c>Logic.CanSkipOwnHandshake</c>.</para>
+    /// <para><b>What completion means (issue #8496).</b> Completion means the peer knows OUR
+    /// uid. Only a <see cref="HandshakeRsp"/> answering a <see cref="HandshakeReq"/> of ours proves
+    /// that. <see cref="Artery.AssociationState.UniqueRemoteAddress"/> does not: the inbound
+    /// direction sets that field too. See <c>Logic.CanSkipOwnHandshake</c>.</para>
     ///
     /// <para><b>Control-channel routing (task group 6, "Control Stream", task 6.3).</b> This
     /// SAME stage class is materialized on EVERY outbound stream (control, ordinary, and later
@@ -110,7 +109,8 @@ namespace Akka.Remote.Artery
             TimeSpan handshakeTimeout,
             TimeSpan injectHandshakeInterval,
             bool isControlStream = true,
-            bool forceReqOnStart = false)
+            bool forceReqOnStart = false,
+            ITimeProvider? timeProvider = null)
         {
             if (retryInterval <= TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(retryInterval), retryInterval, "must be positive.");
@@ -125,10 +125,20 @@ namespace Akka.Remote.Artery
             InjectHandshakeInterval = injectHandshakeInterval;
             IsControlStream = isControlStream;
             ForceReqOnStart = forceReqOnStart;
+            TimeProvider = timeProvider;
             Shape = new FlowShape<IOutboundEnvelope, IOutboundEnvelope>(In, Out);
         }
 
         public IOutboundContext Context { get; }
+
+        /// <summary>
+        /// Clock for the Req-injection schedule (<c>handshake-retry-interval</c> and
+        /// <c>inject-handshake-interval</c>). <see langword="null"/> resolves to the materializing
+        /// system's scheduler when the stream starts. Typed as the base
+        /// <see cref="ITimeProvider"/> so a virtual clock can drive these intervals in a test.
+        /// </summary>
+        public ITimeProvider? TimeProvider { get; }
+
         public TimeSpan RetryInterval { get; }
         public TimeSpan HandshakeTimeout { get; }
         public TimeSpan InjectHandshakeInterval { get; }
@@ -183,15 +193,27 @@ namespace Akka.Remote.Artery
             private readonly OutboundHandshakeStage _stage;
 
             /// <summary>
-            /// Non-null exactly while this logic is registered with the association for
-            /// handshake-state notifications (i.e. from <see cref="PreStart"/>'s
-            /// <c>ReqInProgress</c> branch until completion or <see cref="PostStop"/>).
+            /// Non-null while this logic is registered with the association for handshake
+            /// notifications: from <see cref="PreStart"/>'s <c>ReqInProgress</c> branch until
+            /// completion or <see cref="PostStop"/>.
             /// </summary>
             private Action? _handshakeStateChangedCallback;
 
             private State _state = State.Start;
             private IOutboundEnvelope? _pendingMessage;
-            private DateTime _lastInject = DateTime.MinValue;
+
+            /// <summary>
+            /// When this logic last injected a <see cref="HandshakeReq"/>; <see langword="null"/>
+            /// until the first one. Every read and write goes through <see cref="_timeProvider"/>,
+            /// so the whole schedule moves together when the clock is virtual.
+            /// </summary>
+            private DateTimeOffset? _lastInject;
+
+            /// <summary>
+            /// Resolved once at <see cref="PreStart"/>: the stage's explicit clock, else the
+            /// materializing system's scheduler.
+            /// </summary>
+            private ITimeProvider _timeProvider = null!;
 
             /// <summary>
             /// Only meaningful when <see cref="OutboundHandshakeStage.ForceReqOnStart"/> -- the
@@ -215,19 +237,29 @@ namespace Akka.Remote.Artery
 
             public override void PreStart()
             {
+                // Resolve the clock before anything stamps _lastInject.
+                _timeProvider = _stage.TimeProvider
+                                ?? (Materializer as ActorMaterializer)?.System.Scheduler
+                                ?? throw new InvalidOperationException(
+                                    "No ITimeProvider available: this stream was not materialized " +
+                                    "by an ActorMaterializer, so pass one to the stage explicitly.");
+
                 var state = _stage.Context.AssociationState;
 
                 if (!_stage.ForceReqOnStart && CanSkipOwnHandshake(state))
                 {
                     _state = State.Completed;
-                    _lastInject = DateTime.UtcNow;
+                    _lastInject = _timeProvider.Now;
                     return;
                 }
 
                 if (!_stage.ForceReqOnStart && !_stage.IsControlStream && !state.OutboundHandshakeCompleted &&
                     state.UniqueRemoteAddress is not null)
                 {
-                    // Issue #8496's ordering, named so it is recognizable in the field.
+                    // This is the issue #8496 ordering. The peer dialed us first, so we know its
+                    // uid from its HandshakeReq. The peer does not know our uid. We send our own
+                    // Req and hold traffic until it answers. Log it, so the ordering is visible in
+                    // production logs.
                     Log.Debug(
                         "Outbound Artery stream to [{0}]: the peer's uid is known from an INBOUND handshake only, " +
                         "so this stream sends its own HandshakeReq and holds traffic until the peer answers.",
@@ -239,12 +271,11 @@ namespace Akka.Remote.Artery
                 ScheduleRepeatedly(RetryTimerKey, _stage.RetryInterval);
                 ScheduleOnce(TimeoutTimerKey, _stage.HandshakeTimeout);
 
-                // REGISTER, THEN RE-CHECK -- the ordering is load-bearing. A completion landing
-                // between the snapshot read at the top of this method and this registration would
-                // otherwise be missed entirely, and (once this stage is holding an element and has
-                // stopped pulling) nothing would re-enter the logic until the retry tick. Doing the
-                // re-check after registering means such a completion is either seen by the check or
-                // delivered by the callback -- never neither.
+                // Register first, then re-check. A completion can land between the snapshot read
+                // at the top of this method and this registration. Registering first means either
+                // the re-check below sees it or the callback delivers it. It cannot fall between
+                // the two. That matters because a gating stage stops pulling, so nothing else
+                // re-enters this logic until the retry tick.
                 _handshakeStateChangedCallback = GetAsyncCallback(OnHandshakeStateChanged);
                 _stage.Context.SubscribeHandshakeStateChanged(this, _handshakeStateChangedCallback);
                 RefreshCompletionFromContext();
@@ -252,11 +283,10 @@ namespace Akka.Remote.Artery
 
             public override void PostStop()
             {
-                // Streams here are restarted (RestartFlow/ScheduleOutboundRestart) against an
-                // association that long outlives them, so a leaked registration would accumulate.
-                // Invoking an already-stopped stage's async callback is itself harmless -- the
-                // interpreter drops async input for a completed logic -- so this is hygiene, not a
-                // correctness race.
+                // Streams restart against an association that outlives them, so a leaked
+                // registration would accumulate. Invoking a stopped stage's async callback is
+                // harmless on its own: the interpreter drops async input for a completed logic.
+                // This is hygiene, not a race fix.
                 UnsubscribeHandshakeStateChanged();
             }
 
@@ -270,11 +300,9 @@ namespace Akka.Remote.Artery
             }
 
             /// <summary>
-            /// The association told us its handshake state advanced. Re-verify against THIS
-            /// stream's own completion rule (an ordinary stream waiting for its Rsp is not
-            /// satisfied by the peer's inbound Req, nor by a completion belonging to a newer
-            /// incarnation) and, if we are now complete, release exactly the way the retry-tick
-            /// path used to.
+            /// The association reports that its handshake state advanced. Re-check that state
+            /// against this stream's own rule. An ordinary stream waiting for its Rsp is not
+            /// satisfied by the peer's inbound Req, nor by a completion for a newer incarnation.
             /// </summary>
             private void OnHandshakeStateChanged()
             {
@@ -283,6 +311,9 @@ namespace Akka.Remote.Artery
                 if (_state != State.Completed)
                     return;
 
+                // If we have a pending user message that has not been sent yet, flush it now
+                // that the handshake is done. This runs from the async callback. This is what
+                // prevents the message loss.
                 if (_pendingMessage is { } held && IsAvailable(_stage.Out))
                 {
                     _pendingMessage = null;
@@ -295,28 +326,33 @@ namespace Akka.Remote.Artery
             }
 
             /// <summary>
-            /// May this materialization skip straight to <c>Completed</c> because another stream on
-            /// the same association already did the work?
+            /// Can this materialization skip the handshake and start out <c>Completed</c>?
             ///
             /// <para>
-            /// For an ORDINARY/LARGE/lane stream, only when the peer has answered a
-            /// <see cref="HandshakeReq"/> of OURS
-            /// (<see cref="Artery.AssociationState.OutboundHandshakeCompleted"/>). A known
-            /// <see cref="Artery.AssociationState.UniqueRemoteAddress"/> does not qualify -- the
-            /// peer's own inbound Req sets that, and it says nothing about whether the peer has
-            /// registered our uid, so trusting it let our first user message race our
-            /// <see cref="HandshakeRsp"/> into the peer's unknown-origin drop (issue #8496).
+            /// If another outbound stream on this association has already handled the handshake, we
+            /// can and must skip it. That covers a sibling lane when <c>outbound-lanes &gt; 1</c>.
+            /// It also covers the control, ordinary and large streams of one association at the
+            /// default single lane, and any later re-materialization of them.
             /// </para>
             ///
             /// <para>
-            /// The CONTROL stream keeps the older, weaker rule. That is safe -- the receiver's
-            /// unknown-origin gate only ever drops ORDINARY envelopes; every control envelope
-            /// (handshake, heartbeat, quarantine notice, system messages and their Ack/Nack) is
-            /// dispatched whether or not the origin uid is registered. And it is REQUIRED: the
-            /// <see cref="HandshakeRsp"/> we owe a peer is enqueued on that very control queue, so
-            /// if the control stream held its traffic until the peer answered OUR Req, two systems
-            /// that dial each other at the same instant would each sit holding the Rsp the other is
-            /// waiting for, and neither handshake could ever complete.
+            /// For an ordinary, large or lane stream, "already handled" means the peer answered a
+            /// <see cref="HandshakeReq"/> of ours
+            /// (<see cref="Artery.AssociationState.OutboundHandshakeCompleted"/>). A known
+            /// <see cref="Artery.AssociationState.UniqueRemoteAddress"/> is not enough. The peer's
+            /// own inbound Req sets that field, and it says nothing about whether the peer
+            /// registered our uid. Trusting it sent our first user message into the peer's
+            /// unknown-origin drop (issue #8496).
+            /// </para>
+            ///
+            /// <para>
+            /// If we are the control stream, we are sending and handling the handshake. Waiting on
+            /// it would deadlock us: the <see cref="HandshakeRsp"/> we owe the peer sits in the
+            /// same control queue we would be gating, so two systems that dial each other at the
+            /// same instant would each hold the Rsp the other waits for. So we skip it. Skipping is
+            /// also safe. The receiver drops unknown-origin ORDINARY envelopes only. It always
+            /// dispatches control envelopes: handshake, heartbeat, quarantine notice, and system
+            /// messages with their Ack/Nack.
             /// </para>
             /// </summary>
             private bool CanSkipOwnHandshake(AssociationState state) =>
@@ -375,7 +411,7 @@ namespace Akka.Remote.Artery
 
                         if (IsAvailable(_stage.Out))
                         {
-                            _lastInject = DateTime.UtcNow;
+                            _lastInject = _timeProvider.Now;
                             Push(_stage.Out, BuildReqEnvelope());
                         }
 
@@ -385,7 +421,7 @@ namespace Akka.Remote.Artery
                     // Non-control stream: the Req travels via the control side channel and never
                     // occupies this stream's Out slot, so the user element can flow through
                     // immediately below -- no need to hold it.
-                    _lastInject = DateTime.UtcNow;
+                    _lastInject = _timeProvider.Now;
                     _stage.Context.SendControl(BuildReqMessage());
                 }
 
@@ -452,10 +488,10 @@ namespace Akka.Remote.Artery
                     !Equals(remote.Address, _stage.Context.RemoteAddress))
                     return;
 
-                // Same control/ordinary split as CanSkipOwnHandshake, and load-bearing here too:
-                // the generation counter below is advanced by the peer's own inbound Req as well,
-                // so without this an ordinary stream would complete on the peer's Req retry that
-                // happens to land while we wait for our Rsp -- issue #8496 through the back door.
+                // If we are not the control stream, we cannot continue until the handshake is
+                // done. The generation counter below also advances on the peer's own inbound Req,
+                // so without this check an ordinary stream would complete on a Req retry that
+                // lands while we wait for our Rsp. That is issue #8496 again.
                 if (!_stage.IsControlStream && !state.OutboundHandshakeCompleted)
                     return;
 
@@ -475,7 +511,7 @@ namespace Akka.Remote.Artery
                 CancelTimer(RetryTimerKey);
                 CancelTimer(TimeoutTimerKey);
                 UnsubscribeHandshakeStateChanged();
-                _lastInject = DateTime.UtcNow;
+                _lastInject = _timeProvider.Now;
             }
 
             private void TryInjectReq()
@@ -483,8 +519,8 @@ namespace Akka.Remote.Artery
                 if (_state == State.Completed)
                     return;
 
-                var now = DateTime.UtcNow;
-                var due = _lastInject == DateTime.MinValue || now - _lastInject >= _stage.RetryInterval;
+                var now = _timeProvider.Now;
+                var due = _lastInject is not { } lastInject || now - lastInject >= _stage.RetryInterval;
                 if (!due)
                     return;
 
@@ -506,8 +542,8 @@ namespace Akka.Remote.Artery
 
             private bool ShouldReinjectForLiveness()
             {
-                var now = DateTime.UtcNow;
-                return _lastInject == DateTime.MinValue || now - _lastInject >= _stage.InjectHandshakeInterval;
+                var now = _timeProvider.Now;
+                return _lastInject is not { } lastInject || now - lastInject >= _stage.InjectHandshakeInterval;
             }
 
             private HandshakeReq BuildReqMessage() => new(_stage.Context.LocalAddress, _stage.Context.RemoteAddress);


### PR DESCRIPTION
Fixes #8496.

**Two commits**: the correctness gate (revised per review feedback to its essential core), and a push-based completion wake-up that replaces the stage's timer-poll detection — added after the gate exposed a pre-existing ~1s detection latency (see below).

## Problem

Artery's receiver drops any ordinary envelope from an unregistered origin uid — safe only if every sender holds ordinary traffic behind its own completed handshake. `OutboundHandshakeStage.PreStart` broke that invariant by treating "this association has a `UniqueRemoteAddress`" as "our handshake is done." That field is also set by the **inbound** direction when we process the peer's `HandshakeReq`, so when the peer dialed us first, our first outbound ordinary stream skipped its own `HandshakeReq`. Our first user message then raced our `HandshakeRsp` — a different TCP connection, no ordering between them — into the peer's unknown-origin gate. Lost races were silent, permanent message loss (ordinary messages have no resend). Three artery MNTR lane failures carried the exact signature; classic is immune because `EndpointWriter` buffers until association.

## Fix

One new fact is tracked: **`AssociationState.OutboundHandshakeCompleted`** — per-incarnation, in the same immutable snapshot as `UniqueRemoteAddress`, set *only* via the new `IInboundContext.CompleteOutboundHandshake`, which only `HandleRsp` calls (a `HandshakeRsp` is only ever sent after the responder registers the requester's uid, so it is proof the peer knows us). Reset on incarnation change, cleared by quarantine.

Consulted at the two places "handshake done" is decided for ordinary/large/lane streams:

- **`PreStart`'s fast path** now requires it. An association born from the peer's inbound handshake falls through to the normal handshake flow — send our Req, hold traffic, existing retry/timeout machinery. Cost: one round trip before the first ordinary message on a peer-opened association.
- **`RefreshCompletionFromContext`** (the in-progress completion check) gets the same 2-line gate. This closes a third door: while our stream holds traffic awaiting its Rsp, the *peer retrying its own `HandshakeReq`* advances the handshake generation and would falsely complete us. An ablation run proves this gate is load-bearing — with it commented out, exactly one test fails (the message releases after 110ms with no Rsp).
- **The control stream keeps the older, weaker rule — deliberately.** Control traffic is dispatched before the receiver's unknown-origin check (never dropped there), and requiring the strict rule would deadlock two simultaneously-dialing peers, each holding the `HandshakeRsp` the other is waiting for. Rationale documented at the decision site.

Also: the unknown-origin drop is raised from silent DEBUG to a **rate-limited WARNING** at both gate sites (inline fields, no new type — first drop immediate, then at most once per 10s with a suppressed count), and the `InboundHandshakeStage` invariant comment now states the real construction. A compact DEBUG line names the #8496 ordering when the corrected path fires, which is what makes the fix observable in soak logs.

No wire-format change, no config change, no public API delta. `ForceReqOnStart` composes unchanged.

## Fail-first

Four of the five tests fail on unfixed dev:

| Test | On unfixed code |
|---|---|
| Stage repro (peer dialed first) | message released in 11µs, zero `HandshakeReq`s sent |
| Peer's-own-Req-retry must not complete us | released while Rsp still outstanding |
| End-to-end peer-dials-first ordering | first message never delivered, 20s timeout |
| Unknown-origin WARNING visible | 0/1 matched |
| Fast-path preservation | passes before and after, as it must |

## Verification (slim version)

| Check | Result |
|---|---|
| `-warnaserror`: Akka.Remote + both test projects | 0 warnings |
| `ArteryPeerDialedFirstSpec` | 5/5, independently replicated |
| Artery unit suite | 269/269 |
| Full `Akka.Remote.Tests` | 668 passed, 0 failed |
| `Akka.API.Tests` | 18/18, no approval delta |
| MNTR `AttemptSysMsgRedeliverySpec` artery/classic | 4/4 and 2/2; the #8496 ordering occurred 1–2× per round, zero unknown-origin drops |

Caveat as before: fast loopback lets pre-fix code pass the MNTR soak (the Rsp wins the race locally), so the soak is no-regression evidence plus proof the corrected path fires; the deterministic proof is the unit/E2E suite. Across the earlier full-matrix run of the fatter revision, ~2 artery MNTR suites produced **zero** unknown-origin drops.

## The second commit: push-based completion detection

The stage detected handshake completion only by polling on the retry timer (default 1s). The `HandshakeRsp` typically lands in ~1ms, but a held first message waited for the next tick — a pre-existing latency the gate newly exposed on peer-opened associations, where the first held message is often the cluster `Welcome` on a star join. That ~1.1s `Welcome` delay is what made `ReplicatorChaosSpec` fail on this PR's earlier CI runs: peers' replicators silently ignore `WriteAll` writes that arrive before membership lands, and `WriteAll` never re-sends.

Detection is now push, matching the reference stage design: the association keeps a keyed listener registry fired from the CAS transition helper after every state swap; the stage registers a `GetAsyncCallback` on entering `ReqInProgress` (register-then-check, so nothing lands unseen), re-verifies through the existing refresh logic on wake, and releases the held message through the same path a retry-tick release used. Listeners are deregistered on completion and in `PostStop` (hygiene — post-stop invocation is independently safe via the interpreter's stage-completed guard). The retry timer now only retransmits Reqs; the timeout timer still bounds the whole handshake.

Reviewer note on one breadth choice: the notification fires on **every** completion (both directions), not just outbound — every subscriber re-verifies its own condition on wake, so a non-qualifying nudge is a no-op, and the broad trigger also removes the same 1s latency for control-stream and reconnect waits. Narrowing it to outbound-only is a two-line change if preferred.

Fail-first: a release-latency test pins a 30s retry interval so polling cannot pass — it fails on the gate-only commit (`no element signaled during 00:00:03`) and passes with the wake-up. Welcome-latency A/B (Join→Welcome, ReplicatorChaosSpec formation, artery):

| revision | range |
|---|---|
| dev base | 0.062–0.085s |
| gate only | 1.052–1.106s |
| gate + wake-up | **0.063–0.084s** |

`ReplicatorChaosSpec` artery: 5/5 locally on the final branch. Full battery re-run green (`ArteryPeerDialedFirstSpec` 7/7, artery unit suite 271/271, `Akka.Remote.Tests` 670/670, API tests no delta, MNTR AttemptSysMsgRedelivery 4/4 artery + 2/2 classic, `-warnaserror` clean). Branch total vs dev: 349 product lines, 540 test lines.

## Split out

The restart-path variant of the same conflation (`ForceReqOnStart` re-materializations can complete off a generation bump caused by the peer's inbound Req) is real but **not harmful today** — the flag being true guarantees the peer has our uid, so nothing is dropped. Filed separately with a repro sketch rather than carried here.
