### PR TITLE
Wave-3 de-flake: ReplicatorChaosSpec, ClusterShardingLeavingSpec pin, DistributedPubSubRestartSpec baseline

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
@@ -30,6 +30,12 @@ namespace Akka.Cluster.Sharding.Tests
             : base(mode: mode, loglevel: "DEBUG", additionalConfig: @"
             akka.cluster.sharding.verbose-debug-logging = on
             akka.cluster.sharding.rebalance-interval = 1s # make rebalancing more likely to happen to test for https://github.com/akka/akka/issues/29093
+            # This spec asserts that entities on surviving nodes keep the same actor incarnation
+            # across a graceful leave. Only the legacy threshold strategy has that property. The
+            # bounded default may move survivor shards during the leave window, which restarts
+            # their entities under new refs. Pin the legacy strategy so the assertion tests the
+            # algorithm that guarantees it. See issue 8481.
+            akka.cluster.sharding.least-shard-allocation-strategy.rebalance-absolute-limit = 0
             akka.cluster.sharding.distributed-data.majority-min-cap = 1
             akka.cluster.sharding.coordinator-state.write-majority-plus = 1
             akka.cluster.sharding.coordinator-state.read-majority-plus = 1

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
@@ -139,12 +139,10 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
         await ExpectMsgAsync("msg1", 10.Seconds());
         await EnterBarrierAsync("got-msg1");
 
-        // All nodes capture the baseline DeltaCount before node-specific logic. Read it on a
-        // probe with an explicit bound: TestActor is subscribed to topic1, and every later
-        // DeltaCount read already moved off TestActor for that reason.
-        var baselineProbe = CreateTestProbe();
-        Mediator.Tell(DeltaCount.Instance, baselineProbe.Ref);
-        var oldDeltaCount = await baselineProbe.ExpectMsgAsync<long>(5.Seconds());
+        // All nodes capture the baseline DeltaCount before node-specific logic. The baseline must
+        // be read AFTER pub-sub gossip goes quiet, not merely after CountAsync - see the comment on
+        // ReadStableDeltaCountAsync for why those are not the same moment.
+        var oldDeltaCount = await ReadStableDeltaCountAsync();
         await EnterBarrierAsync("old-delta-count");
 
         await RunOnAsync(async () =>
@@ -331,6 +329,56 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
             return Task.CompletedTask;
         }, from);
         await EnterBarrierAsync(from.Name + "-joined");
+    }
+
+    /// <summary>
+    /// Reads the mediator's DeltaCount, but only once the pub-sub gossip that feeds it has
+    /// stopped moving. Returns the settled value.
+    /// </summary>
+    private async Task<long> ReadStableDeltaCountAsync()
+    {
+        // DeltaCount counts Delta MESSAGES received. It does not count registry changes, and the
+        // two diverge badly while a node is still learning the cluster.
+        //
+        // A mediator merges a bucket only if it already knows the bucket's owner as a cluster
+        // member. DistributedPubSubMediator's Delta handler increments _deltaCount first and only
+        // then tests _nodes.Contains(bucket.Owner). So while this node still waits for third's
+        // MemberUp, first pushes third's bucket on every 500ms gossip tick and this node discards
+        // every push - each discarded push still counted. Convergence therefore arrives as a BURST
+        // of Deltas, and redundant ones trail it: a peer keeps re-sending until our next outbound
+        // gossip tells it we caught up.
+        //
+        // CountAsync below unblocks on the FIRST push this node actually merges, so it returns
+        // while that burst is still draining. Reading the baseline right there captures a mid-burst
+        // value and lets the trailing Deltas land after it - which is exactly the reported failure
+        // ("Expected value to be 3L, but found 4L" on second). Measured over 20 local runs the last
+        // Delta arrived only 104-1010ms before the old unguarded read, against a 500ms gossip tick:
+        // one delayed tick flips it.
+        //
+        // So gate the baseline on quiescence instead of reading mid-burst. Two samples 2s apart
+        // must agree. 2s = 4 ticks of this spec's 500ms gossip-interval, which covers our own
+        // outbound tick plus the peer's reaction to it, with slack. The 30s ceiling is
+        // convergence-scale headroom, not a budget to lean on - the gate settles on the second
+        // sample in practice. Fresh probe per sample, matching CountAsync, so a late reply cannot
+        // be mistaken for the next sample.
+        var previous = long.MinValue;
+        var settledValue = 0L;
+        await AwaitAssertAsync(async () =>
+        {
+            var probe = CreateTestProbe();
+            Mediator.Tell(DeltaCount.Instance, probe.Ref);
+            var current = await probe.ExpectMsgAsync<long>(1.Seconds());
+
+            var lastSeen = previous;
+            previous = current;
+            settledValue = current;
+
+            (current == lastSeen).Should().BeTrue(
+                "pub-sub gossip must go quiet before DeltaCount can serve as a baseline " +
+                $"(previous sample {lastSeen}, current sample {current})");
+        }, 30.Seconds(), 2.Seconds());
+
+        return settledValue;
     }
 
     private async Task CountAsync(int expected)

