### PR TITLE
MNTR: eliminate the conductor port race - bind port 0 and propagate via stdout sentinel

### DIFF
--- a/src/core/Akka.MultiNode.TestAdapter.Xunit2/Internal/MultiNodeTestCaseRunner.cs
+++ b/src/core/Akka.MultiNode.TestAdapter.Xunit2/Internal/MultiNodeTestCaseRunner.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Runtime.Versioning;
@@ -33,6 +34,21 @@ namespace Akka.MultiNode.TestAdapter.Internal
     {
         // Fixed TCP buffer size
         public const int TcpBufferSize = 10240;
+
+        /// <summary>
+        /// Value handed to the conductor node as <c>multinode.server-port</c>. Zero tells the node
+        /// to bind a free port and print it, which removes the race a probe-then-hand-over would
+        /// leave open.
+        /// </summary>
+        private const int AutoAssignConductorPort = 0;
+
+        /// <summary>
+        /// How long to wait for the conductor node to publish its port. Generous on purpose: the
+        /// node has to boot the runtime, load the test assembly and discover its specs before it
+        /// reaches the conductor bind. This only fires when that node hangs - a node that fails
+        /// outright exits, and the exit is detected immediately.
+        /// </summary>
+        private static readonly TimeSpan ConductorStartupTimeout = TimeSpan.FromSeconds(60);
         
         private ActorSystem TestRunSystem { get; set; }
         private IActorRef SinkCoordinator { get; set; }
@@ -154,42 +170,72 @@ akka.io.tcp {{
 
             var timelineCollector = TestRunSystem.ActorOf(Props.Create(() => new TimelineLogCollectorActor(Options.AppendLogOutput)));
             
-            var tasks = new List<Task<RunSummary>>();
-            var serverPort = SocketUtil.TemporaryTcpAddress("localhost").Port;
-            foreach (var nodeTest in TestCase.Nodes)
-            {
-                //Loop through each test, work out number of nodes to run on and kick off process
-                var args = new []
-                    {
-                        $@"-Dmultinode.test-class=""{nodeTest.TestCase.TypeName}""",
-                        $@"-Dmultinode.test-method=""{nodeTest.TestCase.MethodName}""",
-                        $@"-Dmultinode.max-nodes={TestCase.Nodes.Count}",
-                        $@"-Dmultinode.server-host=""{"localhost"}""",
-                        $@"-Dmultinode.server-port={serverPort}",
-                        $@"-Dmultinode.host=""{"localhost"}""",
-                        $@"-Dmultinode.index={nodeTest.Node - 1}",
-                        $@"-Dmultinode.role=""{nodeTest.Role}""",
-                        $@"-Dmultinode.listen-address={Options.ListenAddress}",
-                        $@"-Dmultinode.listen-port={Options.ListenPort}",
-                        $@"-Dmultinode.test-assembly=""{TestCase.AssemblyPath}"""
-                    };
-
-                // Start process for node
-                var runner = new MultiNodeTestRunner(
-                    nodeTest, MessageBus, args, SkipReason, Aggregator, SinkCoordinator,
-                    timelineCollector, Options, CancellationTokenSource);
-                
-                tasks.Add(runner.RunAsync());
-            }
-
             var summary = new RunSummary();
-            // Wait for all nodes to finish and collect results
-            while (tasks.Count > 0)
+            var tasks = new List<Task<RunSummary>>();
+            var nodes = TestCase.Nodes;
+
+            // The first node hosts the TestConductor. Start it alone with server-port=0, let it bind
+            // a free port, and read the port back off its stdout. Probing for a free port here and
+            // handing the number to the node is a race: the port is in the ephemeral range, so any
+            // outbound connection on the machine can take it before the conductor binds.
+            var conductorNode = nodes[0];
+            var conductorPortSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // Own token source so the conductor node can be killed on its own when it never
+            // publishes a port, without cancelling the whole test run.
+            var conductorCts = CancellationTokenSource.CreateLinkedTokenSource(CancellationTokenSource.Token);
+            try
             {
-                // TODO: might be a bug source if await throws
-                var finished = await Task.WhenAny(tasks);
-                tasks.Remove(finished);
-                summary.Aggregate(finished.Result);
+                var conductorRunner = new MultiNodeTestRunner(
+                    conductorNode, MessageBus, BuildNodeArgs(conductorNode, AutoAssignConductorPort), SkipReason,
+                    Aggregator, SinkCoordinator, timelineCollector, Options, conductorCts, conductorPortSource);
+
+                var conductorTask = conductorRunner.RunAsync();
+                tasks.Add(conductorTask);
+
+                var serverPort = await AwaitConductorPortAsync(conductorPortSource.Task, conductorTask, conductorCts);
+                if (serverPort.HasValue)
+                {
+                    foreach (var nodeTest in nodes.Skip(1))
+                    {
+                        // Start process for node
+                        var runner = new MultiNodeTestRunner(
+                            nodeTest, MessageBus, BuildNodeArgs(nodeTest, serverPort.Value), SkipReason, Aggregator,
+                            SinkCoordinator, timelineCollector, Options, CancellationTokenSource);
+
+                        tasks.Add(runner.RunAsync());
+                    }
+                }
+                else
+                {
+                    // No conductor, so there is nothing for the other nodes to attach to. Fail them
+                    // now with a message that names the cause, instead of starting them and letting
+                    // each one burn a 30 second attach timeout against a dead conductor.
+                    var failure = new ConductorStartupException(
+                        $"Node {conductorNode.Node} [{conductorNode.Role}] hosts the TestConductor but never published " +
+                        "its port, so this node was never started. See that node's output for the conductor failure.");
+
+                    foreach (var nodeTest in nodes.Skip(1))
+                    {
+                        MessageBus.QueueMessage(new TestStarting(nodeTest));
+                        MessageBus.QueueMessage(new TestFailed(nodeTest, 0, "", failure));
+                        MessageBus.QueueMessage(new TestFinished(nodeTest, 0, ""));
+                        summary.Total++;
+                        summary.Failed++;
+                    }
+                }
+
+                // Wait for all started nodes to finish and collect results
+                while (tasks.Count > 0)
+                {
+                    var finished = await Task.WhenAny(tasks);
+                    tasks.Remove(finished);
+                    summary.Aggregate(await finished);
+                }
+            }
+            finally
+            {
+                conductorCts.Dispose();
             }
             
             try
@@ -230,6 +276,69 @@ akka.io.tcp {{
             }
             
             return summary;
+        }
+
+        /// <summary>
+        /// Builds the command line for one node process.
+        /// </summary>
+        /// <param name="nodeTest">The node to start.</param>
+        /// <param name="serverPort">
+        /// Conductor port. <see cref="AutoAssignConductorPort"/> for the conductor node itself,
+        /// otherwise the port the conductor published.
+        /// </param>
+        private string[] BuildNodeArgs(NodeTest nodeTest, int serverPort)
+        {
+            return new[]
+            {
+                $@"-Dmultinode.test-class=""{nodeTest.TestCase.TypeName}""",
+                $@"-Dmultinode.test-method=""{nodeTest.TestCase.MethodName}""",
+                $@"-Dmultinode.max-nodes={TestCase.Nodes.Count}",
+                $@"-Dmultinode.server-host=""{"localhost"}""",
+                $@"-Dmultinode.server-port={serverPort}",
+                $@"-Dmultinode.host=""{"localhost"}""",
+                $@"-Dmultinode.index={nodeTest.Node - 1}",
+                $@"-Dmultinode.role=""{nodeTest.Role}""",
+                $@"-Dmultinode.listen-address={Options.ListenAddress}",
+                $@"-Dmultinode.listen-port={Options.ListenPort}",
+                $@"-Dmultinode.test-assembly=""{TestCase.AssemblyPath}"""
+            };
+        }
+
+        /// <summary>
+        /// Waits for the conductor node to publish the port its TestConductor bound to.
+        /// </summary>
+        /// <param name="portTask">Completes with the published port.</param>
+        /// <param name="conductorTask">The conductor node's run. Completing means that node exited.</param>
+        /// <param name="conductorCts">Cancelling this kills the conductor node process.</param>
+        /// <returns>The published port, or <c>null</c> when the conductor never came up.</returns>
+        private async Task<int?> AwaitConductorPortAsync(
+            Task<int> portTask,
+            Task<RunSummary> conductorTask,
+            CancellationTokenSource conductorCts)
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(CancellationTokenSource.Token);
+            var timeout = Task.Delay(ConductorStartupTimeout, timeoutCts.Token);
+            var completed = await Task.WhenAny(portTask, conductorTask, timeout);
+            timeoutCts.Cancel();
+
+            // Checked first: a node that exited has no live conductor, even if it managed to print
+            // the port on its way out.
+            if (conductorTask.IsCompleted)
+            {
+                PublishRunnerMessage(
+                    $"Node {TestCase.Nodes[0].Node} [{TestCase.Nodes[0].Role}] exited before its TestConductor was " +
+                    "reachable. The remaining nodes were not started.");
+                return null;
+            }
+
+            if (completed == portTask)
+                return await portTask;
+
+            PublishRunnerMessage(
+                $"Node {TestCase.Nodes[0].Node} [{TestCase.Nodes[0].Role}] did not publish a TestConductor port " +
+                $"within {ConductorStartupTimeout}; killing it. The remaining nodes were not started.");
+            conductorCts.Cancel();
+            return null;
         }
 
         private async Task DumpAggregatedSpecLogs(RunSummary summary, IActorRef timelineCollector)

--- a/src/core/Akka.MultiNode.TestAdapter.Xunit2/Internal/MultiNodeTestRunner.cs
+++ b/src/core/Akka.MultiNode.TestAdapter.Xunit2/Internal/MultiNodeTestRunner.cs
@@ -17,6 +17,7 @@ using Akka.Actor;
 using Akka.MultiNode.TestAdapter.Configuration;
 using Akka.MultiNode.TestAdapter.Internal.Sinks;
 using Akka.MultiNode.TestAdapter.NodeRunner;
+using Akka.Remote.TestKit;
 using Xunit.Sdk;
 using TestFailed = Xunit.Sdk.TestFailed;
 using TestFinished = Xunit.Sdk.TestFinished;
@@ -38,7 +39,8 @@ namespace Akka.MultiNode.TestAdapter.Internal
             IActorRef sinkCoordinator,
             IActorRef timelineCollector,
             MultiNodeTestRunnerOptions options,
-            CancellationTokenSource cancellationTokenSource) 
+            CancellationTokenSource cancellationTokenSource,
+            TaskCompletionSource<int> conductorPortSource = null)
         {
             _test = test;
             _messageBus = messageBus;
@@ -49,7 +51,14 @@ namespace Akka.MultiNode.TestAdapter.Internal
             _options = options;
             _cancellationTokenSource = cancellationTokenSource;
             _skipReason = skipReason;
+            _conductorPortSource = conductorPortSource;
         }
