### PR TITLE
Serialization.V2: remove [AkkaEnvelopePayload]; a property typed object is the serializer boundary

### DIFF
--- a/openspec/changes/internal-serializers-messagepack-v2/tasks.md
+++ b/openspec/changes/internal-serializers-messagepack-v2/tasks.md
@@ -17,7 +17,7 @@
 ## 3. Subsystem 2 — DistributedData (ids 12->52, 11->51) [headline hot-path]
 
 - [ ] 3.1 DTO mirrors for the `ReplicatorMessage` set; hand-written `IAkkaMessagePackFormatter<T>` for `UniqueAddress`/`VersionVector` (design.md Decision 10)
-- [ ] 3.2 Preserve/re-evaluate gzip on `Gossip`/`ORSet`/`ORMap`; `OtherMessage` -> `[AkkaEnvelopePayload]`
+- [ ] 3.2 Preserve/re-evaluate gzip on `Gossip`/`ORSet`/`ORMap`; `OtherMessage` -> an `object`-typed field (the serializer boundary)
 - [ ] 3.3 `ReplicatedData` CRDT mirrors + delta-op serializers
 - [ ] 3.4 **Prerequisite PR — make `LmdbDurableStore` self-describing**: prepend a per-record `(serializerId, manifest)` header; recover headerless records as legacy protobuf `DurableDataEnvelope`; disambiguate with a leading `0x00` sentinel (invalid as a protobuf record start). Lands BEFORE the DData flip (design.md Decision 11)
 - [ ] 3.5 Register v2 ids additively; golden + cross-read tests; durable-read-back proof: write a pre-header (protobuf, headerless) LMDB database, flip the binding, restart, recover successfully; plus mixed old/new records recover by their stored header

--- a/openspec/changes/messagepack-sourcegen-validation/proposal.md
+++ b/openspec/changes/messagepack-sourcegen-validation/proposal.md
@@ -8,7 +8,7 @@ This change runs after the atomic `serializer-v2` foundation. It is not a late o
 
 - Add `Akka.Serialization.V2` package for user-facing generated serializers.
 - Use direct MessagePack-CSharp reader/writer cursors in generated serializers.
-- Add attributes such as `[AkkaSerializable]`, `[AkkaField]`, and serializer configuration attributes (`[AkkaSerializer<TProtocol>]`, `[AkkaEnvelopePayload]`, `[AkkaSerializerFormatter<TTarget, TFormatter>]`).
+- Add attributes such as `[AkkaSerializable]`, `[AkkaField]`, and serializer configuration attributes (`[AkkaSerializer<TProtocol>]`, `[AkkaSerializerFormatter<TTarget, TFormatter>]`); an `object`-typed field is the serializer boundary.
 - Add manifest-discriminated closed unions (`[AkkaUnion]`) and closed generic type registrations (`[AkkaSerializable<T>]`) so the generator can serialize a bounded polymorphic field or a closed construction of a generic message type.
 - Add a Roslyn incremental source generator that emits V2 serializers.
 - Register generated serializers explicitly through per-serializer generated helpers; do not use runtime assembly scanning.

