### PR TITLE
Backport #8510 to v1.5: ClusterClient reconnect deadline via IWithTimers

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/ClusterClient/ClusterClientReconnectTimeoutSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/ClusterClient/ClusterClientReconnectTimeoutSpec.cs
@@ -1,0 +1,180 @@
+//-----------------------------------------------------------------------
+// <copyright file="ClusterClientReconnectTimeoutSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Tools.Client;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.TestKit;
+using Akka.TestKit.TestActors;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+
+namespace Akka.Cluster.Tools.Tests.ClusterClient
+{
+    /// <summary>
+    /// Regression tests for https://github.com/akkadotnet/akka.net/issues/8508.
+    ///
+    /// <see cref="Akka.Cluster.Tools.Client.ClusterClient"/> used to arm a one-shot
+    /// <c>ReconnectTimeout</c> timer on every message it handled while establishing, and only ever
+    /// cancelled the last one. Leftover timers that fired while the client was active were merely
+    /// noise, but one that fired after the client went back to establishing stopped a healthy
+    /// client mid-reconnect - long before its own reconnect deadline was due.
+    /// </summary>
+    public class ClusterClientReconnectTimeoutSpec : AkkaSpec
+    {
+        /// <summary>
+        /// The reconnect deadline. Long enough that the two phases of the kill test are far apart.
+        /// </summary>
+        private static readonly TimeSpan ReconnectTimeout = 10.Seconds();
+
+        public ClusterClientReconnectTimeoutSpec(ITestOutputHelper output) : base(GetConfig(), output)
+        {
+        }
+
+        private static Config GetConfig()
+        {
+            // Heartbeats and contact refreshes are pinned out of the way so the only timer that can
+            // move during these tests is the reconnect deadline under test. Without that, an
+            // acceptable-heartbeat-pause expiry would race the deadline and blur which one fired.
+            return ConfigurationFactory.ParseString($@"
+                akka.actor.provider = cluster
+                akka.remote.dot-netty.tcp.port = 0
+                akka.remote.dot-netty.tcp.hostname = 127.0.0.1
+                akka.loglevel = INFO
+                akka.cluster.client {{
+                  heartbeat-interval = 1d
+                  acceptable-heartbeat-pause = 1d
+                  refresh-contacts-interval = 1d
+                  reconnect-timeout = {ReconnectTimeout.TotalSeconds}s
+                }}
+            ").WithFallback(ClusterClientReceptionist.DefaultConfig());
+        }
+
+        /// <summary>
+        /// Brings up a single-node cluster with a receptionist and one registered service, then
+        /// returns a client that has completed its first establishing phase.
+        /// </summary>
+        private async Task<(IActorRef client, IActorRef receptionist)> StartEstablishedClientAsync()
+        {
+            var cluster = Akka.Cluster.Cluster.Get(Sys);
+            cluster.Join(cluster.SelfAddress);
+            await AwaitAssertAsync(
+                () => cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(1),
+                10.Seconds(),
+                200.Milliseconds());
+
+            var receptionist = ClusterClientReceptionist.Get(Sys);
+            receptionist.RegisterService(Sys.ActorOf(EchoActor.Props(this, true), "testService"));
+
+            var contacts = ImmutableHashSet.Create(receptionist.Underlying.Path);
+            var client = Sys.ActorOf(
+                Akka.Cluster.Tools.Client.ClusterClient.Props(
+                    ClusterClientSettings.Create(Sys).WithInitialContacts(contacts)),
+                "client");
+
+            // The echo round trip proves the client reached Active. It also makes the client
+            // heartbeat the receptionist, which is what registers it for the shutdown notification
+            // the kill test relies on.
+            client.Tell(new Akka.Cluster.Tools.Client.ClusterClient.Send("/user/testService", "hello", localAffinity: true));
+            await ExpectMsgAsync("hello", 10.Seconds());
+
+            return (client, receptionist.Underlying);
+        }
+
+        [Fact(DisplayName =
+            "ClusterClient should not be stopped by a reconnect deadline armed during an earlier establishing phase")]
+        public async Task Should_Survive_Stale_Reconnect_Deadline_When_Reestablishing()
+        {
+            var (client, receptionist) = await StartEstablishedClientAsync();
+
+            var deathProbe = CreateTestProbe();
+            deathProbe.Watch(client);
+
+            // Phase 1 armed its deadline when the client was constructed, so it comes due at
+            // roughly T0 + 10s. Sit in Active for 7s of that, which is also an assertion: an active
+            // client must not be stopped by anything.
+            var activeWindow = 7.Seconds();
+            await deathProbe.ExpectNoMsgAsync(activeWindow);
+
+            // Stopping the receptionist makes it tell its registered clients it is going away, which
+            // sends the client back to establishing. Nothing replaces the receptionist, so the
+            // client stays there and cannot mask a premature stop by reconnecting.
+            Sys.Stop(receptionist);
+
+            // Phase 2 begins here, so a correct client lives until roughly now + 10s.
+            //
+            // On the unfixed code a leftover phase-1 deadline fires at T0 + 10s, which is only
+            // 10 - 7 = 3s into this window, and stops the client. So a 5s window fails there with
+            // ~2s to spare and passes on fixed code with ~5s to spare: the deadline that legitimately
+            // applies is still 5s away when the window closes.
+            var survivalWindow = 5.Seconds();
+            await deathProbe.ExpectNoMsgAsync(survivalWindow);
+
+            // Still alive and still doing its job: it must be trying to reconnect, not sitting dead.
+            client.Tell(GetContactPoints.Instance, deathProbe.Ref);
+            (await deathProbe.ExpectMsgAsync<ContactPoints>(3.Seconds()))
+                .ContactPointsList.Should().NotBeEmpty();
+        }
+
+        [Fact(DisplayName =
+            "ClusterClient should leave no stray ReconnectTimeout behind across establish, active and re-establish")]
+        public async Task Should_Not_Leak_ReconnectTimeout_Timers()
+        {
+            // The leak is directly observable: every abandoned timer eventually fires into an actor
+            // that is no longer establishing, where ReconnectTimeout is unhandled and lands on the
+            // event stream. A correct client arms exactly one deadline per establishing phase and
+            // cancels it on the way into Active, so this collector must stay empty.
+            var strayProbe = CreateTestProbe();
+            var collector = Sys.ActorOf(Props.Create(() => new ReconnectTimeoutCollector(strayProbe.Ref)));
+            Sys.EventStream.Subscribe(collector, typeof(UnhandledMessage));
+            Sys.EventStream.Subscribe(collector, typeof(DeadLetter));
+
+            var (client, receptionist) = await StartEstablishedClientAsync();
+
+            // Stay ACTIVE across a whole reconnect-timeout. This is where a leak becomes visible:
+            // any deadline abandoned by the first establishing phase comes due here, and
+            // ReconnectTimeout is unhandled once the client is active, so each one is published.
+            // Waiting inside establishing would hide the leak instead, because there the message is
+            // handled - by stopping the client.
+            await strayProbe.ExpectNoMsgAsync(ReconnectTimeout + 2.Seconds());
+
+            // Now cover the re-establish leg of the cycle. The client is still well inside its
+            // phase-2 deadline when this window closes, so a correct client publishes nothing here
+            // either. The deadline it eventually hits is handled while establishing, not stray.
+            Sys.Stop(receptionist);
+            await strayProbe.ExpectNoMsgAsync(5.Seconds());
+        }
+
+        /// <summary>
+        /// Forwards only stray <c>ReconnectTimeout</c> messages, so unrelated event-stream traffic
+        /// cannot be misread as a leak.
+        /// </summary>
+        private sealed class ReconnectTimeoutCollector : ReceiveActor
+        {
+            public ReconnectTimeoutCollector(IActorRef target)
+            {
+                Receive<UnhandledMessage>(m =>
+                {
+                    if (m.Message is Akka.Cluster.Tools.Client.ClusterClient.ReconnectTimeout)
+                        target.Tell(m.Message);
+                });
+
+                Receive<DeadLetter>(m =>
+                {
+                    if (m.Message is Akka.Cluster.Tools.Client.ClusterClient.ReconnectTimeout)
+                        target.Tell(m.Message);
+                });
+            }
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClient.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClient.cs
@@ -33,7 +33,7 @@ public interface IClusterClientProtocolMessage
 /// points retrieved from previous establishment, or periodically refreshed
 /// contacts, i.e. not necessarily the initial contact points.
 /// </summary>
-public sealed class ClusterClient : ActorBase
+public sealed class ClusterClient : ActorBase, IWithTimers
 {
     #region Messages
 
@@ -287,9 +287,21 @@ public sealed class ClusterClient : ActorBase
     private ActorSelection[] _contacts;
     private ImmutableHashSet<ActorPath> _contactPathsPublished;
     private ImmutableList<IActorRef> _subscribers;
-    private readonly ICancelable _heartbeatTask;
-    private ICancelable _refreshContactsCancelable;
     private readonly Queue<(object, IActorRef)> _buffer;
+
+    // All three timers below are keyed. A key means StartSingleTimer/StartPeriodicTimer REPLACES
+    // any live timer under that key, so at most one of each can exist no matter where it is armed.
+    // The scheduler also cancels every timer when the actor stops or restarts, so there is no
+    // PostStop cleanup to forget.
+    private const string ReconnectTimerKey = "reconnect-timeout";
+    private const string HeartbeatTimerKey = "heartbeat";
+    private const string RefreshContactsTimerKey = "refresh-contacts";
+
+    /// <summary>
+    /// Injected by the actor cell after construction. Timers are armed in <see cref="PreStart"/>,
+    /// not in the constructor, because this is still null while the constructor runs.
+    /// </summary>
+    public ITimerScheduler Timers { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ClusterClient" /> class.
@@ -323,49 +335,59 @@ public sealed class ClusterClient : ActorBase
         _contactPathsPublished = _contactPaths;
         _subscribers = ImmutableList<IActorRef>.Empty;
 
-        _heartbeatTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(
-            settings.HeartbeatInterval,
-            settings.HeartbeatInterval,
-            Self,
-            HeartbeatTick.Instance,
-            Self);
-
-        _refreshContactsCancelable = null;
-        ScheduleRefreshContactsTick(settings.EstablishingGetContactsInterval);
-        Self.Tell(RefreshContactsTick.Instance);
-
         _buffer = new Queue<(object, IActorRef)>();
+    }
+
+    /// <summary>
+    /// Arms the timers and enters the initial establishing phase. This runs after the constructor,
+    /// which is the earliest point where <see cref="Timers"/> is available.
+    /// </summary>
+    protected override void PreStart()
+    {
+        base.PreStart();
+
+        Timers.StartPeriodicTimer(
+            HeartbeatTimerKey,
+            HeartbeatTick.Instance,
+            _settings.HeartbeatInterval,
+            _settings.HeartbeatInterval);
+
+        // Construction is the entry into the first establishing phase, so the reconnect deadline
+        // starts here.
+        ScheduleReconnectTimeout();
+        ScheduleRefreshContactsTick(_settings.EstablishingGetContactsInterval);
+        Self.Tell(RefreshContactsTick.Instance);
+    }
+
+    /// <summary>
+    /// Starts the deadline that stops this client if it cannot reach a receptionist in time.
+    /// </summary>
+    private void ScheduleReconnectTimeout()
+    {
+        // The deadline measures time spent in the CURRENT establishing phase, so it must be armed
+        // once per entry into that phase - never per message. Arming it per message was the bug in
+        // issue #8508: each message left another one-shot timer behind, only the last was ever
+        // cancelled, and a leftover firing after the client had gone back to establishing stopped a
+        // healthy client mid-reconnect.
+        //
+        // Two properties of a keyed timer make this safe. Starting the timer replaces any live one
+        // under the same key, so re-entering establishing cannot accumulate deadlines. And the
+        // scheduler discards messages from a cancelled or replaced timer even when they are already
+        // sitting in the mailbox - which a plain ICancelable cannot do, because Cancel() cannot
+        // recall a message that has already been queued.
+        //
+        // reconnect-timeout defaults to off, in which case no timer is armed at all.
+        if (_settings.ReconnectTimeout.HasValue)
+        {
+            Timers.StartSingleTimer(ReconnectTimerKey, ReconnectTimeout.Instance, _settings.ReconnectTimeout.Value);
+        }
     }
 
     private void ScheduleRefreshContactsTick(TimeSpan interval)
     {
-        if (_refreshContactsCancelable != null)
-        {
-            _refreshContactsCancelable.Cancel();
-            _refreshContactsCancelable = null;
-        }
-
-        _refreshContactsCancelable = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(
-            interval,
-            interval,
-            Self,
-            RefreshContactsTick.Instance,
-            Self);
-    }
-
-    /// <summary>
-    /// TBD
-    /// </summary>
-    protected override void PostStop()
-    {
-        base.PostStop();
-        _heartbeatTask.Cancel();
-
-        if (_refreshContactsCancelable != null)
-        {
-            _refreshContactsCancelable.Cancel();
-            _refreshContactsCancelable = null;
-        }
+        // Keyed, so this replaces the timer running at the previous interval. A tick left over from
+        // the old cadence is discarded rather than delivered against the new one.
+        Timers.StartPeriodicTimer(RefreshContactsTimerKey, RefreshContactsTick.Instance, interval, interval);
     }
 
     /// <summary>
@@ -380,16 +402,9 @@ public sealed class ClusterClient : ActorBase
 
     private bool Establishing(object message)
     {
-        ICancelable connectTimerCancelable = null;
-        if (_settings.ReconnectTimeout.HasValue)
-        {
-            connectTimerCancelable = Context.System.Scheduler.ScheduleTellOnceCancelable(
-                _settings.ReconnectTimeout.Value,
-                Self,
-                ReconnectTimeout.Instance,
-                Self);
-        }
-
+        // No timer work here. The reconnect deadline belongs to the phase, not to each message -
+        // see ScheduleReconnectTimeout. It is armed on entry (PreStart and Reestablish) and
+        // cancelled on the transition to Active.
         switch (message)
         {
             case ClusterReceptionist.Contacts contacts:
@@ -415,7 +430,8 @@ public sealed class ClusterClient : ActorBase
                     ScheduleRefreshContactsTick(_settings.RefreshContactsInterval);
                     SendBuffered(receptionist);
                     Context.Become(Active(receptionist));
-                    connectTimerCancelable?.Cancel();
+                    // Leaving the establishing phase, so the deadline no longer applies.
+                    Timers.Cancel(ReconnectTimerKey);
                     _failureDetector.HeartBeat();
                     Self.Tell(HeartbeatTick.Instance); // will register us as active client of the selected receptionist
                 }
@@ -534,6 +550,8 @@ public sealed class ClusterClient : ActorBase
         SendGetContacts();
         ScheduleRefreshContactsTick(_settings.EstablishingGetContactsInterval);
         Context.Become(Establishing);
+        // Entering a new establishing phase, so the deadline restarts from now.
+        ScheduleReconnectTimeout();
         _failureDetector.HeartBeat();
     }
 

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
@@ -6,10 +6,11 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Cluster.Tools.Client
 {
-    public sealed class ClusterClient : Akka.Actor.ActorBase
+    public sealed class ClusterClient : Akka.Actor.ActorBase, Akka.Actor.IWithTimers
     {
         public ClusterClient(Akka.Cluster.Tools.Client.ClusterClientSettings settings) { }
-        protected override void PostStop() { }
+        public Akka.Actor.ITimerScheduler Timers { get; set; }
+        protected override void PreStart() { }
         public static Akka.Actor.Props Props(Akka.Cluster.Tools.Client.ClusterClientSettings settings) { }
         protected override bool Receive(object message) { }
         public sealed class Publish : Akka.Cluster.Tools.Client.IClusterClientProtocolMessage, System.IEquatable<Akka.Cluster.Tools.Client.ClusterClient.Publish>

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
@@ -6,10 +6,11 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Cluster.Tools.Client
 {
-    public sealed class ClusterClient : Akka.Actor.ActorBase
+    public sealed class ClusterClient : Akka.Actor.ActorBase, Akka.Actor.IWithTimers
     {
         public ClusterClient(Akka.Cluster.Tools.Client.ClusterClientSettings settings) { }
-        protected override void PostStop() { }
+        public Akka.Actor.ITimerScheduler Timers { get; set; }
+        protected override void PreStart() { }
         public static Akka.Actor.Props Props(Akka.Cluster.Tools.Client.ClusterClientSettings settings) { }
         protected override bool Receive(object message) { }
         public sealed class Publish : Akka.Cluster.Tools.Client.IClusterClientProtocolMessage, System.IEquatable<Akka.Cluster.Tools.Client.ClusterClient.Publish>


### PR DESCRIPTION
Backport of #8510 to the v1.5 maintenance line — a straight `cherry-pick -x` of dev's `855e8d85f`, not a re-implementation. The provenance trailer is in the commit, and the actor file on this branch hashes identical to dev's post-fix `ClusterClient.cs`.

## Why v1.5 needs it

v1.5's `ClusterClient.cs` was byte-identical to dev's pre-fix file: the `ReconnectTimeout` timer is armed on every message processed while establishing, only the success branch cancels (and only its own timer), and a stray landing after re-entry into `Establishing` stops a healthy client mid-reconnect (issue #8508 has the full mechanism and CI evidence). Masked by default because `reconnect-timeout` defaults to `off` — any v1.5 deployment enabling it is exposed.

## Fail-first, demonstrated on v1.5's own unfixed code

Both new tests were run against this branch's pre-pick `ClusterClient.cs`:

- Deterministic kill: the leaked timer (armed in the *previous* establishing phase) stops the client **2.993s into a fresh 10-second window** — the same subtraction as dev's repro and both original CI failures.
- Stray observable: unfixed v1.5 leaks `ReconnectTimeout` dead letters; measured across `ClusterClientHandoverSpec` runs on this branch: **24 strays in 4 runs before, 0 in 8 runs after**, with handover behavior unchanged (`connects=2` every run).

## Conflict resolution (the only non-picked content)

- `BREAKING_CHANGES_V1.6.md` hunk dropped — the file does not exist on v1.5.
- The two ClusterTools approval files had an ordering conflict (v1.5 lists `Props` before `Receive`); resolved by keeping v1.5's ordering and applying only the semantic delta. Validated by the approval tool itself: 18/18 API tests, zero `.received.txt` files generated.
- Commit message amended with a v1.5 scope note before the provenance line, since the inherited body references the dev-only ledger and artery soaks.

## API surface delta (identical in both approval variants)

```diff
-    public sealed class ClusterClient : Akka.Actor.ActorBase
+    public sealed class ClusterClient : Akka.Actor.ActorBase, Akka.Actor.IWithTimers
         public ClusterClient(ClusterClientSettings settings) { }
-    protected override void PostStop() { }
+    public Akka.Actor.ITimerScheduler Timers { get; set; }
+    protected override void PreStart() { }
```

Additive interface + property; the removed `PostStop` override is `protected` on a `sealed` class — unreachable, uncallable, and un-overridable by consumers.

## Validation on v1.5

| Check | Result |
|---|---|
| New `ClusterClientReconnectTimeoutSpec` on unfixed code | 2/2 fail (recorded) |
| Same, on this branch | 2/2 pass |
| Full `Akka.Cluster.Tools.Tests` | 99/99 |
| `Akka.API.Tests` (net10.0) | 18/18, no received files |
| `ClusterClientHandoverSpec` classic ×8 under CPU load | 8/8, zero strays |
| `-warnaserror` (Tools + both test projects) | 0 warnings |

Caveat: the net48 `Akka.API.Tests` host could not run locally (Linux box); the approval *content* for all target surfaces was validated on net10.0, and CI covers the net48 host.

`RELEASE_NOTES.md` deliberately untouched.