--- a/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/ReplicatorChaosSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/ReplicatorChaosSpec.cs
@@ -6,9 +6,11 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
@@ -56,6 +58,51 @@ namespace Akka.DistributedData.Tests.MultiNode
         public static readonly RoleName Fourth = new("fourth");
         public static readonly RoleName Fifth = new("fifth");
 
+        /// <summary>
+        /// Raw budget for the WriteTo/WriteAll consistency levels used below.
+        /// <see cref="_timeout"/> holds the dilated form. The replicator schedules on real
+        /// time, so the dilation is applied before the value reaches it.
+        /// </summary>
+        private static readonly TimeSpan WriteTimeout = TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        /// Budget for a test-side expect that waits on a WriteTo/WriteAll reply.
+        /// <para>
+        /// A write aggregator answers - UpdateSuccess or UpdateTimeout - no earlier than
+        /// its own deadline, <see cref="WriteTimeout"/>, counted from the moment the
+        /// replicator picks the Update up. That moment is at or after the expect that
+        /// waits for the answer. An unbounded expect inherits
+        /// akka.test.single-expect-default, which is 3s here - the same 3s as
+        /// <see cref="WriteTimeout"/> - so it always expires first. The wait is a dead
+        /// heat with the thing it waits on.
+        /// </para>
+        /// <para>
+        /// Budget = <see cref="WriteTimeout"/>, the aggregator deadline this expect waits
+        /// on, plus one akka.test.single-expect-default (3s) of slack for the local hop
+        /// that carries the answer. 3s is exactly what these expects used to get.
+        /// </para>
+        /// <para>
+        /// Undilated on purpose. TestKit dilates whatever timeout it is handed, so passing
+        /// the already-dilated <see cref="_timeout"/> would dilate twice.
+        /// </para>
+        /// </summary>
+        private static readonly TimeSpan WriteReplyTimeout = WriteTimeout + TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        /// Per-attempt budget inside the AwaitAssert loops below. An unbounded inner
+        /// expect inherits the whole remaining loop budget, so the loop makes one attempt
+        /// and then a useless one - CI logged a final attempt with a 00:00:00.0000044
+        /// budget. 1s per attempt keeps every attempt equal and leaves the loop budget to
+        /// decide how many attempts run.
+        /// </summary>
+        private static readonly TimeSpan AttemptTimeout = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        /// Poll interval for the AwaitAssert loops. Each attempt allocates a fresh probe,
+        /// so keep the attempt count modest.
+        /// </summary>
+        private static readonly TimeSpan AttemptInterval = TimeSpan.FromMilliseconds(500);
+
         private readonly Cluster.Cluster _cluster;
         private readonly IActorRef _replicator;
         private readonly TimeSpan _timeout;