--- a/openspec/changes/messagepack-sourcegen-validation/specs/messagepack-sourcegen/spec.md
+++ b/openspec/changes/messagepack-sourcegen-validation/specs/messagepack-sourcegen/spec.md
@@ -66,28 +66,40 @@ The system SHALL provide a Roslyn incremental source generator that emits `Seria
 
 ### Requirement: Generated serializers support envelope payload boundaries
 
-Generated serializers SHALL support `[AkkaEnvelopePayload]` fields as Akka serializer boundaries rather than inline generated schemas.
+Generated serializers SHALL treat a field whose static type, after generic substitution, is `object` (or `object?`) as an Akka serializer boundary rather than an inline generated schema. No attribute is required, and none exists for this purpose.
 
 #### Scenario: Envelope payload field serialized
-- **WHEN** a generated serializer writes a field marked `[AkkaEnvelopePayload]`
+- **WHEN** a generated serializer writes an `object`-typed field
 - **THEN** it SHALL resolve the field value through normal Akka serializer lookup
 - **AND** it SHALL store the payload serializer id, serializer manifest, and opaque serialized payload bytes
 
 #### Scenario: Envelope payload field deserialized
-- **WHEN** a generated serializer reads a non-null `[AkkaEnvelopePayload]` field
+- **WHEN** a generated serializer reads a non-null `object`-typed field
 - **THEN** it SHALL recover the field value through normal Akka deserialization using the stored serializer id, manifest, and bytes
 
 #### Scenario: V2 envelope payload deserialized without byte-array copy
-- **WHEN** a generated serializer reads a non-null `[AkkaEnvelopePayload]` field whose payload serializer is V2
+- **WHEN** a generated serializer reads a non-null `object`-typed field whose payload serializer is V2
 - **THEN** it SHALL dispatch the MessagePack `bin` payload as a `ReadOnlySequence<byte>` without first copying it into a byte array
 
 #### Scenario: Unknown-size envelope payload serialized through staging buffer
-- **WHEN** a generated serializer writes a non-null `[AkkaEnvelopePayload]` field whose serialized length is not known before writing the MessagePack `bin` header
+- **WHEN** a generated serializer writes a non-null `object`-typed field whose serialized length is not known before writing the MessagePack `bin` header
 - **THEN** it SHALL stage the inner payload bytes before writing the outer `bin` field
 
 #### Scenario: Nested envelope payload chain
-- **WHEN** generated envelopes contain nested `[AkkaEnvelopePayload]` fields
+- **WHEN** generated envelopes contain nested `object`-typed fields
 - **THEN** generated V2 payloads and custom V1 payloads SHALL round-trip without requiring structural MessagePack encoding for the inner payload object
+
+#### Scenario: Generic wrapper closed over object is a boundary
+- **WHEN** a generic `[AkkaSerializable]` definition has a `[AkkaField]` property typed by its type parameter, and a registered closed construction substitutes `object` for that parameter
+- **THEN** the generator SHALL treat that field as a serializer boundary in the closed construction
+
+#### Scenario: Union declaration on an object-typed field rejected
+- **WHEN** an `[AkkaField]` property typed `object` carries a field-level `[AkkaUnion]`
+- **THEN** the generator SHALL fail compilation with a diagnostic (AKKASG038), because an `object`-typed field is always a serializer boundary
+
+#### Scenario: Interface field without a closed set names the fixes
+- **WHEN** an `[AkkaField]` property's static type is an interface, an abstract class, or a type parameter with no closed member set
+- **THEN** the generator SHALL fail compilation with a diagnostic (AKKASG003) whose message names both fixes: declare a closed member set with `[AkkaUnion]`, or type the property as `object`
 
 ### Requirement: Generated serializers use explicit registration
 
@@ -167,7 +179,7 @@ Generated serializers SHALL initially support immutable message designs and nest
 
 ### Requirement: Generated serializers support manifest-discriminated closed unions
 
-The system SHALL support declaring a closed, explicitly-enumerated set of concrete `[AkkaSerializable]` member types for a field via `[AkkaUnion]`, encoded structurally inline and discriminated by manifest, distinct from the runtime-resolved `[AkkaEnvelopePayload]` serializer boundary.
+The system SHALL support declaring a closed, explicitly-enumerated set of concrete `[AkkaSerializable]` member types for a field via `[AkkaUnion]`, encoded structurally inline and discriminated by manifest, distinct from the runtime-resolved serializer boundary of an `object`-typed field.
 
 #### Scenario: Type-level union declaration
 - **WHEN** a union base interface or abstract class is annotated with `[AkkaUnion]`

--- a/openspec/changes/messagepack-sourcegen-validation/tasks.md
+++ b/openspec/changes/messagepack-sourcegen-validation/tasks.md
@@ -57,6 +57,7 @@
 - [x] 5.13 Support `[AkkaEnvelopePayload]` fields through runtime Akka serializer lookup
 - [x] 5.14 Support foreign-type formatters via [AkkaSerializerFormatter] escape hatch (AddressFormatter/ActorPathFormatter built-ins, byte-compatible with Artery control-message wire format)
 - [x] 5.15 Honor declared accessibility of serializer partial classes (internal serializers)
+- [x] 5.16 Remove `[AkkaEnvelopePayload]`; an `object`-typed field is the serializer boundary on its own, AKKASG035 retired, AKKASG038 added (design.md Decision 20) — PR #8518
 
 ## 6. Integration Validation
 

--- a/src/benchmark/Akka.Benchmarks/Serialization/GeneratedMessagePackSerializerBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Serialization/GeneratedMessagePackSerializerBenchmarks.cs
@@ -217,7 +217,7 @@ public class GeneratedMessagePackSerializerBenchmarks
             _generatedNestedEnvelopeBytes,
             _envelopeSerializer.Identifier,
             _nestedEnvelopeManifest);
-        return envelope.Inner.Payload;
+        return ((BenchmarkInnerEnvelope)envelope.Inner).Payload;
     }
 
     [Benchmark]
@@ -233,7 +233,7 @@ public class GeneratedMessagePackSerializerBenchmarks
             _customNestedEnvelopeBytes,
             _envelopeSerializer.Identifier,
             _nestedEnvelopeManifest);
-        return envelope.Inner.Payload;
+        return ((BenchmarkInnerEnvelope)envelope.Inner).Payload;
     }
 
     [Benchmark]
@@ -249,7 +249,7 @@ public class GeneratedMessagePackSerializerBenchmarks
             _customSameShapeNestedEnvelopeBytes,
             _envelopeSerializer.Identifier,
             _nestedEnvelopeManifest);
-        return envelope.Inner.Payload;
+        return ((BenchmarkInnerEnvelope)envelope.Inner).Payload;
     }
 
     [Benchmark(Baseline = true)]
@@ -348,12 +348,12 @@ public sealed record BenchmarkSerializedPayload(
 [AkkaSerializable(Manifest = "benchmark-outer-envelope-v1")]
 public sealed record BenchmarkOuterEnvelope(
     [property: AkkaField(0)] string EnvelopeId,
-    [property: AkkaField(1), AkkaEnvelopePayload] BenchmarkInnerEnvelope Inner) : IEnvelopeBenchmarkProtocol;
+    [property: AkkaField(1)] object Inner) : IEnvelopeBenchmarkProtocol;
 
 [AkkaSerializable(Manifest = "benchmark-inner-envelope-v1")]
 public sealed record BenchmarkInnerEnvelope(
     [property: AkkaField(0)] string EnvelopeId,
-    [property: AkkaField(1), AkkaEnvelopePayload] object Payload) : IEnvelopeBenchmarkProtocol;
+    [property: AkkaField(1)] object Payload) : IEnvelopeBenchmarkProtocol;
 
 public sealed record CustomBenchmarkPayload(string PayloadId, int Value);
 

--- a/src/core/Akka.Remote.Tests/Artery/ArteryControlMessageSerializerSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryControlMessageSerializerSpec.cs
@@ -195,7 +195,7 @@ namespace Akka.Remote.Tests.Artery
             protected override bool Receive(object message) => true;
         }
 
-        [Fact(DisplayName = "ArteryControlMessageSerializer should round-trip SystemMessageEnvelope wrapping a Watch, nesting the inner system message via [AkkaEnvelopePayload] (design.md gate G3)")]
+        [Fact(DisplayName = "ArteryControlMessageSerializer should round-trip SystemMessageEnvelope wrapping a Watch, nesting the inner system message via its object-typed envelope field (design.md gate G3)")]
         public void Should_round_trip_SystemMessageEnvelope_wrapping_Watch()
         {
             var watchee = (IInternalActorRef)_system.ActorOf(Props.Create<NopActor>());

--- a/src/core/Akka.Remote/Artery/SystemMessageDeliveryMessages.cs
+++ b/src/core/Akka.Remote/Artery/SystemMessageDeliveryMessages.cs
@@ -117,8 +117,8 @@ namespace Akka.Remote.Artery
     /// mirroring today's ordinary-message fallback for an absent sender.
     /// </para>
     /// <para>
-    /// <b>Sourcegen swap field-id note.</b> <see cref="Message"/> is marked
-    /// <see cref="AkkaEnvelopePayloadAttribute"/>, routing it through the generated serializer's
+    /// <b>Sourcegen swap field-id note.</b> <see cref="Message"/> is typed <see langword="object"/>,
+    /// which the generator always routes through the generated serializer's
     /// <c>WriteEnvelopePayload</c>/<c>ReadEnvelopePayload</c> calls -- the SAME
     /// <see cref="Akka.Serialization.V2.AkkaSerializer"/> base-class helpers the
     /// prior hand-rolled <see cref="ArteryControlMessageSerializer"/> used, confirming the generator
@@ -136,7 +136,7 @@ namespace Akka.Remote.Artery
     /// <param name="RecipientPath">The resolved wire-format path of the recipient actor.</param>
     [AkkaSerializable(Manifest = ArteryControlMessageSerializer.SystemMessageEnvelopeManifest)]
     internal sealed record SystemMessageEnvelope(
-        [property: AkkaField(1), AkkaEnvelopePayload] ISystemMessage Message,
+        [property: AkkaField(1)] object Message,
         [property: AkkaField(2)] long SeqNo,
         [property: AkkaField(3)] UniqueAddress AckReplyTo,
         [property: AkkaField(4)] string RecipientPath) : IArterySystemMessageDeliveryMessage;

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.cs
@@ -24,7 +24,6 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
     private const string SerializerAttributeFullName = "Akka.Serialization.V2.AkkaSerializerAttribute`1";
     private const string SerializableAttributeFullName = "Akka.Serialization.V2.AkkaSerializableAttribute";
     private const string FieldAttributeFullName = "Akka.Serialization.V2.AkkaFieldAttribute";