+
+        /// <summary>
+        /// Set only for the conductor node. Completed with the port the node's TestConductor bound
+        /// to, as soon as that node prints its sentinel line.
+        /// </summary>
+        private readonly TaskCompletionSource<int> _conductorPortSource;
 
         private readonly MultiNodeTestRunnerOptions _options;
         private readonly IActorRef _sinkCoordinator;
@@ -218,6 +227,19 @@ namespace Akka.MultiNode.TestAdapter.Internal
             }
         }
 
+        /// <summary>
+        /// Picks the conductor's bound port out of the node's output. Only the conductor node
+        /// carries a port source; every other node ignores the line.
+        /// </summary>
+        private void ExtractConductorPort(string data)
+        {
+            if (_conductorPortSource is null)
+                return;
+
+            if (ConductorPortSentinel.TryParse(data, out var port))
+                _conductorPortSource.TrySetResult(port);
+        }
+
         private async Task<int> RunNode()
         {
             var nodeInfo = new TimelineLogCollectorActor.NodeInfo(_test.Node, _test.Role, _options.Platform, TestCase.DisplayName);
@@ -235,6 +257,7 @@ namespace Akka.MultiNode.TestAdapter.Internal
                     _timelineCollector.Tell(new TimelineLogCollectorActor.LogMessage(nodeInfo, data));
 
                     ExtractExceptionData(data);
+                    ExtractConductorPort(data);
                 }
             }
 

--- a/src/core/Akka.MultiNode.TestAdapter/Internal/Exceptions.cs
+++ b/src/core/Akka.MultiNode.TestAdapter/Internal/Exceptions.cs
@@ -39,6 +39,19 @@ namespace Akka.MultiNode.TestAdapter.Internal
         { }
     }
     