@@ -72,38 +119,58 @@ namespace Akka.DistributedData.Tests.MultiNode
         protected ReplicatorChaosSpec(ReplicatorChaosSpecConfig config) : base(config, typeof(ReplicatorChaosSpec))
         {
             _cluster = Akka.Cluster.Cluster.Get(Sys);
-            _timeout = Dilated(TimeSpan.FromSeconds(3));
+            _timeout = Dilated(WriteTimeout);
             _replicator = Sys.ActorOf(Replicator.Props(ReplicatorSettings.Create(Sys)
                 .WithRole("backend")
                 .WithGossipInterval(TimeSpan.FromSeconds(1))), "replicator");
         }
 
         [MultiNodeFact()]
-        public void ReplicatorChaos_Tests()
+        public async Task ReplicatorChaos_Tests()
         {
-            Replicator_in_chaotic_cluster_should_replicate_data_in_initial_phase();
-            Replicator_in_chaotic_cluster_should_be_available_during_network_split();
-            Replicator_in_chaotic_cluster_should_converge_after_partition();
+            await Replicator_in_chaotic_cluster_should_replicate_data_in_initial_phase();
+            await Replicator_in_chaotic_cluster_should_be_available_during_network_split();
+            await Replicator_in_chaotic_cluster_should_converge_after_partition();
         }
 
-        public void Replicator_in_chaotic_cluster_should_replicate_data_in_initial_phase()
+        public async Task Replicator_in_chaotic_cluster_should_replicate_data_in_initial_phase()
         {
-            Join(First, First);
-            Join(Second, First);
-            Join(Third, First);
-            Join(Fourth, First);
-            Join(Fifth, First);
+            await JoinAsync(First, First);
+            await JoinAsync(Second, First);
+            await JoinAsync(Third, First);
+            await JoinAsync(Fourth, First);
+            await JoinAsync(Fifth, First);
 
-            Within(TimeSpan.FromSeconds(10), () =>
+            // Every node proves its own replicator has seen all five members. ReplicaCount
+            // answers _nodes.Count + 1, and _nodes only holds members the replicator has
+            // already processed a MemberUp for, so ReplicaCount(5) means this replicator
+            // knows every other node.
+            await AwaitAssertAsync(async () =>
             {
-                AwaitAssert(() =>
-                {
-                    _replicator.Tell(Dsl.GetReplicaCount);
-                    ExpectMsg(new ReplicaCount(5));
-                });
-            });
+                // Fresh probe per attempt. A late ReplicaCount from a timed-out attempt
+                // must not be read as this attempt's answer.
+                var probe = CreateTestProbe();
+                _replicator.Tell(Dsl.GetReplicaCount, probe.Ref);
+                await probe.ExpectMsgAsync(new ReplicaCount(5), AttemptTimeout);
+            }, TimeSpan.FromSeconds(10), AttemptInterval);
 