-    private const string EnvelopePayloadAttributeFullName = "Akka.Serialization.V2.AkkaEnvelopePayloadAttribute";
     private const string UnionAttributeFullName = "Akka.Serialization.V2.AkkaUnionAttribute";
     private const string GenericSerializableAttributeFullName = "Akka.Serialization.V2.AkkaSerializableAttribute`1";
     private const string FormatterAttributeFullName = "Akka.Serialization.V2.AkkaSerializerFormatterAttribute`2";
@@ -61,11 +60,12 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         isEnabledByDefault: true);
 
     // Same id/title/severity as UnsupportedFieldType. Used only for an interface, abstract class,
-    // or type parameter field, which is usually a forgotten [AkkaEnvelopePayload]/[AkkaUnion].
+    // or type parameter field, which is usually a forgotten [AkkaUnion], or a field that should
+    // simply be typed object.
     private static readonly DiagnosticDescriptor UnsupportedFieldTypePolymorphic = new(
         "AKKASG003",
         "Unsupported field type",
-        "Property '{0}' on type '{1}' has unsupported generated serializer field type '{2}'. Mark the property [AkkaEnvelopePayload], or declare a closed member set with [AkkaUnion].",
+        "Property '{0}' on type '{1}' has unsupported generated serializer field type '{2}'. Declare a closed member set with [AkkaUnion], or type the property as object.",
         "Akka.Serialization.V2",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
@@ -345,14 +345,6 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
-    private static readonly DiagnosticDescriptor UnionDeclarationIgnoredOnEnvelopePayload = new(
-        "AKKASG035",
-        "Union declaration is ignored on an envelope payload field",
-        "Property '{0}' on type '{1}' has both [AkkaEnvelopePayload] and [AkkaUnion]; the union declaration is ignored -- envelope payload takes precedence",
-        "Akka.Serialization.V2",
-        DiagnosticSeverity.Info,
-        isEnabledByDefault: true);
-
     private static readonly DiagnosticDescriptor UnionMemberAbstract = new(
         "AKKASG036",
         "Union member type is abstract",
@@ -367,6 +359,21 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         "Generic [AkkaSerializable] type '{0}' specifies Manifest '{1}', which is ignored: a generic definition is never serialized directly, and each closed construction registered with [AkkaSerializable<T>] supplies its own Manifest",
         "Akka.Serialization.V2",
         DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// An object-typed property is ALWAYS the envelope-payload boundary (Decision 20): the static
+    /// type alone carries that meaning, with no attribute involved. A field-level <c>[AkkaUnion]</c>
+    /// on such a property is therefore contradictory author intent -- not a harmless no-op -- so
+    /// this is an ERROR, unlike the retired AKKASG035 advisory it replaces (deliberately a
+    /// different id; AKKASG035 stays a permanent gap).
+    /// </summary>
+    private static readonly DiagnosticDescriptor UnionDeclaredOnObjectField = new(
+        "AKKASG038",
+        "Union declaration on an object-typed property",
+        "Property '{0}' on type '{1}' is typed object, which is always an envelope payload boundary, but carries a field-level [AkkaUnion]. Type the property as the union's base type, or remove the attribute.",
+        "Akka.Serialization.V2",
+        DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
     /// <summary>
@@ -1232,16 +1239,17 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
 
             var index = (int)fieldAttribute.ConstructorArguments[0].Value!;
             var isNullable = member.NullableAnnotation == NullableAnnotation.Annotated || IsNullableValueType(member.Type);
-            var isEnvelopePayload = member.GetAttributes()
-                .Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, knownTypes.EnvelopePayloadAttribute));
+            // A property whose static type is `object` (nullable or not), after generic
+            // substitution, is always the envelope-payload boundary: the type alone carries that
+            // meaning, with no attribute involved.
+            var isEnvelopePayload = member.Type.SpecialType == SpecialType.System_Object;
             var unionMembers = ExtractUnionMembers(member, knownTypes, compilation, out var hasUnionAttribute, out var unionDeclaredOnField);
 
-            // Precedence: [AkkaEnvelopePayload] always wins (matching its documented precedence over
-            // formatter registrations), then [AkkaUnion], then ordinary inference. When the envelope
-            // suppresses a FIELD-LEVEL [AkkaUnion] the conflict is remembered for the AKKASG035
-            // advisory: both attributes on one property are conflicting author intent. A TYPE-LEVEL
-            // [AkkaUnion] on the field's static type is deliberately exempt -- it serves that
-            // interface's other, non-envelope fields, so its presence here is incidental.
+            // Precedence: an `object`-typed field always wins (matching its documented precedence
+            // over formatter registrations), then [AkkaUnion], then ordinary inference. A field
+            // typed `object` that ALSO carries a field-level [AkkaUnion] is contradictory author
+            // intent, not a harmless no-op -- AKKASG038 (error) fires on it below. A TYPE-LEVEL
+            // [AkkaUnion] is irrelevant here: `object`'s own type never carries one.
             var mapping = isEnvelopePayload ? new TypeMapping(FieldKind.EnvelopePayload)
                 : hasUnionAttribute ? new TypeMapping(FieldKind.Union)
                 : MapType(member.Type, knownTypes);
@@ -1252,7 +1260,7 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
                 mapping,
                 isNullable,
                 unionMembers: isEnvelopePayload ? default : unionMembers,
-                unionSuppressedByEnvelope: isEnvelopePayload && unionDeclaredOnField));
+                unionDeclaredOnObjectField: isEnvelopePayload && unionDeclaredOnField));
             fieldSymbols.Add(member);
         }
 
@@ -1443,7 +1451,10 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         // Field-level override wins; otherwise inherit the type-level declaration from the field's
         // static type. OriginalDefinition covers a generic union base, where the attribute lives on
         // the definition. Whether the declaration sits on the FIELD itself is reported separately
-        // (unionDeclaredOnField) for the AKKASG035 envelope-conflict advisory.
+        // (unionDeclaredOnField) -- needed ONLY to tell an object-typed field's own [AkkaUnion]
+        // (AKKASG038, contradictory author intent) apart from a type-level [AkkaUnion] it merely
+        // inherited (irrelevant for `object`, since `object`'s own type never carries one, but kept
+        // symmetric with the general lookup below).
         var unionAttribute = member.GetAttributes()
             .FirstOrDefault(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, knownTypes.UnionAttribute));
         unionDeclaredOnField = unionAttribute != null;
@@ -1661,12 +1672,13 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
                 context.ReportDiagnostic(Diagnostic.Create(ConstructorParameterNotCovered, Location.None, parameterName, ToDisplayName(message.FullyQualifiedName)));
             }
 