+    /// <summary>
+    /// Reported for the nodes a multi-node spec never started, because the node hosting the
+    /// TestConductor did not publish the port it bound.
+    /// </summary>
+    internal class ConductorStartupException : Exception
+    {
+        public ConductorStartupException(string message) : base(message)
+        { }
+
+        // No stack trace: this exception is built to describe a failure, not thrown from one.
+        public override string StackTrace => "";
+    }
+
     internal class TestFailedException : Exception
     {
         private readonly string _stackTrace;

--- a/src/core/Akka.MultiNode.TestAdapter/Internal/MultiNodeTestCaseRunner.cs
+++ b/src/core/Akka.MultiNode.TestAdapter/Internal/MultiNodeTestCaseRunner.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Runtime.Versioning;
@@ -33,6 +34,21 @@ namespace Akka.MultiNode.TestAdapter.Internal
     {
         // Fixed TCP buffer size
         public const int TcpBufferSize = 10240;
+
+        /// <summary>
+        /// Value handed to the conductor node as <c>multinode.server-port</c>. Zero tells the node
+        /// to bind a free port and print it, which removes the race a probe-then-hand-over would
+        /// leave open.
+        /// </summary>
+        private const int AutoAssignConductorPort = 0;
+
+        /// <summary>
+        /// How long to wait for the conductor node to publish its port. Generous on purpose: the
+        /// node has to boot the runtime, load the test assembly and discover its specs before it
+        /// reaches the conductor bind. This only fires when that node hangs - a node that fails
+        /// outright exits, and the exit is detected immediately.
+        /// </summary>
+        private static readonly TimeSpan ConductorStartupTimeout = TimeSpan.FromSeconds(60);
 
         private ActorSystem TestRunSystem { get; set; }
         private IActorRef SinkCoordinator { get; set; }
@@ -145,41 +161,72 @@ akka.io.tcp {{
 
             var timelineCollector = TestRunSystem.ActorOf(Props.Create(() => new TimelineLogCollectorActor(Options.AppendLogOutput)));
 
-            var tasks = new List<Task<RunSummary>>();
-            var serverPort = SocketUtil.TemporaryTcpAddress("localhost").Port;
-            foreach (var nodeTest in _testCase.Nodes)
-            {
-                //Loop through each test, work out number of nodes to run on and kick off process
-                var args = new []
-                    {
-                        $@"-Dmultinode.test-class=""{nodeTest.TestCase.TypeName}""",
-                        $@"-Dmultinode.test-method=""{nodeTest.TestCase.MethodName}""",
-                        $@"-Dmultinode.max-nodes={_testCase.Nodes.Count}",
-                        $@"-Dmultinode.server-host=""{"localhost"}""",
-                        $@"-Dmultinode.server-port={serverPort}",
-                        $@"-Dmultinode.host=""{"localhost"}""",
-                        $@"-Dmultinode.index={nodeTest.Node - 1}",
-                        $@"-Dmultinode.role=""{nodeTest.Role}""",
-                        $@"-Dmultinode.listen-address={Options.ListenAddress}",
-                        $@"-Dmultinode.listen-port={Options.ListenPort}",
-                        $@"-Dmultinode.test-assembly=""{_testCase.AssemblyPath}"""
-                    };
-
-                // Start process for node
-                var runner = new MultiNodeTestRunner(
-                    nodeTest, _messageBus, args, _skipReason, _aggregator, SinkCoordinator,
-                    timelineCollector, Options, _cancellationTokenSource);
-
-                tasks.Add(runner.RunAsync());
-            }
-
             var summary = new RunSummary();
-            // Wait for all nodes to finish and collect results
-            while (tasks.Count > 0)
+            var tasks = new List<Task<RunSummary>>();
+            var nodes = _testCase.Nodes;
+
+            // The first node hosts the TestConductor. Start it alone with server-port=0, let it bind
+            // a free port, and read the port back off its stdout. Probing for a free port here and
+            // handing the number to the node is a race: the port is in the ephemeral range, so any
+            // outbound connection on the machine can take it before the conductor binds.
+            var conductorNode = nodes[0];
+            var conductorPortSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // Own token source so the conductor node can be killed on its own when it never
+            // publishes a port, without cancelling the whole test run.
+            var conductorCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationTokenSource.Token);
+            try
             {
-                var finished = await Task.WhenAny(tasks);
-                tasks.Remove(finished);
-                summary.Aggregate(finished.Result);
+                var conductorRunner = new MultiNodeTestRunner(
+                    conductorNode, _messageBus, BuildNodeArgs(conductorNode, AutoAssignConductorPort), _skipReason,
+                    _aggregator, SinkCoordinator, timelineCollector, Options, conductorCts, conductorPortSource);
+
+                var conductorTask = conductorRunner.RunAsync();
+                tasks.Add(conductorTask);
+
+                var serverPort = await AwaitConductorPortAsync(conductorPortSource.Task, conductorTask, conductorCts);
+                if (serverPort.HasValue)
+                {
+                    foreach (var nodeTest in nodes.Skip(1))
+                    {
+                        // Start process for node
+                        var runner = new MultiNodeTestRunner(
+                            nodeTest, _messageBus, BuildNodeArgs(nodeTest, serverPort.Value), _skipReason, _aggregator,
+                            SinkCoordinator, timelineCollector, Options, _cancellationTokenSource);
+
+                        tasks.Add(runner.RunAsync());
+                    }
+                }
+                else
+                {
+                    // No conductor, so there is nothing for the other nodes to attach to. Fail them
+                    // now with a message that names the cause, instead of starting them and letting
+                    // each one burn a 30 second attach timeout against a dead conductor.
+                    var failure = new ConductorStartupException(
+                        $"Node {conductorNode.Node} [{conductorNode.Role}] hosts the TestConductor but never published " +
+                        "its port, so this node was never started. See that node's output for the conductor failure.");
+
+                    foreach (var nodeTest in nodes.Skip(1))
+                    {
+                        _messageBus.QueueMessage(CreateTestStarting(nodeTest));
+                        _messageBus.QueueMessage(CreateTestFailed(nodeTest, 0, "", failure));
+                        _messageBus.QueueMessage(CreateTestFinished(nodeTest));
+                        summary.Total++;
+                        summary.Failed++;
+                    }
+                }
+
+                // Wait for all started nodes to finish and collect results
+                while (tasks.Count > 0)
+                {
+                    var finished = await Task.WhenAny(tasks);
+                    tasks.Remove(finished);
+                    summary.Aggregate(await finished);
+                }
+            }
+            finally
+            {
+                conductorCts.Dispose();
             }
 
             try
@@ -220,6 +267,69 @@ akka.io.tcp {{
             }
 
             return summary;
+        }
+
+        /// <summary>
+        /// Builds the command line for one node process.
+        /// </summary>
+        /// <param name="nodeTest">The node to start.</param>
+        /// <param name="serverPort">
+        /// Conductor port. <see cref="AutoAssignConductorPort"/> for the conductor node itself,
+        /// otherwise the port the conductor published.
+        /// </param>
+        private string[] BuildNodeArgs(NodeTest nodeTest, int serverPort)
+        {
+            return new[]
+            {
+                $@"-Dmultinode.test-class=""{nodeTest.TestCase.TypeName}""",
+                $@"-Dmultinode.test-method=""{nodeTest.TestCase.MethodName}""",
+                $@"-Dmultinode.max-nodes={_testCase.Nodes.Count}",
+                $@"-Dmultinode.server-host=""{"localhost"}""",
+                $@"-Dmultinode.server-port={serverPort}",
+                $@"-Dmultinode.host=""{"localhost"}""",
+                $@"-Dmultinode.index={nodeTest.Node - 1}",
+                $@"-Dmultinode.role=""{nodeTest.Role}""",
+                $@"-Dmultinode.listen-address={Options.ListenAddress}",
+                $@"-Dmultinode.listen-port={Options.ListenPort}",
+                $@"-Dmultinode.test-assembly=""{_testCase.AssemblyPath}"""
+            };
+        }
+
+        /// <summary>
+        /// Waits for the conductor node to publish the port its TestConductor bound to.
+        /// </summary>
+        /// <param name="portTask">Completes with the published port.</param>
+        /// <param name="conductorTask">The conductor node's run. Completing means that node exited.</param>
+        /// <param name="conductorCts">Cancelling this kills the conductor node process.</param>
+        /// <returns>The published port, or <c>null</c> when the conductor never came up.</returns>
+        private async Task<int?> AwaitConductorPortAsync(
+            Task<int> portTask,
+            Task<RunSummary> conductorTask,
+            CancellationTokenSource conductorCts)
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationTokenSource.Token);
+            var timeout = Task.Delay(ConductorStartupTimeout, timeoutCts.Token);
+            var completed = await Task.WhenAny(portTask, conductorTask, timeout);
+            timeoutCts.Cancel();
+
+            // Checked first: a node that exited has no live conductor, even if it managed to print
+            // the port on its way out.
+            if (conductorTask.IsCompleted)
+            {
+                PublishRunnerMessage(
+                    $"Node {_testCase.Nodes[0].Node} [{_testCase.Nodes[0].Role}] exited before its TestConductor was " +
+                    "reachable. The remaining nodes were not started.");
+                return null;
+            }
+
+            if (completed == portTask)
+                return await portTask;
+
+            PublishRunnerMessage(
+                $"Node {_testCase.Nodes[0].Node} [{_testCase.Nodes[0].Role}] did not publish a TestConductor port " +
+                $"within {ConductorStartupTimeout}; killing it. The remaining nodes were not started.");
+            conductorCts.Cancel();
+            return null;
         }
 
         #region Message factory methods
@@ -279,6 +389,28 @@ akka.io.tcp {{
                 FinishTime = DateTimeOffset.UtcNow,
                 Output = output,
                 Warnings = null
+            };
+        }
+
+        /// <summary>
+        /// Closes out a node that was reported without running a process. Every
+        /// <see cref="TestStarting"/> needs a matching <see cref="TestFinished"/>.
+        /// </summary>
+        internal TestFinished CreateTestFinished(NodeTest test)
+        {
+            return new TestFinished
+            {
+                AssemblyUniqueID = _ids.AssemblyUniqueID,
+                TestCollectionUniqueID = _ids.TestCollectionUniqueID,
+                TestClassUniqueID = _ids.TestClassUniqueID,
+                TestMethodUniqueID = _ids.TestMethodUniqueID,
+                TestCaseUniqueID = _ids.TestCaseUniqueID,
+                TestUniqueID = test.UniqueID,
+                ExecutionTime = 0m,
+                FinishTime = DateTimeOffset.UtcNow,
+                Output = "",
+                Warnings = null,
+                Attachments = new Dictionary<string, TestAttachment>()
             };
         }
 

--- a/src/core/Akka.MultiNode.TestAdapter/Internal/MultiNodeTestRunner.cs
+++ b/src/core/Akka.MultiNode.TestAdapter/Internal/MultiNodeTestRunner.cs
@@ -17,6 +17,7 @@ using Akka.Actor;
 using Akka.MultiNode.TestAdapter.Configuration;
 using Akka.MultiNode.TestAdapter.Internal.Sinks;
 using Akka.MultiNode.TestAdapter.NodeRunner;
+using Akka.Remote.TestKit;
 using Xunit.Sdk;
 using Xunit.v3;
 
@@ -33,7 +34,8 @@ namespace Akka.MultiNode.TestAdapter.Internal
             IActorRef sinkCoordinator,
             IActorRef timelineCollector,
             MultiNodeTestRunnerOptions options,
-            CancellationTokenSource cancellationTokenSource)
+            CancellationTokenSource cancellationTokenSource,
+            TaskCompletionSource<int> conductorPortSource = null)
         {
             _test = test;
             _messageBus = messageBus;
@@ -45,6 +47,7 @@ namespace Akka.MultiNode.TestAdapter.Internal
             _cancellationTokenSource = cancellationTokenSource;
             _skipReason = skipReason;
             _ids = TestMessageIds.From(test.TestCase);
+            _conductorPortSource = conductorPortSource;
         }
 
         private readonly MultiNodeTestRunnerOptions _options;