-            RunOn(() =>
+            // The barrier turns the per-node fact above into a global one, and it is
+            // required before any node writes.
+            //
+            // A replicator drops a Write whose sender it does not yet know - it logs
+            // "Ignoring message [Write] from [...] unknown node" - and sends no ack. A
+            // WriteAll update has no re-send path to recover from that: every node is
+            // primary, so SendToSecondary re-sends to nobody, and a GCounter update
+            // carries no delta on the aggregator, so the delta re-send does not run
+            // either. One dropped Write therefore costs the whole update; it can only end
+            // in UpdateTimeout.
+            //
+            // Without this barrier each node starts writing the moment it passes its own
+            // check. CI caught first writing 0.8s before fifth received its Welcome; fifth
+            // ignored all five Writes and every KeyC update timed out.
+            await EnterBarrierAsync("replicas-ready");
+
+            await RunOnAsync(async () =>
             {
                 for (var i = 0; i < 5; i++)
                 {
@@ -111,16 +178,26 @@ namespace Akka.DistributedData.Tests.MultiNode
                     _replicator.Tell(Dsl.Update(KeyB, PNCounter.Empty, WriteLocal.Instance, x => x.Decrement(_cluster, 1)));
                     _replicator.Tell(Dsl.Update(KeyC, GCounter.Empty, new WriteAll(_timeout), x => x.Increment(_cluster, 1)));
                 }
-                ReceiveN(15).Select(x => x.GetType()).ToImmutableHashSet().ShouldBe(new[] { typeof(UpdateSuccess) });
+
+                // Five of these fifteen replies come from WriteAll aggregators, so this
+                // collect needs WriteReplyTimeout - see the note on that field. CI lost
+                // that race by about 70ms. The Tell burst started at 40.136, an unbounded
+                // ReceiveN gave up 00:00:02.9997005 later with "Only got 10", and the
+                // aggregators answered at 43.226. The ten replies it did collect were
+                // exactly the WriteLocal ones, which need no aggregator.
+                var replies = await CollectRepliesAsync(15, WriteReplyTimeout);
+                replies.Select(x => x.GetType()).ToImmutableHashSet().ShouldBe(new[] { typeof(UpdateSuccess) });
             }, First);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 _replicator.Tell(Dsl.Update(KeyA, GCounter.Empty, WriteLocal.Instance, x => x.Increment(_cluster, 20)));
                 _replicator.Tell(Dsl.Update(KeyB, PNCounter.Empty, new WriteTo(2, _timeout), x => x.Increment(_cluster, 20)));
                 _replicator.Tell(Dsl.Update(KeyC, GCounter.Empty, new WriteAll(_timeout), x => x.Increment(_cluster, 20)));
 
-                ReceiveN(3).ToImmutableHashSet().Should().BeEquivalentTo(new[]
+                // Two of these three replies come from write aggregates.
+                var replies = await CollectRepliesAsync(3, WriteReplyTimeout);
+                replies.ToImmutableHashSet().Should().BeEquivalentTo(new[]
                 {
                     new UpdateSuccess(KeyA, null),
                     new UpdateSuccess(KeyB, null),
@@ -128,152 +205,169 @@ namespace Akka.DistributedData.Tests.MultiNode
                 });
 
                 _replicator.Tell(Dsl.Update(KeyE, GSet<string>.Empty, WriteLocal.Instance, x => x.Add("e1").Add("e2")));
-                ExpectMsg(new UpdateSuccess(KeyE, null));
+                await ExpectMsgAsync(new UpdateSuccess(KeyE, null));
 
                 _replicator.Tell(Dsl.Update(KeyF, ORSet<string>.Empty, WriteLocal.Instance, x => x
                     .Add(_cluster, "e1")
                     .Add(_cluster, "e2")));
-                ExpectMsg(new UpdateSuccess(KeyF, null));
+                await ExpectMsgAsync(new UpdateSuccess(KeyF, null));
             }, Second);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 _replicator.Tell(Dsl.Update(KeyD, GCounter.Empty, WriteLocal.Instance, x => x.Increment(_cluster, 40)));
-                ExpectMsg(new UpdateSuccess(KeyD, null));
+                await ExpectMsgAsync(new UpdateSuccess(KeyD, null));
 
                 _replicator.Tell(Dsl.Update(KeyE, GSet<string>.Empty, WriteLocal.Instance, x => x.Add("e2").Add("e3")));
-                ExpectMsg(new UpdateSuccess(KeyE, null));
+                await ExpectMsgAsync(new UpdateSuccess(KeyE, null));
 
                 _replicator.Tell(Dsl.Update(KeyF, ORSet<string>.Empty, WriteLocal.Instance, x => x
                     .Add(_cluster, "e2")
                     .Add(_cluster, "e3")));
-                ExpectMsg(new UpdateSuccess(KeyF, null));
+                await ExpectMsgAsync(new UpdateSuccess(KeyF, null));
             }, Fourth);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 _replicator.Tell(Dsl.Update(KeyX, GCounter.Empty, new WriteTo(2, _timeout), x => x.Increment(_cluster, 50)));