-            // Advisory only (AKKASG035): both [AkkaEnvelopePayload] and a field-level [AkkaUnion]
-            // were declared on this property; extraction dropped the union member set because
-            // envelope payload takes precedence (see ExtractMessageCore).
-            foreach (var field in message.Fields.Where(field => field.UnionSuppressedByEnvelope))
+            // Error (AKKASG038): an object-typed property is always the envelope-payload boundary
+            // (the static type alone carries that meaning); a field-level [AkkaUnion] on it can
+            // never take effect, so this is contradictory author intent, not a harmless no-op.
+            foreach (var field in message.Fields.Where(field => field.UnionDeclaredOnObjectField))
             {
-                context.ReportDiagnostic(Diagnostic.Create(UnionDeclarationIgnoredOnEnvelopePayload, Location.None, field.Name, ToDisplayName(message.FullyQualifiedName)));
+                context.ReportDiagnostic(Diagnostic.Create(UnionDeclaredOnObjectField, Location.None, field.Name, ToDisplayName(message.FullyQualifiedName)));
+                isValid = false;
             }
 
             foreach (var field in message.Fields.Where(field => field.Mapping.Kind == FieldKind.Unsupported))
@@ -2435,8 +2447,8 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
     // member's ordinary inline field map> }. The manifest is the discriminator -- the same
     // serializer-owned manifest the member would carry as a top-level message -- so a value reads
     // identically whether it arrived through union dispatch or ordinary manifest dispatch. Contrast
-    // with [AkkaEnvelopePayload]'s { 1: serializerId, 2: manifest, 3: opaque bytes }: the union
-    // omits the serializer id (every member is owned by this serializer) and inlines the member's
+    // with an object-typed envelope field's { 1: serializerId, 2: manifest, 3: opaque bytes }: the
+    // union omits the serializer id (every member is owned by this serializer) and inlines the member's
     // fields directly instead of double-buffering them into a length-prefixed blob.
     //
     // Write dispatch matches the runtime type EXACTLY (value.GetType() == typeof(Member)) rather
@@ -3495,9 +3507,9 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             return new TypeMapping(FieldKind.MissingSerializableDefinition, GetFullyQualifiedTypeName(missingNestedType), foreignAssemblyName: GetForeignAssemblyName(missingNestedType, knownTypes));
 
         // AKKASG003 on an interface, an abstract class, or a type parameter is usually a forgotten
-        // [AkkaEnvelopePayload]/[AkkaUnion] declaration rather than a genuinely unrepresentable
-        // type -- flag it so ValidateMessages can point authors at both fixes instead of leaving
-        // them to guess.
+        // [AkkaUnion] declaration, or a field that should simply be typed `object`, rather than a
+        // genuinely unrepresentable type -- flag it so ValidateMessages can point authors at both
+        // fixes instead of leaving them to guess.
         var suggestsEnvelopeOrUnion = type.TypeKind == TypeKind.TypeParameter
             || (type is INamedTypeSymbol { IsAbstract: true } && type.TypeKind is TypeKind.Interface or TypeKind.Class);
         return suggestsEnvelopeOrUnion ? new TypeMapping(FieldKind.Unsupported, suggestsEnvelopeOrUnion: true) : mapping;
@@ -4155,7 +4167,6 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         {
             CompilationAssembly = compilation.Assembly;
             FieldAttribute = compilation.GetTypeByMetadataName(FieldAttributeFullName);
-            EnvelopePayloadAttribute = compilation.GetTypeByMetadataName(EnvelopePayloadAttributeFullName);
             UnionAttribute = compilation.GetTypeByMetadataName(UnionAttributeFullName);
             SerializableAttribute = compilation.GetTypeByMetadataName(SerializableAttributeFullName);
             Guid = compilation.GetTypeByMetadataName("System.Guid");
@@ -4181,7 +4192,6 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         public IAssemblySymbol CompilationAssembly { get; }
 
         public INamedTypeSymbol? FieldAttribute { get; }
-        public INamedTypeSymbol? EnvelopePayloadAttribute { get; }
         public INamedTypeSymbol? UnionAttribute { get; }
         public INamedTypeSymbol? SerializableAttribute { get; }
         public INamedTypeSymbol? Guid { get; }
@@ -4499,7 +4509,7 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
 
     private sealed class FieldInfo : IEquatable<FieldInfo>
     {
-        public FieldInfo(int index, string name, string typeFullName, TypeMapping mapping, bool isNullable, FormatterInfo? formatter = null, ImmutableArray<UnionMemberInfo> unionMembers = default, bool unionSuppressedByEnvelope = false)
+        public FieldInfo(int index, string name, string typeFullName, TypeMapping mapping, bool isNullable, FormatterInfo? formatter = null, ImmutableArray<UnionMemberInfo> unionMembers = default, bool unionDeclaredOnObjectField = false)
         {
             Index = index;
             Name = name;
@@ -4508,7 +4518,7 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             IsNullable = isNullable;
             Formatter = formatter;
             UnionMembers = unionMembers.IsDefault ? ImmutableArray<UnionMemberInfo>.Empty : unionMembers;
-            UnionSuppressedByEnvelope = unionSuppressedByEnvelope;
+            UnionDeclaredOnObjectField = unionDeclaredOnObjectField;
         }
 
         public int Index { get; }
@@ -4522,15 +4532,16 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         public ImmutableArray<UnionMemberInfo> UnionMembers { get; }
 
         /// <summary>
-        /// True when the property carried BOTH [AkkaEnvelopePayload] and a field-level [AkkaUnion]:
-        /// extraction dropped the union member set because envelope payload takes precedence.
-        /// Advisory AKKASG035 fires on it.
+        /// True when this is an object-typed (envelope-payload) field that ALSO carries a
+        /// field-level [AkkaUnion]: contradictory author intent -- an object property is always the
+        /// envelope boundary, so a union declaration on it can never take effect. Drives the
+        /// AKKASG038 error.
         /// </summary>
-        public bool UnionSuppressedByEnvelope { get; }
+        public bool UnionDeclaredOnObjectField { get; }
 
         public FieldInfo WithFormatter(TypeMapping mapping, FormatterInfo formatter)
         {
-            return new FieldInfo(Index, Name, TypeFullName, mapping, IsNullable, formatter, UnionMembers, UnionSuppressedByEnvelope);
+            return new FieldInfo(Index, Name, TypeFullName, mapping, IsNullable, formatter, UnionMembers, UnionDeclaredOnObjectField);
         }
 
         public bool Equals(FieldInfo? other)
@@ -4546,7 +4557,7 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
                 && string.Equals(TypeFullName, other.TypeFullName, StringComparison.Ordinal)
                 && Mapping.Equals(other.Mapping)
                 && IsNullable == other.IsNullable
-                && UnionSuppressedByEnvelope == other.UnionSuppressedByEnvelope
+                && UnionDeclaredOnObjectField == other.UnionDeclaredOnObjectField
                 && Equals(Formatter, other.Formatter)
                 && ValueEquality.SequenceEquals(UnionMembers, other.UnionMembers);
         }
@@ -4561,7 +4572,7 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             hash = ValueEquality.Combine(hash, TypeFullName);
             hash = ValueEquality.Combine(hash, Mapping.GetHashCode());
             hash = ValueEquality.Combine(hash, IsNullable);
-            hash = ValueEquality.Combine(hash, UnionSuppressedByEnvelope);
+            hash = ValueEquality.Combine(hash, UnionDeclaredOnObjectField);
             hash = ValueEquality.Combine(hash, Formatter?.GetHashCode() ?? 0);
             hash = ValueEquality.Combine(hash, UnionMembers);
             return hash;
@@ -4645,8 +4656,8 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         public string ForeignAssemblyName { get; }
 
         // For Unsupported: whether the field's static type is an interface, abstract class, or type
-        // parameter, the shapes a forgotten [AkkaEnvelopePayload]/[AkkaUnion] usually produces.
-        // Drives the AKKASG003 hint.
+        // parameter, the shapes a forgotten [AkkaUnion], or a field that should be typed object,
+        // usually produce. Drives the AKKASG003 hint.
         public bool SuggestsEnvelopeOrUnion { get; }
 
         /// <summary>

--- a/src/core/Akka.Serialization.V2.Tests/AkkaSerializerGeneratorDiagnosticsSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/AkkaSerializerGeneratorDiagnosticsSpec.cs
@@ -2060,92 +2060,6 @@ public sealed class AkkaSerializerGeneratorDiagnosticsSpec
         diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
     }
 