@@ -56,6 +59,12 @@ namespace Akka.MultiNode.TestAdapter.Internal
         private readonly string[] _remoteArguments;
         private readonly IMessageBus _messageBus;
         private readonly NodeTest _test;
+
+        /// <summary>
+        /// Set only for the conductor node. Completed with the port the node's TestConductor bound
+        /// to, as soon as that node prints its sentinel line.
+        /// </summary>
+        private readonly TaskCompletionSource<int> _conductorPortSource;
 
         /// <summary>
         /// Ceiling on how long a single node process may run before it is treated as hung and killed, when
@@ -264,6 +273,19 @@ namespace Akka.MultiNode.TestAdapter.Internal
             }
         }
 
+        /// <summary>
+        /// Picks the conductor's bound port out of the node's output. Only the conductor node
+        /// carries a port source; every other node ignores the line.
+        /// </summary>
+        private void ExtractConductorPort(string data)
+        {
+            if (_conductorPortSource is null)
+                return;
+
+            if (ConductorPortSentinel.TryParse(data, out var port))
+                _conductorPortSource.TrySetResult(port);
+        }
+
         private async Task<int> RunNode()
         {
             var nodeInfo = new TimelineLogCollectorActor.NodeInfo(_test.Node, _test.Role, _options.Platform, TestCase.TestCaseDisplayName);
@@ -290,6 +312,7 @@ namespace Akka.MultiNode.TestAdapter.Internal
                     _timelineCollector.Tell(new TimelineLogCollectorActor.LogMessage(nodeInfo, data));
 
                     ExtractExceptionData(data);
+                    ExtractConductorPort(data);
                 }
             }
 

--- a/src/core/Akka.Remote.TestKit.Tests/ConductorBindSpec.cs
+++ b/src/core/Akka.Remote.TestKit.Tests/ConductorBindSpec.cs
@@ -1,0 +1,106 @@
+// -----------------------------------------------------------------------
+//  <copyright file="ConductorBindSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Remote.TestKit.Tests;
+
+public class ConductorBindSpec : Akka.TestKit.Xunit.TestKit
+{
+    /// <summary>
+    /// Ceiling for the "port already in use" failure. Well under the 30s query timeout the old
+    /// code waited out, so the assertion fails if the failure ever goes back to being a timeout.
+    /// </summary>
+    private static readonly TimeSpan FailFastCeiling = TimeSpan.FromSeconds(10);
+
+    public ConductorBindSpec(ITestOutputHelper output)
+        : base("akka.actor.provider = remote", nameof(ConductorBindSpec), output)
+    {
+    }
+
+    [Fact(DisplayName = "StartController must bind an OS assigned port and report it before waiting for players")]
+    public async Task StartController_must_report_the_port_it_bound()
+    {
+        var conductor = TestConductor.Get(Sys);
+        IPEndPoint reported = null;
+
+        // One participant: the conductor is its own player, so this completes without other nodes.
+        var bound = await conductor.StartControllerAsync(
+            participants: 1,
+            name: new RoleName("conductor"),
+            controllerPort: new IPEndPoint(IPAddress.Loopback, 0),
+            onBound: endpoint => reported = endpoint);
+
+        bound.Port.Should().NotBe(0, "port 0 means the OS picks a port, so the bound port must be a real one");
+        reported.Should().NotBeNull("the runner needs the port before the conductor starts waiting for players");
+        reported.Port.Should().Be(bound.Port);
+
+        // The reported port is what goes over the wire to the other nodes.
+        ConductorPortSentinel.TryParse(ConductorPortSentinel.Format(reported.Port), out var published)
+            .Should().BeTrue();
+        published.Should().Be(bound.Port);
+    }
+
+    [Fact(DisplayName = "StartController must bind the exact port it was given and still report it")]
+    public async Task StartController_must_honour_an_explicit_port()
+    {
+        // Someone running node processes by hand sets multinode.server-port themselves. That path
+        // must still bind that exact port, and must report it like any other.
+        var free = FreeTcpPort();
+
+        var conductor = TestConductor.Get(Sys);
+        IPEndPoint reported = null;
+
+        var bound = await conductor.StartControllerAsync(
+            participants: 1,
+            name: new RoleName("conductor"),
+            controllerPort: new IPEndPoint(IPAddress.Loopback, free),
+            onBound: endpoint => reported = endpoint);
+
+        bound.Port.Should().Be(free);
+        reported.Port.Should().Be(free);
+    }
+
+    /// <summary>
+    /// Picks a port that is free right now. Only safe here because the test binds it immediately
+    /// afterwards and does not care which port it gets, only that the conductor honours it.
+    /// </summary>
+    private static int FreeTcpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint).Port;
+    }
+
+    [Fact(DisplayName = "StartController must fail fast and name the port when the conductor port is taken")]
+    public async Task StartController_must_fail_fast_when_the_port_is_taken()
+    {
+        // Hold the port for the whole test so the conductor's bind cannot succeed.
+        using var occupied = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        occupied.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        occupied.Listen(1);
+        var taken = (IPEndPoint)occupied.LocalEndPoint;
+
+        var conductor = TestConductor.Get(Sys);
+        var stopwatch = Stopwatch.StartNew();
+
+        var exception = await Assert.ThrowsAsync<ConductorBindException>(
+            () => conductor.StartControllerAsync(participants: 2, name: new RoleName("conductor"), controllerPort: taken));
+
+        stopwatch.Stop();
+
+        exception.Message.Should().Contain($"conductor port {taken.Port} already in use");
+        stopwatch.Elapsed.Should().BeLessThan(FailFastCeiling,
+            "a bind failure must be reported straight away, not waited out as a query timeout");
+    }
+}