-                ExpectMsg(new UpdateSuccess(KeyX, null));
+                await ExpectMsgAsync(new UpdateSuccess(KeyX, null), WriteReplyTimeout);
                 _replicator.Tell(Dsl.Delete(KeyX, WriteLocal.Instance));
-                ExpectMsg(new DeleteSuccess(KeyX));
+                await ExpectMsgAsync(new DeleteSuccess(KeyX));
             }, Fifth);
 
-            EnterBarrier("initial-updates-done");
+            await EnterBarrierAsync("initial-updates-done");
 
-            AssertValue(KeyA, 25UL);
-            AssertValue(KeyB, new BigInteger(15.0));
-            AssertValue(KeyC, 25UL);
-            AssertValue(KeyD, 40UL);
-            AssertValue(KeyE, ImmutableHashSet.CreateRange(new[] { "e1", "e2", "e3" }));
-            AssertValue(KeyF, ImmutableHashSet.CreateRange(new[] { "e1", "e2", "e3" }));
-            AssertDeleted(KeyX);
+            await AssertValueAsync(KeyA, 25UL);
+            await AssertValueAsync(KeyB, new BigInteger(15.0));
+            await AssertValueAsync(KeyC, 25UL);
+            await AssertValueAsync(KeyD, 40UL);
+            await AssertValueAsync(KeyE, ImmutableHashSet.CreateRange(new[] { "e1", "e2", "e3" }));
+            await AssertValueAsync(KeyF, ImmutableHashSet.CreateRange(new[] { "e1", "e2", "e3" }));
+            await AssertDeletedAsync(KeyX);
 
-            EnterBarrier("after-1");
+            await EnterBarrierAsync("after-1");
         }
 
-        public void Replicator_in_chaotic_cluster_should_be_available_during_network_split()
+        public async Task Replicator_in_chaotic_cluster_should_be_available_during_network_split()
         {
             var side1 = new[] { First, Second };
             var side2 = new[] { Third, Fourth, Fifth };
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 foreach (var a in side1)
                     foreach (var b in side2)
-                        TestConductor.Blackhole(a, b, ThrottleTransportAdapter.Direction.Both).Wait(TimeSpan.FromSeconds(1));
+                        await TestConductor.Blackhole(a, b, ThrottleTransportAdapter.Direction.Both);
             }, First);
 
-            EnterBarrier("split");
+            await EnterBarrierAsync("split");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 _replicator.Tell(Dsl.Update(KeyA, GCounter.Empty, new WriteTo(2, _timeout), x => x.Increment(_cluster, 1)));
-                ExpectMsg(new UpdateSuccess(KeyA, null));
+                await ExpectMsgAsync(new UpdateSuccess(KeyA, null), WriteReplyTimeout);
             }, First);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 _replicator.Tell(Dsl.Update(KeyA, GCounter.Empty, new WriteTo(2, _timeout), x => x.Increment(_cluster, 2)));
-                ExpectMsg(new UpdateSuccess(KeyA, null));
+                await ExpectMsgAsync(new UpdateSuccess(KeyA, null), WriteReplyTimeout);
 
                 _replicator.Tell(Dsl.Update(KeyE, GSet<string>.Empty, new WriteTo(2, _timeout), x => x.Add("e4")));
-                ExpectMsg(new UpdateSuccess(KeyE, null));
+                await ExpectMsgAsync(new UpdateSuccess(KeyE, null), WriteReplyTimeout);
 
                 _replicator.Tell(Dsl.Update(KeyF, ORSet<string>.Empty, new WriteTo(2, _timeout), x => x.Remove(_cluster, "e2")));
-                ExpectMsg(new UpdateSuccess(KeyF, null));
+                await ExpectMsgAsync(new UpdateSuccess(KeyF, null), WriteReplyTimeout);
             }, Third);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 _replicator.Tell(Dsl.Update(KeyD, GCounter.Empty, new WriteTo(2, _timeout), x => x.Increment(_cluster, 1)));