-    [Fact(DisplayName = "Generator should report advisory AKKASG035 when a field declares both [AkkaEnvelopePayload] and [AkkaUnion]")]
-    public void Generator_should_report_AKKASG035_when_envelope_and_union_share_a_field()
-    {
-        const string source = """
-            #nullable enable
-            using Akka.Actor;
-            using Akka.Serialization.V2;
-
-            namespace DiagnosticSample;
-
-            public interface IProtocol
-            {
-            }
-
-            public interface IEvent
-            {
-            }
-
-            [AkkaSerializable(Manifest = "inner-v1")]
-            public sealed record Inner([property: AkkaField(1)] string Value) : IEvent;
-
-            [AkkaSerializer<IProtocol>("sample", 140101)]
-            public sealed partial class SampleSerializer : AkkaSerializer
-            {
-                public static partial SerializerRegistration CreateRegistration();
-            }
-
-            [AkkaSerializable(Manifest = "outer-v1")]
-            public sealed record Outer(
-                [property: AkkaField(1), AkkaEnvelopePayload, AkkaUnion(typeof(Inner))] IEvent Event) : IProtocol;
-            """;
-
-        var diagnostics = RunGenerator(source);
-
-        // Advisory only: envelope payload wins (its documented precedence), the union declaration
-        // is dropped during extraction, and the serializer still generates without errors.
-        diagnostics.Should().Contain(diagnostic =>
-            diagnostic.Id == "AKKASG035" &&
-            diagnostic.Severity == DiagnosticSeverity.Info &&
-            diagnostic.GetMessage(null).Contains("Event", StringComparison.Ordinal) &&
-            diagnostic.GetMessage(null).Contains("Outer", StringComparison.Ordinal));
-        diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
-    }
-
-    [Fact(DisplayName = "Generator should not report AKKASG035 for an envelope payload field whose static type declares a type-level [AkkaUnion]")]
-    public void Generator_should_not_report_AKKASG035_for_type_level_union()
-    {
-        // The type-level [AkkaUnion] on IEvent serves that interface's other, non-envelope fields;
-        // its presence on an envelope payload field's static type is incidental, not a conflicting
-        // author intent, so the advisory deliberately stays quiet here.
-        const string source = """
-            #nullable enable
-            using Akka.Actor;
-            using Akka.Serialization.V2;
-
-            namespace DiagnosticSample;
-
-            public interface IProtocol
-            {
-            }
-
-            [AkkaUnion(typeof(Inner))]
-            public interface IEvent
-            {
-            }
-
-            [AkkaSerializable(Manifest = "inner-v1")]
-            public sealed record Inner([property: AkkaField(1)] string Value) : IEvent;
-
-            [AkkaSerializer<IProtocol>("sample", 140102)]
-            public sealed partial class SampleSerializer : AkkaSerializer
-            {
-                public static partial SerializerRegistration CreateRegistration();
-            }
-
-            [AkkaSerializable(Manifest = "outer-v1")]
-            public sealed record Outer(
-                [property: AkkaField(1), AkkaEnvelopePayload] IEvent Event) : IProtocol;
-            """;
-
-        var diagnostics = RunGenerator(source);
-
-        diagnostics.Should().NotContain(diagnostic => diagnostic.Id == "AKKASG035");
-        diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
-    }
-
     [Fact(DisplayName = "Generator should report advisory AKKASG036 when a union member is abstract")]
     public void Generator_should_report_AKKASG036_when_union_member_is_abstract()
     {
@@ -2327,6 +2241,57 @@ public sealed class AkkaSerializerGeneratorDiagnosticsSpec
         diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
     }
 
+    [Fact(DisplayName = "Generator should report AKKASG038 when an object-typed property carries a field-level [AkkaUnion]")]
+    public void Generator_should_report_AKKASG038_when_union_declared_on_object_typed_field()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Actor;
+            using Akka.Serialization.V2;
+
+            namespace DiagnosticSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializable(Manifest = "a-v1")]
+            public sealed record A([property: AkkaField(1)] string Value) : IProtocol;
+
+            [AkkaSerializable(Manifest = "b-v1")]
+            public sealed record B([property: AkkaField(1)] int Value) : IProtocol;
+
+            [AkkaSerializer<IProtocol>("sample", 140401)]
+            public sealed partial class SampleSerializer : AkkaSerializer
+            {
+                public static partial SerializerRegistration CreateRegistration();
+            }
+
+            [AkkaSerializable(Manifest = "outer-v1")]
+            public sealed record Outer(
+                [property: AkkaField(1), AkkaUnion(typeof(A), typeof(B))] object Payload) : IProtocol;
+            """;
+
+        var diagnostics = RunGenerator(source);
+
+        // An object-typed property is always the envelope-payload boundary; a field-level
+        // [AkkaUnion] on it can never take effect, so this is an ERROR, not an advisory. Filtered
+        // to this generator's own AKKASG* diagnostics: the union-on-object conflict is the ONLY
+        // thing wrong with this source (the field maps cleanly to FieldKind.EnvelopePayload, so
+        // AKKASG003 never fires alongside it) -- the cascading CS0534/CS8795/CS7036 compiler errors
+        // that follow are the ordinary, expected consequence of ValidateMessages failing this
+        // message (see every other Error-severity AKKASG003/AKKASG034 test in this file: a failed
+        // message skips AddSource for the whole serializer, leaving its partial class an
+        // unimplemented stub), not a second finding about this field.
+        var akkaDiagnostics = diagnostics.Where(diagnostic => diagnostic.Id.StartsWith("AKKASG", StringComparison.Ordinal)).ToImmutableArray();
+        akkaDiagnostics.Should().ContainSingle();
+        var reported = akkaDiagnostics[0];
+        reported.Id.Should().Be("AKKASG038");
+        reported.Severity.Should().Be(DiagnosticSeverity.Error);
+        reported.GetMessage(null).Should().Be(
+            "Property 'Payload' on type 'DiagnosticSample.Outer' is typed object, which is always an envelope payload boundary, but carries a field-level [AkkaUnion]. Type the property as the union's base type, or remove the attribute.");
+    }
+
     // ------------------------------------------------------------------------------------------
     // Immutable / read-only collection shapes (openspec task 5.7): ImmutableArray<T>,
     // ImmutableList<T>, ImmutableHashSet<T>, ImmutableDictionary<TKey,TValue>,
@@ -2455,7 +2420,7 @@ public sealed class AkkaSerializerGeneratorDiagnosticsSpec
         diagnostics.Should().Contain(diagnostic => diagnostic.Id == "AKKASG003" && diagnostic.Severity == DiagnosticSeverity.Error);
     }
 
-    [Fact(DisplayName = "Generator should append the [AkkaEnvelopePayload]/[AkkaUnion] hint to AKKASG003 when the unsupported field type is an interface")]
+    [Fact(DisplayName = "Generator should append the [AkkaUnion]/object hint to AKKASG003 when the unsupported field type is an interface")]
     public void Generator_should_append_polymorphism_hint_to_AKKASG003_for_interface_field()
     {
         const string source = """