--- a/src/core/Akka.Remote.TestKit.Tests/ConductorPortSentinelSpec.cs
+++ b/src/core/Akka.Remote.TestKit.Tests/ConductorPortSentinelSpec.cs
@@ -1,0 +1,65 @@
+// -----------------------------------------------------------------------
+//  <copyright file="ConductorPortSentinelSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Remote.TestKit.Tests;
+
+public class ConductorPortSentinelSpec
+{
+    [Theory(DisplayName = "Sentinel must survive a format then parse round trip")]
+    [InlineData(1)]
+    [InlineData(4711)]
+    [InlineData(33365)]
+    [InlineData(65535)]
+    public void Sentinel_must_round_trip(int port)
+    {
+        var line = ConductorPortSentinel.Format(port);
+
+        ConductorPortSentinel.TryParse(line, out var parsed).Should().BeTrue();
+        parsed.Should().Be(port);
+    }
+
+    [Fact(DisplayName = "Sentinel must reject ports outside the TCP range")]
+    public void Sentinel_must_reject_out_of_range_ports()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ConductorPortSentinel.Format(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ConductorPortSentinel.Format(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ConductorPortSentinel.Format(65536));
+    }
+
+    [Fact(DisplayName = "Sentinel must tolerate the trailing whitespace a console line can carry")]
+    public void Sentinel_must_tolerate_surrounding_whitespace()
+    {
+        ConductorPortSentinel.TryParse("  " + ConductorPortSentinel.Format(4711) + " \t", out var parsed)
+            .Should().BeTrue();
+        parsed.Should().Be(4711);
+    }
+
+    [Theory(DisplayName = "Sentinel must not read a port out of a line that is not a sentinel")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Running specs for Akka.Cluster.Tests.MultiNode.dll")]
+    [InlineData("[MULTINODE-CONDUCTOR-PORT]")]
+    [InlineData("[MULTINODE-CONDUCTOR-PORT]not-a-number")]
+    [InlineData("[MULTINODE-CONDUCTOR-PORT]4711abc")]
+    [InlineData("[MULTINODE-CONDUCTOR-PORT]-4711")]
+    [InlineData("[MULTINODE-CONDUCTOR-PORT] 4711")]
+    [InlineData("[MULTINODE-CONDUCTOR-PORT]0")]
+    [InlineData("[MULTINODE-CONDUCTOR-PORT]65536")]
+    [InlineData("[MULTINODE-CONDUCTOR-PORT]99999999999999999999")]
+    [InlineData("prefixed [MULTINODE-CONDUCTOR-PORT]4711")]
+    [InlineData("[multinode-conductor-port]4711")]
+    public void Sentinel_must_reject_malformed_lines(string line)
+    {
+        ConductorPortSentinel.TryParse(line, out var parsed).Should().BeFalse();
+        parsed.Should().Be(0);
+    }
+}

--- a/src/core/Akka.Remote.TestKit.Xunit2/Akka.Remote.TestKit.Xunit2.csproj
+++ b/src/core/Akka.Remote.TestKit.Xunit2/Akka.Remote.TestKit.Xunit2.csproj
@@ -34,6 +34,12 @@
     <Compile Include="..\Akka.Remote.TestKit\Conductor.cs">
       <Link>Conductor.cs</Link>
     </Compile>
+    <Compile Include="..\Akka.Remote.TestKit\ConductorBindException.cs">
+      <Link>ConductorBindException.cs</Link>
+    </Compile>
+    <Compile Include="..\Akka.Remote.TestKit\ConductorPortSentinel.cs">
+      <Link>ConductorPortSentinel.cs</Link>
+    </Compile>
     <Compile Include="..\Akka.Remote.TestKit\Controller.cs">
       <Link>Controller.cs</Link>
     </Compile>

--- a/src/core/Akka.Remote.TestKit/Conductor.cs
+++ b/src/core/Akka.Remote.TestKit/Conductor.cs
@@ -88,15 +88,57 @@ namespace Akka.Remote.TestKit
         /// <param name="controllerPort"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<IPEndPoint> StartControllerAsync(int participants, RoleName name, IPEndPoint controllerPort, CancellationToken cancellationToken = default)
+        public Task<IPEndPoint> StartControllerAsync(int participants, RoleName name, IPEndPoint controllerPort, CancellationToken cancellationToken = default)
+        {
+            return StartControllerAsync(participants, name, controllerPort, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// INTERNAL API. Same as
+        /// <see cref="StartControllerAsync(int,RoleName,IPEndPoint,CancellationToken)"/>, but calls
+        /// <paramref name="onBound"/> with the endpoint the controller actually bound to before
+        /// waiting for the other participants to attach.
+        ///
+        /// The callback has to run at that point. The wait for participants only ends once every
+        /// node has connected, and the nodes cannot connect until they know the port.
+        /// </summary>
+        internal async Task<IPEndPoint> StartControllerAsync(
+            int participants,
+            RoleName name,
+            IPEndPoint controllerPort,
+            Action<IPEndPoint> onBound,
+            CancellationToken cancellationToken = default)
         {
             if(_controller != null) throw new IllegalStateException("TestConductorServer was already started");
-            _controller = _system.ActorOf(Props.Create(() => new Controller(participants, controllerPort)),
+
+            // The Controller reports its bind result here rather than through an ask. A bind that
+            // fails must surface now, loudly, instead of as a query timeout.
+            var bindResult = new TaskCompletionSource<IPEndPoint>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _controller = _system.ActorOf(Props.Create(() => new Controller(participants, controllerPort, bindResult)),
                 "controller");
 
-            var node = await _controller.Ask<IPEndPoint>(TestKit.Controller.GetSockAddr.Instance, Settings.QueryTimeout, cancellationToken);
+            var node = await AwaitBindAsync(bindResult.Task, cancellationToken);
+            onBound?.Invoke(node);
             await StartClient(name, node);
             return node;
+        }
+
+        /// <summary>
+        /// Waits for the <see cref="Controller"/> to report the endpoint it bound.
+        /// </summary>
+        private async Task<IPEndPoint> AwaitBindAsync(Task<IPEndPoint> bindResult, CancellationToken cancellationToken)
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var timeout = Task.Delay(Settings.QueryTimeout, timeoutCts.Token);
+            var completed = await Task.WhenAny(bindResult, timeout);
+            timeoutCts.Cancel();
+
+            if (completed != bindResult)
+                throw new TimeoutException(
+                    $"TestConductor controller did not report a bound address within {Settings.QueryTimeout}.");
+
+            // Rethrows the bind failure with its own message and stack trace.
+            return await bindResult;
         }
 
         /// <summary>

--- a/src/core/Akka.Remote.TestKit/ConductorBindException.cs
+++ b/src/core/Akka.Remote.TestKit/ConductorBindException.cs
@@ -1,0 +1,71 @@
+//-----------------------------------------------------------------------
+// <copyright file="ConductorBindException.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Net;
+using System.Net.Sockets;
+using Akka.Actor;
+
+namespace Akka.Remote.TestKit;
+
+/// <summary>
+/// INTERNAL API.
+///
+/// Thrown when the <see cref="Controller"/> cannot bind its listener socket. The message names
+/// the endpoint so a failed run says why it failed instead of showing every client node timing
+/// out against a conductor that never came up.
+/// </summary>
+internal sealed class ConductorBindException : AkkaException
+{
+    private ConductorBindException(string message, Exception cause) : base(message, cause)
+    {
+    }
+
+    /// <summary>
+    /// Builds the exception for a failed bind, naming the port when the address was already taken.
+    /// </summary>
+    /// <param name="endpoint">Endpoint the controller tried to bind.</param>
+    /// <param name="cause">Failure reported by the transport.</param>
+    public static ConductorBindException ForEndpoint(IPEndPoint endpoint, Exception cause)
+    {
+        var message = IsAddressAlreadyInUse(cause)
+            ? $"conductor port {endpoint.Port} already in use - could not bind TestConductor controller to {endpoint}"
+            : $"could not bind TestConductor controller to {endpoint}";
+
+        return new ConductorBindException(message, cause);
+    }
+
+    /// <summary>
+    /// Walks the exception chain looking for an "address already in use" socket error. The
+    /// transport wraps the socket failure, so the top level exception is not the socket one.
+    /// </summary>
+    private static bool IsAddressAlreadyInUse(Exception? cause)
+    {
+        while (cause is not null)
+        {
+            switch (cause)
+            {
+                case SocketException { SocketErrorCode: SocketError.AddressAlreadyInUse }:
+                    return true;
+
+                case AggregateException aggregate:
+                    foreach (var inner in aggregate.Flatten().InnerExceptions)
+                    {
+                        if (IsAddressAlreadyInUse(inner))
+                            return true;
+                    }
+
+                    return false;
+            }
+
+            cause = cause.InnerException;
+        }
+
+        return false;
+    }
+}

--- a/src/core/Akka.Remote.TestKit/ConductorPortSentinel.cs
+++ b/src/core/Akka.Remote.TestKit/ConductorPortSentinel.cs
@@ -1,0 +1,78 @@
+//-----------------------------------------------------------------------
+// <copyright file="ConductorPortSentinel.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Globalization;
+using Akka.Annotations;
+
+namespace Akka.Remote.TestKit;
+
+/// <summary>
+/// INTERNAL API.
+///
+/// Contract between a conductor node and the multi-node test runner that started it.
+/// The conductor binds its <see cref="Controller"/> socket, then writes one sentinel line to
+/// stdout naming the port it got. The runner reads that line and starts the remaining nodes
+/// with that port.
+///
+/// The runner cannot pick the port itself. Probing for a free port and handing it over leaves a
+/// window in which any other socket on the machine can take that port before the conductor binds.
+/// </summary>
+[InternalApi]
+public static class ConductorPortSentinel
+{
+    private const int MinPort = 1;
+    private const int MaxPort = 65535;
+
+    /// <summary>
+    /// Leading text of the sentinel line. Distinctive so it cannot collide with spec output.
+    /// </summary>
+    public const string Prefix = "[MULTINODE-CONDUCTOR-PORT]";
+
+    /// <summary>
+    /// Renders the sentinel line for a bound conductor port.
+    /// </summary>
+    /// <param name="port">Port the conductor bound to. Must be in [1, 65535].</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="port"/> is out of range.</exception>
+    public static string Format(int port)
+    {
+        if (port < MinPort || port > MaxPort)
+            throw new ArgumentOutOfRangeException(nameof(port), port,
+                $"Conductor port must be in [{MinPort}, {MaxPort}].");
+
+        return Prefix + port.ToString(CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Reads a conductor port out of one line of node output.
+    /// </summary>
+    /// <param name="line">A single line of node stdout or stderr. May be <c>null</c>.</param>
+    /// <param name="port">Receives the parsed port, or <c>0</c> when the line is not a sentinel.</param>
+    /// <returns><c>true</c> when the line is a well formed sentinel.</returns>
+    public static bool TryParse(string? line, out int port)
+    {
+        port = 0;
+        if (string.IsNullOrWhiteSpace(line))
+            return false;
+
+        var trimmed = line!.Trim();
+        if (!trimmed.StartsWith(Prefix, StringComparison.Ordinal))
+            return false;
+
+        // NumberStyles.None rejects signs, decimal points and embedded whitespace.
+        var value = trimmed.Substring(Prefix.Length);
+        if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed))
+            return false;
+
+        if (parsed < MinPort || parsed > MaxPort)
+            return false;
+
+        port = parsed;
+        return true;
+    }
+}

--- a/src/core/Akka.Remote.TestKit/Controller.cs
+++ b/src/core/Akka.Remote.TestKit/Controller.cs
@@ -211,13 +211,39 @@ namespace Akka.Remote.TestKit
         private readonly ILoggingAdapter _log = Context.GetLogger();
 
         public Controller(int initialParticipants, IPEndPoint controllerPort)
+            : this(initialParticipants, controllerPort, null)
+        {
+        }
+
+        /// <param name="initialParticipants">Number of clients that must attach before the run starts.</param>
+        /// <param name="controllerPort">Endpoint to bind. Port 0 asks the OS for a free port.</param>
+        /// <param name="bindResult">
+        /// Optional. Receives the endpoint that was actually bound, or the bind failure. The caller
+        /// needs both without an ask: an ask turns a failed bind into a query timeout, and every
+        /// client node then burns its own attach timeout before the run gives up.
+        /// </param>
+        public Controller(int initialParticipants, IPEndPoint controllerPort, TaskCompletionSource<IPEndPoint> bindResult)
         {
             _log.Debug("Opening connection");
-            _connection = RemoteConnection.CreateConnection(Role.Server, controllerPort, _settings.ServerSocketWorkerPoolSize,
-                new ConductorHandler(Self, Logging.GetLogger(Context.System, typeof (ConductorHandler)))).Result;
+            try
+            {
+                _connection = RemoteConnection.CreateConnection(Role.Server, controllerPort, _settings.ServerSocketWorkerPoolSize,
+                    new ConductorHandler(Self, Logging.GetLogger(Context.System, typeof (ConductorHandler)))).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                var failure = ConductorBindException.ForEndpoint(controllerPort, ex);
+                bindResult?.TrySetException(failure);
+                throw failure;
+            }
+
             _log.Debug("Connection bound");
             _barrier = Context.ActorOf(Props.Create<BarrierCoordinator>(), "barriers");
             _initialParticipants = initialParticipants;
+
+            // Report last. The actor handles no message until this constructor returns, so the
+            // caller cannot observe a half built Controller.
+            bindResult?.TrySetResult((IPEndPoint)_connection.LocalAddress);
         }
 
         /// <summary>

--- a/src/core/Akka.Remote.TestKit/Controller.cs
+++ b/src/core/Akka.Remote.TestKit/Controller.cs
@@ -23,7 +23,7 @@ namespace Akka.Remote.TestKit
     /// 
     /// INTERNAL API.
     /// </summary>
-    internal class Controller : UntypedActor, ILogReceive
+    internal class Controller : UntypedActor, ILogReceive, IWithUnboundedStash
     {
         public sealed class ClientDisconnected : IDeadLetterSuppression
         {
@@ -194,14 +194,41 @@ namespace Akka.Remote.TestKit
             public IChannel Channel { get; private set; }
         }
 
+        /// <summary>
+        /// Carries a successful bind from <see cref="PreStart"/> back into the mailbox.
+        /// </summary>
+        private sealed class Bound : INoSerializationVerificationNeeded
+        {
+            public Bound(IChannel channel)
+            {
+                Channel = channel;
+            }
+
+            public IChannel Channel { get; }
+        }
+
+        /// <summary>
+        /// Carries a failed bind from <see cref="PreStart"/> back into the mailbox.
+        /// </summary>
+        private sealed class BindFailed : INoSerializationVerificationNeeded
+        {
+            public BindFailed(ConductorBindException cause)
+            {
+                Cause = cause;
+            }
+
+            public ConductorBindException Cause { get; }
+        }
+
         int _initialParticipants;
         readonly TestConductorSettings _settings = TestConductor.Get(Context.System).Settings;
 
         /// <summary>
-        /// Lazily load the result later
+        /// Set once the bind started in <see cref="PreStart"/> reports back. Non-null for the whole
+        /// of the <see cref="Ready"/> behavior.
         /// </summary>
         private IChannel _connection;
-        readonly IActorRef _barrier;
+        IActorRef _barrier;
         ImmutableDictionary<RoleName, NodeInfo> _nodes =
             ImmutableDictionary.Create<RoleName, NodeInfo>();
         // map keeping unanswered queries for node addresses (enqueued upon GetAddress, serviced upon NodeInfo)
@@ -209,6 +236,12 @@ namespace Akka.Remote.TestKit
             ImmutableDictionary.Create<RoleName, ImmutableHashSet<IActorRef>>();
         int _generation = 1;
         private readonly ILoggingAdapter _log = Context.GetLogger();
+        private readonly IPEndPoint _controllerPort;
+
+        /// <summary>
+        /// Null unless the caller asked to be told the bind outcome. See the constructor.
+        /// </summary>
+        private readonly TaskCompletionSource<IPEndPoint> _bindResult;
 
         public Controller(int initialParticipants, IPEndPoint controllerPort)
             : this(initialParticipants, controllerPort, null)
@@ -224,26 +257,81 @@ namespace Akka.Remote.TestKit
         /// </param>
         public Controller(int initialParticipants, IPEndPoint controllerPort, TaskCompletionSource<IPEndPoint> bindResult)
         {
-            _log.Debug("Opening connection");
-            try
-            {
-                _connection = RemoteConnection.CreateConnection(Role.Server, controllerPort, _settings.ServerSocketWorkerPoolSize,
-                    new ConductorHandler(Self, Logging.GetLogger(Context.System, typeof (ConductorHandler)))).GetAwaiter().GetResult();
-            }
-            catch (Exception ex)
-            {
-                var failure = ConductorBindException.ForEndpoint(controllerPort, ex);
-                bindResult?.TrySetException(failure);
-                throw failure;
-            }
-
-            _log.Debug("Connection bound");
-            _barrier = Context.ActorOf(Props.Create<BarrierCoordinator>(), "barriers");
             _initialParticipants = initialParticipants;
+            _controllerPort = controllerPort;
+            _bindResult = bindResult;
+        }
 
-            // Report last. The actor handles no message until this constructor returns, so the
-            // caller cannot observe a half built Controller.
-            bindResult?.TrySetResult((IPEndPoint)_connection.LocalAddress);
+        public IStash Stash { get; set; }
+
+        /// <summary>
+        /// Starts the bind. The result comes back as a <see cref="Bound"/> or
+        /// <see cref="BindFailed"/> message, so the bind never blocks a dispatcher thread and
+        /// its outcome is serialized with the rest of the mailbox.
+        /// </summary>
+        protected override void PreStart()
+        {
+            _log.Debug("Opening connection");
+            RemoteConnection
+                .CreateConnection(Role.Server, _controllerPort, _settings.ServerSocketWorkerPoolSize,
+                    new ConductorHandler(Self, Logging.GetLogger(Context.System, typeof (ConductorHandler))))
+                .PipeTo(Self,
+                    success: channel => new Bound(channel),
+                    // Name the failure here, so the message already carries the error the caller reports.
+                    failure: ex => new BindFailed(ConductorBindException.ForEndpoint(_controllerPort, Unwrap(ex))));
+        }
+
+        /// <summary>
+        /// Strips the single-exception AggregateException a piped task failure arrives in, so the
+        /// reported cause is the socket error itself.
+        /// </summary>
+        private static Exception Unwrap(Exception cause)
+        {
+            if (cause is not AggregateException aggregate)
+                return cause;
+
+            var flattened = aggregate.Flatten();
+            return flattened.InnerExceptions.Count == 1 ? flattened.InnerExceptions[0] : flattened;
+        }
+
+        /// <summary>
+        /// Initial behavior: waiting for the bind started in <see cref="PreStart"/> to report back.
+        /// </summary>
+        protected override void OnReceive(object message)
+        {
+            switch (message)
+            {
+                case Bound bound:
+                    _connection = bound.Channel;
+                    _log.Debug("Connection bound");
+
+                    // Barrier first, report second. The caller must not see a bound conductor
+                    // before this actor can serve barrier traffic.
+                    _barrier = Context.ActorOf(Props.Create<BarrierCoordinator>(), "barriers");
+                    _bindResult?.TrySetResult((IPEndPoint)_connection.LocalAddress);
+
+                    Become(Ready);
+                    Stash.UnstashAll();
+                    return;
+
+                case BindFailed failed:
+                    _log.Error(failed.Cause, "Could not bind TestConductor controller");
+                    _bindResult?.TrySetException(failed.Cause);
+
+                    // Stop, never throw. A throw from a message handler runs the default
+                    // supervision directive, Restart, which re-runs PreStart and binds the same
+                    // dead port again - forever.
+                    Context.Stop(Self);
+                    return;
+
+                default:
+                    // The bound socket is the only source of real controller traffic, but it starts
+                    // accepting the moment the bind completes - which is before this actor gets the
+                    // Bound message. A client that connects in that window makes ConductorHandler
+                    // send CreateServerFSM ahead of Bound. Hold anything that races in.
+                    Stash.Stash();
+                    return;
+            }
         }
 
         /// <summary>
@@ -284,7 +372,11 @@ namespace Akka.Remote.TestKit
             return Directive.Restart;
         }
 
-        protected override void OnReceive(object message)
+        /// <summary>
+        /// Behavior after a successful bind. <see cref="_connection"/> and <see cref="_barrier"/>
+        /// are non-null here by construction of the state machine.
+        /// </summary>
+        private void Ready(object message)
         {
             var createServerFSM = message as CreateServerFSM;
             if (createServerFSM != null)
@@ -423,8 +515,16 @@ namespace Akka.Remote.TestKit
         {
             try
             {
-                RemoteConnection.Shutdown(_connection);
-                RemoteConnection.ReleaseAll().Wait(_settings.ConnectTimeout);
+                // Null when the bind failed: this actor stops without ever holding a connection.
+                if (_connection is not null)
+                    RemoteConnection.Shutdown(_connection);
+
+                // PostStop cannot await, and blocking the dispatcher on a drain is what this class
+                // is being cleaned of. ReleaseAll detaches the pools before it returns, so any
+                // later CreateConnection builds fresh ones; only the graceful drain runs on.
+                RemoteConnection.ReleaseAll().ContinueWith(
+                    t => _log.Error(t.Exception, "Error while terminating RemoteConnection."),
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
             }
             catch (Exception ex)
             {

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -335,6 +335,10 @@ public abstract class MultiNodeSpec : TestKitBase, IMultiNodeSpecCallbacks, IDis
     /// Port number of the node that's running the server system. Defaults to 4711.
     ///
     /// <code>-Dmultinode.server-port=4711</code>
+    ///
+    /// A value of 0 means automatic allocation: the conductor node binds a free port and prints
+    /// it as a <see cref="ConductorPortSentinel"/> line, and the runner passes that port to the
+    /// other nodes. Only the conductor node (<c>multinode.index=0</c>) may be given 0.
     /// </summary>
     public static int ServerPort
     {
@@ -346,7 +350,7 @@ public abstract class MultiNodeSpec : TestKitBase, IMultiNodeSpecCallbacks, IDis
                 _serverPort = string.IsNullOrEmpty(serverPortStr) ? ServerPortDefault : Int32.Parse(serverPortStr);
             }
 
-            if (!(_serverPort > 0 && _serverPort < 65535)) throw new InvalidOperationException("multinode.server-port is out of bounds: " + _serverPort);
+            if (!(_serverPort >= 0 && _serverPort < 65535)) throw new InvalidOperationException("multinode.server-port is out of bounds: " + _serverPort);
             return _serverPort;
         }
     }
@@ -461,6 +465,13 @@ public abstract class MultiNodeSpec : TestKitBase, IMultiNodeSpecCallbacks, IDis
         _log = Logging.GetLogger(Sys, this);
         Roles = roles;
         _deployments = deployments;
+
+        // Port 0 means "bind a free port and publish it". Only the conductor node can do that;
+        // a client node given 0 has no address to connect to.
+        if (ServerPort == 0 && SelfIndex != 0)
+            throw new InvalidOperationException(
+                "multinode.server-port=0 is only valid on the conductor node (multinode.index=0). " +
+                "Client nodes must be given the port the conductor published.");
 
         var node = new IPEndPoint(Dns.GetHostAddresses(ServerName)[0], ServerPort);
         _controllerAddr = node;
@@ -655,7 +666,7 @@ public abstract class MultiNodeSpec : TestKitBase, IMultiNodeSpecCallbacks, IDis
         try
         {
             if (SelfIndex == 0)
-                await tc.StartControllerAsync(InitialParticipants, Myself, _controllerAddr, cts.Token);
+                await tc.StartControllerAsync(InitialParticipants, Myself, _controllerAddr, PublishConductorPort, cts.Token);
             else
                 await tc.StartClientAsync(Myself, _controllerAddr, cts.Token);
         }
@@ -664,6 +675,17 @@ public abstract class MultiNodeSpec : TestKitBase, IMultiNodeSpecCallbacks, IDis
             throw new Exception("failure while attaching new conductor", e);
         }
         TestConductor = tc;
+    }
+
+    /// <summary>
+    /// Writes the conductor's bound port to stdout for the multi-node test runner to read.
+    /// Emitted for explicitly configured ports too, so the runner sees one contract no matter
+    /// how the port was chosen.
+    /// </summary>
+    private static void PublishConductorPort(IPEndPoint boundAddress)
+    {
+        Console.Out.WriteLine(ConductorPortSentinel.Format(boundAddress.Port));
+        Console.Out.Flush();
     }
 
     // now add deployments, if so desired


### PR DESCRIPTION
The MNTR conductor had a port race. This PR removes it. The conductor now binds port 0 and publishes the port it received. Conductor startup failures now fail fast with a clear error.

## The defect

The runner chose the conductor port before anything bound it. It bound a probe socket, read the port number, closed the socket, and passed the number to all node processes. Any other process could take the port in that gap. The probe also bound IPv4, but the conductor binds `::1` on CI agents. So the probe never reserved the port it reported.

When the port was taken, the `Controller` threw `Address already in use`. No conductor existed. Every node then waited 30 seconds for its attach to time out. The failure was charged to whatever spec was running. Build 130909 shows the full pattern, including conductor clients that connected to the spec's artery listener by mistake.

## The fix

1. The runner starts the conductor node first, with `server-port = 0`.
2. The conductor binds the port the OS assigns. It then writes one line to stdout: `[MULTINODE-CONDUCTOR-PORT]<port>`.
3. The runner already reads node stdout. It parses this line and learns the real port.
4. The runner then starts the other nodes with that port.
5. If the conductor node exits early, or the line does not arrive within 60 seconds, the runner kills the conductor node and fails the spec at once. The error names the conductor. Nodes that never started get proper `TestFailed` results.
6. An explicit port that is already in use now raises `ConductorBindException: conductor port {port} already in use`. In a controlled test this failed the whole spec in 787 ms. The old path burned 3 × 30 seconds.

Both runner variants (`Akka.MultiNode.TestAdapter` and `.Xunit2`) carry the change.

## The Controller no longer blocks

The old `Controller` bound the socket in its constructor with a blocked wait. The second commit removes that. The constructor now only assigns fields. `PreStart` starts the bind and pipes the result to the actor as a message. The actor starts in a `Binding` state:

- `Bound`: store the connection, create the barrier coordinator, report the port, switch to `Ready`.
- `BindFailed`: report the failure and stop the actor. The actor must stop here, not throw. A throw would trigger a supervision restart, which would bind the same dead port again, forever.
- Anything else: stash. This matters. A client can connect the moment the socket accepts, before the actor processes `Bound`. Its first message waits in the stash until the actor is `Ready`.

The `Controller` contains no `await`, no `.Result`, no `.Wait`, and no `ConfigureAwait`. The pipe continuation only sends a message, so nothing runs outside the actor.

## What does not change

- An explicit non-zero `multinode.server-port` binds that exact port, as before. Hand-run node processes still work. The unset default is still `47110`.
- Barrier timers start where they always did: when each node begins its own attach.
- The public API is unchanged except one new `[InternalApi]` type, `ConductorPortSentinel`. It is public because two assemblies share the line format. No API approval file changed. `Akka.API.Tests` passes 18/18.

One measured shift: the conductor node now attaches while the runner spawns the other nodes. That adds about 0.65 s of serialization against a 30-second attach budget.

## Verification

| Check | Result |
|---|---|
| `ConductorPortSentinelSpec` (20 cases) + `ConductorBindSpec` (3) | pass; port-in-use fails fast and named |
| `Akka.Remote.TestKit.Tests` full | 40 passed |
| Both adapter test suites | 28 + 28 passed |
| Real MNTR specs through the modified adapter (`DistributedPubSubRestartSpec`, `NodeMembershipSpec`, `ShardedDaemonProcess*`, `RemoteReDeploymentFastMultiNetSpec`), classic + artery | all rounds pass; sentinel present in node 1's log every round |
| Full CI matrix on commit 1 | green on every lane, first try |
| `-warnaserror` on all touched projects | 0 warnings |

## Known leftovers, out of scope

- The runner's TCP log server still picks its port with the old probe pattern. A collision there loses node logging, not the run. Follow-up candidate.
- `StartNewSystem` on the conductor node plus port 0 would bind a port no client knows. That combination was already broken with explicit ports. The one spec that uses `StartNewSystemAsync` runs it on a non-conductor node.