-                ExpectMsg(new UpdateSuccess(KeyD, null));
+                await ExpectMsgAsync(new UpdateSuccess(KeyD, null), WriteReplyTimeout);
             }, Fourth);
 
-            EnterBarrier("update-during-split");
+            await EnterBarrierAsync("update-during-split");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                AssertValue(KeyA, 26UL);
-                AssertValue(KeyB, new BigInteger(15.0));
-                AssertValue(KeyD, 40UL);
-                AssertValue(KeyE, ImmutableHashSet.CreateRange(new[] { "e1", "e2", "e3"}));
-                AssertValue(KeyF, ImmutableHashSet.CreateRange(new[] { "e1", "e2", "e3" }));
+                await AssertValueAsync(KeyA, 26UL);
+                await AssertValueAsync(KeyB, new BigInteger(15.0));
+                await AssertValueAsync(KeyD, 40UL);
+                await AssertValueAsync(KeyE, ImmutableHashSet.CreateRange(new[] { "e1", "e2", "e3"}));
+                await AssertValueAsync(KeyF, ImmutableHashSet.CreateRange(new[] { "e1", "e2", "e3" }));
             }, side1);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                AssertValue(KeyA, 27UL);
-                AssertValue(KeyB, new BigInteger(15.0));
-                AssertValue(KeyD, 41UL);
-                AssertValue(KeyE, ImmutableHashSet.CreateRange(new[] { "e1", "e2", "e3", "e4" }));
-                AssertValue(KeyF, ImmutableHashSet.CreateRange(new[] { "e1", "e3" }));
+                await AssertValueAsync(KeyA, 27UL);
+                await AssertValueAsync(KeyB, new BigInteger(15.0));
+                await AssertValueAsync(KeyD, 41UL);
+                await AssertValueAsync(KeyE, ImmutableHashSet.CreateRange(new[] { "e1", "e2", "e3", "e4" }));
+                await AssertValueAsync(KeyF, ImmutableHashSet.CreateRange(new[] { "e1", "e3" }));
             }, side2);
 
-            EnterBarrier("update-during-split-verified");
+            await EnterBarrierAsync("update-during-split-verified");
 
-            RunOn(() => TestConductor.Exit(Fourth, 0).Wait(TimeSpan.FromSeconds(5)), First);
+            await RunOnAsync(async () => await TestConductor.Exit(Fourth, 0), First);
 
-            EnterBarrier("after-2");
+            await EnterBarrierAsync("after-2");
         }
 
-        public void Replicator_in_chaotic_cluster_should_converge_after_partition()
+        public async Task Replicator_in_chaotic_cluster_should_converge_after_partition()
         {
             var side1 = new[] { First, Second };
             var side2 = new[] { Third, Fifth };
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 foreach (var a in side1)
                     foreach (var b in side2)
-                        TestConductor.PassThrough(a, b, ThrottleTransportAdapter.Direction.Both).Wait(TimeSpan.FromSeconds(1));
+                        await TestConductor.PassThrough(a, b, ThrottleTransportAdapter.Direction.Both);
             }, First);
 
-            EnterBarrier("split-repaired");
+            await EnterBarrierAsync("split-repaired");
 
-            AssertValue(KeyA, 28UL);
-            AssertValue(KeyB, new BigInteger(15.0));
-            AssertValue(KeyC, 25UL);
-            AssertValue(KeyD, 41UL);
-            AssertValue(KeyE, ImmutableHashSet.CreateRange(new[] { "e1", "e2", "e3", "e4" }));
-            AssertValue(KeyF, ImmutableHashSet.CreateRange(new[] { "e1", "e3" }));
-            AssertDeleted(KeyX);
+            await AssertValueAsync(KeyA, 28UL);
+            await AssertValueAsync(KeyB, new BigInteger(15.0));
+            await AssertValueAsync(KeyC, 25UL);
+            await AssertValueAsync(KeyD, 41UL);
+            await AssertValueAsync(KeyE, ImmutableHashSet.CreateRange(new[] { "e1", "e2", "e3", "e4" }));
+            await AssertValueAsync(KeyF, ImmutableHashSet.CreateRange(new[] { "e1", "e3" }));
+            await AssertDeletedAsync(KeyX);
 