@@ -2491,7 +2456,7 @@ public sealed class AkkaSerializerGeneratorDiagnosticsSpec
         diagnostics.Should().Contain(diagnostic =>
             diagnostic.Id == "AKKASG003" &&
             diagnostic.Severity == DiagnosticSeverity.Error &&
-            diagnostic.GetMessage(null).Contains("Mark the property [AkkaEnvelopePayload], or declare a closed member set with [AkkaUnion].", StringComparison.Ordinal));
+            diagnostic.GetMessage(null).Contains("Declare a closed member set with [AkkaUnion], or type the property as object.", StringComparison.Ordinal));
     }
 
     [Fact(DisplayName = "Generator should not append the cross-assembly hint to AKKASG007 when the nested type is declared in this same compilation")]

--- a/src/core/Akka.Serialization.V2.Tests/CrossAssemblyBaselineSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/CrossAssemblyBaselineSpec.cs
@@ -300,7 +300,7 @@ public sealed class CrossAssemblyBaselineSpec
         generatedSource.Should().BeEmpty("AKKASG034 fails the whole serializer's coverage check, so the pipeline skips AddSource for CommsSerializer entirely");
     }
 
-    [Fact(DisplayName = "Cross-assembly baseline: [AkkaEnvelopePayload] on a generic property, substituted through a referenced-assembly definition and made reachable, is still recognized as an envelope payload")]
+    [Fact(DisplayName = "Cross-assembly baseline: a generic property substituted to object, through a referenced-assembly definition and made reachable, is still recognized as an envelope payload")]
     public void Envelope_payload_on_generic_property_from_referenced_assembly()
     {
         const string sourceA = """
@@ -311,7 +311,7 @@ public sealed class CrossAssemblyBaselineSpec
 
             [AkkaSerializable]
             public sealed record Envelope<T>(
-                [property: AkkaField(1), AkkaEnvelopePayload] T Message,
+                [property: AkkaField(1)] T Message,
                 [property: AkkaField(2)] string TraceId);
             """;
 
@@ -329,10 +329,10 @@ public sealed class CrossAssemblyBaselineSpec
             public sealed record AcceptCassette([property: AkkaField(1)] int Layer) : IComms;
 
             [AkkaSerializable(Manifest = "holder-v1")]
-            public sealed record Holder([property: AkkaField(1)] Envelope<IComms> Inner) : IComms;
+            public sealed record Holder([property: AkkaField(1)] Envelope<object> Inner) : IComms;
 
             [AkkaSerializer<IComms>("comms", 130006)]
-            [AkkaSerializable<Envelope<IComms>>(Manifest = "env-any")]
+            [AkkaSerializable<Envelope<object>>(Manifest = "env-any")]
             public sealed partial class CommsSerializer : AkkaSerializer
             { public static partial SerializerRegistration CreateRegistration(); }
             """;
@@ -342,10 +342,11 @@ public sealed class CrossAssemblyBaselineSpec
         var all = generatorDiagnostics.AddRange(compileDiagnostics);
 
         // Why this field is an envelope payload, not AKKASG003.
-        // Envelope<IComms>.Message is a substituted member. Roslyn returns the original
-        // definition's attributes for it, including [AkkaEnvelopePayload]. This holds no matter
-        // which assembly declared the generic definition. So the generator treats the field as
-        // an envelope payload. Without this, T substituted to an interface would be unsupported.
+        // Envelope<object>.Message is a substituted member. After substitution its static type
+        // is System.Object, no matter which assembly declared the generic definition. No
+        // attribute is declared anywhere. So the generator treats the field as an envelope
+        // payload from the type alone. Without this, T substituted to an interface would be
+        // unsupported.
         all.Should().NotContain(d => d.Id == "AKKASG003");
         all.Where(d => d.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
         generatedSource.Should().Contain("WriteEnvelopePayload");

--- a/src/core/Akka.Serialization.V2.Tests/EnvelopeDepthGuardSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/EnvelopeDepthGuardSpec.cs
@@ -18,13 +18,13 @@ using Xunit;
 namespace Akka.Serialization.V2.Tests;
 
 /// <summary>
-/// Guards the <see cref="AkkaEnvelopePayloadAttribute"/> depth limit. Envelope payloads legitimately
+/// Guards the object-typed envelope field's nesting-depth limit. Envelope payloads legitimately
 /// nest a level or two, but a message type that declares itself (directly or transitively) as its own
 /// envelope payload recurses without bound. Before the guard that recursion overflowed the thread stack
 /// and killed the process (an uncatchable .NET failure); the guard turns it into an ordinary catchable
 /// <see cref="SerializationException"/> on the write, size, and read paths alike. Reuses the
 /// <see cref="AttributeInnerEnvelope"/> test type from the sibling generated-serializer spec, whose
-/// <c>[AkkaEnvelopePayload] object Payload</c> field can hold another envelope.
+/// <c>object Payload</c> field can hold another envelope.
 /// </summary>
 public sealed class EnvelopeDepthGuardSpec : AkkaSpec
 {

--- a/src/core/Akka.Serialization.V2.Tests/GeneratedClosedGenericSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratedClosedGenericSpec.cs
@@ -66,7 +66,7 @@ public sealed class GeneratedClosedGenericSpec : IAsyncLifetime
     [Fact(DisplayName = "Closed construction wire format should inline the substituted payload with no discriminator")]
     public void Closed_construction_wire_format_should_inline_payload()
     {
-        // Contrast with both [AkkaEnvelopePayload] ({id, manifest, bytes}) and [AkkaUnion]
+        // Contrast with both an object-typed envelope field ({id, manifest, bytes}) and [AkkaUnion]
         // ({manifest, fields}): a T-typed field in a registered construction is statically known,
         // so it encodes as a plain nested field map with NO discriminator of any kind.
         var message = new Wrapper<OrderRequest>("wrap-4", new OrderRequest("order-4", 9), null);

--- a/src/core/Akka.Serialization.V2.Tests/GeneratedMessagePackSerializerSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratedMessagePackSerializerSpec.cs
@@ -396,12 +396,12 @@ public sealed class GeneratedMessagePackSerializerSpec : IAsyncLifetime
 
             var customRecovered = RoundTripThroughSerialization<AttributeOuterEnvelope>(system, customEnvelope);
             customRecovered.Should().Be(customEnvelope);
-            customRecovered.Inner.Payload.Should().BeOfType<CustomProtobufPayload>();
+            ((AttributeInnerEnvelope)customRecovered.Inner).Payload.Should().BeOfType<CustomProtobufPayload>();
             envelopeSerializer.SizeHint(customEnvelope).Should().Be(SerializerV2.UnknownSize);
 
             var generatedRecovered = RoundTripThroughSerialization<AttributeOuterEnvelope>(system, generatedEnvelope);
             generatedRecovered.Should().Be(generatedEnvelope);
-            generatedRecovered.Inner.Payload.Should().BeOfType<RequiredMessage>();
+            ((AttributeInnerEnvelope)generatedRecovered.Inner).Payload.Should().BeOfType<RequiredMessage>();
             envelopeSerializer.SizeHint(generatedEnvelope).Should().Be(system.Serialization.Serialize(generatedEnvelope).Length);
         }
         finally
@@ -755,12 +755,12 @@ public sealed record OpaqueSerializedPayload(
 [AkkaSerializable(Manifest = "attribute-outer-envelope-v1")]
 public sealed record AttributeOuterEnvelope(
     [property: AkkaField(1)] string EnvelopeId,
-    [property: AkkaField(2), AkkaEnvelopePayload] AttributeInnerEnvelope Inner) : IGeneratedTestProtocol;
+    [property: AkkaField(2)] object Inner) : IGeneratedTestProtocol;
 
 [AkkaSerializable(Manifest = "attribute-inner-envelope-v1")]
 public sealed record AttributeInnerEnvelope(
     [property: AkkaField(1)] string EnvelopeId,
-    [property: AkkaField(2), AkkaEnvelopePayload] object Payload) : IGeneratedTestProtocol;
+    [property: AkkaField(2)] object Payload) : IGeneratedTestProtocol;
 
 public sealed record CustomProtobufPayload(string PayloadId, int Value);
 

--- a/src/core/Akka.Serialization.V2.Tests/GeneratedUnionSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratedUnionSpec.cs
@@ -20,7 +20,7 @@ namespace Akka.Serialization.V2.Tests;
 /// <summary>
 /// Specs for <c>[AkkaUnion]</c> fields: closed, explicitly-enumerated member sets encoded
 /// structurally inline and discriminated by each member's serializer-owned manifest -- the typed
-/// alternative to <c>[AkkaEnvelopePayload]</c> for payload sets known at compile time.
+/// alternative to an <c>object</c>-typed envelope field for payload sets known at compile time.
 /// </summary>
 public sealed class GeneratedUnionSpec : IAsyncLifetime
 {
@@ -87,7 +87,7 @@ public sealed class GeneratedUnionSpec : IAsyncLifetime
         reader.ReadInt32().Should().Be(2);
 
         // The union frame: { 1: manifest, 2: inline member field map }. No serializer id, no
-        // length-prefixed opaque byte blob -- contrast with the [AkkaEnvelopePayload] frame.
+        // length-prefixed opaque byte blob -- contrast with an object-typed envelope field's frame.
         reader.ReadMapHeader().Should().Be(2);
         reader.ReadInt32().Should().Be(1);
         reader.ReadString().Should().Be(OrderPlaced.ManifestName);

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorGoldenOutputSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorGoldenOutputSpec.cs
@@ -210,8 +210,8 @@ public sealed class GeneratorGoldenOutputSpec
         [AkkaSerializable(Manifest = "envelope-v1")]
         public sealed record EnvelopeMessage(
             [property: AkkaField(1)] string CorrelationId,
-            [property: AkkaField(2), AkkaEnvelopePayload] object Payload,
-            [property: AkkaField(3), AkkaEnvelopePayload] object? MaybePayload) : IProtocol;
+            [property: AkkaField(2)] object Payload,
+            [property: AkkaField(3)] object? MaybePayload) : IProtocol;
 
         // ---- hybrid reconstruction: case-insensitive ctor matching, a keyword-named ctor
         // parameter, and leftover properties assigned via object initializer ----

--- a/src/core/Akka.Serialization.V2.Tests/WireFormatSnapshotSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/WireFormatSnapshotSpec.cs
@@ -90,7 +90,7 @@ public sealed class WireFormatSnapshotSpec : IAsyncLifetime
         // Keyword-named property/constructor-parameter escaping.
         "keyword-named-property",
 
-        // [AkkaEnvelopePayload]-shaped opaque payload: fixed inner serializer id + manifest + bytes.
+        // Object-typed envelope payload: fixed inner serializer id + manifest + bytes.
         "envelope-payload-fixed-inner-serializer",
 
         // AllowEmpty fieldless message: the smallest possible wire shape (a bare 1-byte map header).

--- a/src/core/Akka.Serialization.V2/AkkaSerializer.cs
+++ b/src/core/Akka.Serialization.V2/AkkaSerializer.cs
@@ -20,8 +20,9 @@ namespace Akka.Serialization.V2;
 public abstract class AkkaSerializer : SerializerV2
 {
     /// <summary>
-    /// Maximum depth of nested <see cref="AkkaEnvelopePayloadAttribute"/> payloads permitted within a
-    /// single serialize / deserialize / size operation. Envelopes legitimately nest a level or two (a
+    /// Maximum depth of nested envelope payloads (properties whose static type is <c>object</c> or
+    /// <c>object?</c>) permitted within a single serialize / deserialize / size operation. Envelopes
+    /// legitimately nest a level or two (a
     /// delivery message wraps a user payload that may itself be an enveloped message), but unbounded
     /// nesting is only reachable when a message type declares itself (directly or transitively) as its own
     /// envelope payload — an application bug. Left unchecked that recurses until the thread's stack
@@ -39,8 +40,8 @@ public abstract class AkkaSerializer : SerializerV2
         if (_envelopePayloadDepth >= MaxEnvelopePayloadDepth)
             throw new SerializationException(
                 $"Envelope payload nesting exceeded the maximum depth of {MaxEnvelopePayloadDepth}. " +
-                "This almost always means a message type declares itself (directly or transitively) as its " +
-                "own [AkkaEnvelopePayload], causing unbounded recursion. Break the self-reference in the message graph.");
+                "This almost always means a message type declares an object-typed envelope field that (directly " +
+                "or transitively) holds itself, causing unbounded recursion. Break the self-reference in the message graph.");
 
         _envelopePayloadDepth++;
     }

--- a/src/core/Akka.Serialization.V2/Attributes.cs
+++ b/src/core/Akka.Serialization.V2/Attributes.cs
@@ -92,14 +92,6 @@ public sealed class AkkaFieldAttribute : Attribute
 }
 
 /// <summary>
-/// Marks an <see cref="AkkaFieldAttribute"/> property as an Akka serializer boundary.
-/// </summary>
-[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
-public sealed class AkkaEnvelopePayloadAttribute : Attribute
-{
-}
-
-/// <summary>
 /// Declares a closed, explicitly-enumerated union of concrete
 /// <see cref="AkkaSerializableAttribute"/> member types for an interface or abstract base -- or,
 /// applied to an <see cref="AkkaFieldAttribute"/> property, overrides the member set for that one
@@ -114,14 +106,14 @@ public sealed class AkkaEnvelopePayloadAttribute : Attribute
 /// set for that field only (for example, to narrow the members a particular schema accepts).
 /// </para>
 /// <para>
-/// Unlike <see cref="AkkaEnvelopePayloadAttribute"/> (a runtime serializer boundary for payloads
-/// whose concrete type may live in an assembly unknown at compile time), a union field is encoded
-/// structurally inline: the generator emits compile-time dispatch over the declared member set,
-/// discriminated by each member's <see cref="AkkaSerializableAttribute.Manifest"/>. Every member
-/// must be <c>[AkkaSerializable]</c>, declare a manifest unique within the union, and be assignable
-/// to the field's static type. A runtime value whose exact type is not a declared member fails
-/// serialization. When both this attribute and <see cref="AkkaEnvelopePayloadAttribute"/> are
-/// present on a field, the envelope payload marker wins (consistent with its precedence over
+/// Unlike a field typed <c>object</c> (a runtime serializer boundary for payloads whose concrete
+/// type may live in an assembly unknown at compile time), a union field is encoded structurally
+/// inline: the generator emits compile-time dispatch over the declared member set, discriminated
+/// by each member's <see cref="AkkaSerializableAttribute.Manifest"/>. Every member must be
+/// <c>[AkkaSerializable]</c>, declare a manifest unique within the union, and be assignable to the
+/// field's static type. A runtime value whose exact type is not a declared member fails
+/// serialization. This attribute has no effect on a field whose static type is <c>object</c>: the
+/// static type alone already selects the envelope boundary (consistent with its precedence over
 /// formatter registrations).
 /// </para>
 /// </remarks>
@@ -189,8 +181,8 @@ public sealed class AkkaSerializableAttribute<TMessage> : Attribute
 /// serializer-scoped: the same foreign type may be handled by different formatters (or not at all)
 /// in different serializers. A formatter registration overrides every field-kind resolution the
 /// generator would otherwise infer for <typeparamref name="TTarget"/> (including
-/// <c>Nullable&lt;T&gt;</c> of a value type), except an
-/// <see cref="AkkaEnvelopePayloadAttribute"/>-marked field, which always wins.
+/// <c>Nullable&lt;T&gt;</c> of a value type), except a field whose static type is <c>object</c>
+/// (or <c>object?</c>), which is always the envelope boundary and always wins.
 /// The <c>where TFormatter : IAkkaMessagePackFormatter&lt;TTarget&gt;</c> constraint is enforced by
 /// the compiler at the attribute usage site: <typeparamref name="TFormatter"/> can never be
 /// something that does not implement the formatter interface for <typeparamref name="TTarget"/>.


### PR DESCRIPTION
## Summary

Part of #8384. Implements Decision 20 of the OpenSpec design record (`openspec/changes/messagepack-sourcegen-validation/design.md`): `[AkkaEnvelopePayload]` is removed, and a property typed `object` is the serializer boundary on its own.

The static type of a property, after generic substitution, selects its encoding:

- `object` or `object?`: the envelope frame, `{1: serializerId, 2: manifest, 3: bytes}`, decoded by whatever serializer owns the payload's runtime type.
- an interface or abstract class with a type-level `[AkkaUnion]`: the union frame.
- an interface or abstract class with no closed set: AKKASG003, with the hint "Declare a closed member set with [AkkaUnion], or type the property as object."
- a concrete serializable type: inline.

A generic wrapper follows its type argument: `Envelope<object>` is a boundary, `Envelope<AcceptCassette>` is inline.

## Changes

- `AkkaEnvelopePayloadAttribute` deleted. XML docs on `AkkaSerializer` updated.
- Generator: envelope-payload field kind now derives from `SpecialType.System_Object` on the substituted member type. Attribute detection removed.
- AKKASG035 removed; its conflict cannot occur. The id stays a permanent gap.
- New AKKASG038 (Error): a field-level `[AkkaUnion]` on an `object`-typed property is contradictory intent. Message: "Property '{0}' on type '{1}' is typed object, which is always an envelope payload boundary, but carries a field-level [AkkaUnion]. Type the property as the union's base type, or remove the attribute."
- AKKASG003 polymorphic hint text updated as above. Ids, titles, and severities unchanged.
- Retyped boundary fields: Artery `SystemMessageEnvelope.Message` (`ISystemMessage` to `object`), benchmark `BenchmarkOuterEnvelope.Inner`, and test fixtures; casts added at the consumers that needed them. The envelope nesting-depth guard is untouched.

## Why

The attribute only ever added a static type to a boundary field. On `dev`, eight usages existed: four already `object`, two interfaces in a DTO and a spec, two concrete envelope types in nesting tests. All are DTO mirrors or fixtures, where retyping costs almost nothing. Same principle as the rest of the design: the closed set comes from the type, and the open case is explicit because the author wrote `object`.

## Compatibility

No wire-format change: emitted code for an envelope field is byte-identical, and no golden-output or wire-snapshot file changed. The attribute never shipped in a release, so no `BREAKING_CHANGES_V1.6.md` entry. This must land before the first 1.6 beta; after that it would be a breaking change. `Akka.Serialization.V2` is not covered by the API approval suite, and the retyped Artery type is internal; the approval tests pass unchanged.

## Testing

`dotnet test src/core/Akka.Serialization.V2.Tests -c Release`: 268 passed, 0 failed (two AKKASG035 tests removed, one AKKASG038 test added). `Akka.Remote` builds; `ArteryControlMessageSerializerSpec` 32/32. Benchmarks build.

## Follow-up

The user guide (#8514, merged) documents the attribute as it shipped before this PR and lists this removal under planned changes. A docs PR updates the envelope-payloads section once this merges.