-            EnterBarrier("after-3");
+            await EnterBarrierAsync("after-3");
         }
 
         protected override int InitialParticipantsValueFactory => Roles.Count;
 
-        private void Join(RoleName from, RoleName to)
+        private async Task JoinAsync(RoleName from, RoleName to)
         {
             RunOn(() => _cluster.Join(Node(to).Address), from);
-            EnterBarrier(from.Name + "-joined");
+            await EnterBarrierAsync(from.Name + "-joined");
         }
 
-        private void AssertValue(IKey<IReplicatedData> key, object expected)
+        /// <summary>
+        /// Collects <paramref name="count"/> messages from the test actor within
+        /// <paramref name="max"/>.
+        /// </summary>
+        private async Task<IReadOnlyList<object>> CollectRepliesAsync(int count, TimeSpan max)
         {
-            Within(TimeSpan.FromSeconds(10), () => AwaitAssert(() =>
+            var received = new List<object>(count);
+            await foreach (var message in ReceiveNAsync(count, max))
+                received.Add(message);
+            return received;
+        }
+
+        private async Task AssertValueAsync(IKey<IReplicatedData> key, object expected)
+        {
+            await AwaitAssertAsync(async () =>
             {
-                _replicator.Tell(Dsl.Get(key, ReadLocal.Instance));
-                var g = ExpectMsg<GetSuccess>().Get(key);
+                // Fresh probe and an explicit bound per attempt - see the note on
+                // AttemptTimeout. The probe also keeps a late GetSuccess from a timed-out
+                // attempt out of the next attempt's queue, where it would be read as a
+                // stale answer.
+                var probe = CreateTestProbe();
+                _replicator.Tell(Dsl.Get(key, ReadLocal.Instance), probe.Ref);
+                var g = (await probe.ExpectMsgAsync<GetSuccess>(AttemptTimeout)).Get(key);
                 object value;
                 switch (g)
                 {
@@ -294,19 +388,18 @@ namespace Akka.DistributedData.Tests.MultiNode
                 }
 
                 value.ShouldBe(expected);
-            }));
+            }, TimeSpan.FromSeconds(10), AttemptInterval);
         }
 
-        private void AssertDeleted(IKey<IReplicatedData> key)
+        private async Task AssertDeletedAsync(IKey<IReplicatedData> key)
         {
-            Within(TimeSpan.FromSeconds(5), () =>
+            await AwaitAssertAsync(async () =>
             {
-                AwaitAssert(() =>
-                {
-                    _replicator.Tell(Dsl.Get(key, ReadLocal.Instance));
-                    ExpectMsg(new DataDeleted(key));
-                });
-            });
+                // Same shape as AssertValueAsync: fresh probe, explicit per-attempt bound.
+                var probe = CreateTestProbe();
+                _replicator.Tell(Dsl.Get(key, ReadLocal.Instance), probe.Ref);
+                await probe.ExpectMsgAsync(new DataDeleted(key), AttemptTimeout);
+            }, TimeSpan.FromSeconds(5), AttemptInterval);
         }
     }
 }


### PR DESCRIPTION
Wave-3 de-flake batch: three spec families, test-only, no product code touched. No timeout raised, no sleep, no retry backoff — every change removes a structural race or pins the algorithm an assertion was written against.

Closes #8481.

## ReplicatorChaosSpec (3 artery-lane failures across builds 130927/130934, history to #3079)

Three defects, each fail-first-proven:

- **`ReceiveN(15)` could never observe a slow `WriteAll`**: its 3s deadline starts at the call; each `WriteAll(3s)` aggregator's deadline starts at or after it — the collector always loses the race by construction. Every write-reply expect now uses a bound derived as `WriteTimeout + 3s` (undilated, since TestKit dilates what it is handed).
- **No rendezvous between readiness and the write burst**: every node asserted `ReplicaCount(5)`, but nothing made nodes wait for each other, so `first`'s `WriteAll` could reach a peer whose replicator had not yet processed membership — the peer logs `Ignoring message [Write] from [unknown node]`, sends no ack, and `WriteAll` has no re-send (with WriteAll every node is primary, so `SendToSecondary` re-sends to nobody; GCounter's delta path nulls the aggregator's delta). One ignored Write = guaranteed `UpdateTimeout`. A `replicas-ready` barrier now separates the phases. Paired-injection proof: a throwaway 4s membership hold reproduces the CI fingerprint on the original spec (5 ignored Writes) and passes on the fixed spec (0).
- **Three `Within → AwaitAssert → unbounded ExpectMsg` shapes** (`AssertValue`, `AssertDeleted`, the `ReplicaCount` loop) inherited drained budgets — one CI run logged `Timeout 00:00:00.0000044`. All three now use fresh probes with explicit 1s per-attempt bounds, per the #8500 pattern.

Also found in the sweep: `TestConductor.Blackhole/PassThrough/Exit` calls used `.Wait(1s)` and discarded the bool — a conductor round-trip slower than 1s let the spec proceed as if the partition were installed. Now awaited and bounded by the conductor's own query timeout, so failures raise instead of being swallowed.

## ClusterShardingLeavingSpec family (2 failures: DData in 130784, Persistent in 130956)

The spec asserts entities on surviving nodes keep the same actor incarnation across a graceful leave. Only the legacy threshold strategy has that property; the bounded default (since #8445) may legitimately move survivor shards during the leave window — and the reference implementation's gate, ordering, and spec are all identical to ours, so deferring rebalance on Leaving would be an unjustified divergence (full parity analysis on #8481). The fix pins `rebalance-absolute-limit = 0` in the family's base config: the identity assertion now tests the algorithm that guarantees it, as a real regression test for the legacy strategy's leave behavior.

## DistributedPubSubRestartSpec delta-count baseline (1 failure: `Expected 3L, found 4L`, build 130927)

Mechanism confirmed before changing anything: `DeltaCount` counts Delta messages *received* — including ones whose payload is discarded because the sender's bucket owner is not yet a known member. While `second` awaits the restarted node's `MemberUp`, the peer pushes that node's bucket every 500ms tick and every discarded push still counts. The old baseline read landed mid-burst, so a trailing tick's Delta crossed the assertion window (locally measured margins of 104ms–1s against the 500ms tick). The baseline read now requires two samples 2s apart to agree (4 gossip ticks, derived in-comment) before the invariance assertion arms. Fail-first: injecting one extra Delta 1s after the old baseline read reproduces the verbatim CI signature on the original spec; the fixed spec absorbs it.

## Deliberately NOT fixed: ClusterClientHandoverSpec

Its two artery-lane failures are a **true positive** — a `ClusterClient` product bug (a `ReconnectTimeout` timer armed per message during `Establishing` and only the last one cancelled; a stray kills the client on re-entry). No honest test-side fix exists; removing the spec's `reconnect-timeout = 3s` would delete the only coverage of the buggy path. Filed with full evidence and a fix shape as #8508; the spec stays on the ledger as known-true-positive until that lands.

## Verification

| Spec | classic | artery | artery under CPU load |
|---|---|---|---|
| ReplicatorChaosSpec | 5/5 | 10/10 (+3 re-confirm) | 4/4 |
| PersistentClusterShardingLeavingSpec | 3/3 | 3/3 | — |
| DDataClusterShardingLeavingSpec | 3/3 | 3/3 | — |
| DistributedPubSubRestartSpec | 4/4 | 8/8 (under load) | — |

Independent single-round replications of ReplicatorChaos (artery 5/5 nodes) and DistributedPubSubRestart (artery 3/3 nodes) on the pushed SHAs. All touched projects build at `-warnaserror` with 0 warnings.
