### PR TITLE
Serialization.V2: generator test harness, internal models, incrementality scenarios, baseline benchmark

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
+++ b/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
@@ -12,6 +12,18 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
+  <!--
+    Serialization/SourceGeneratorBenchmarks.cs drives AkkaSerializerGenerator directly (building
+    synthetic Compilations and GeneratorDriver runs), which needs Microsoft.CodeAnalysis.CSharp
+    types at compile time. BenchmarkDotNet $(BenchmarkDotNetVersion) already depends on
+    Microsoft.CodeAnalysis.CSharp >= 4.14.0 (newer than this repo's pinned
+    $(MicrosoftCodeAnalysisCSharpVersion), 4.13.0), and that transitive reference already flows
+    through for compilation in an SDK-style project: adding an explicit PackageReference pinned to
+    $(MicrosoftCodeAnalysisCSharpVersion) here would only create a NU1605 downgrade error against
+    BenchmarkDotNet's own floor. So this project deliberately does NOT add one; it relies on the
+    version BenchmarkDotNet already pulls in.
+  -->
+
   <ItemGroup>
     <ProjectReference Include="..\..\contrib\cluster\Akka.DistributedData\Akka.DistributedData.csproj" />
     <ProjectReference Include="..\..\contrib\serializers\Akka.Serialization.Hyperion\Akka.Serialization.Hyperion.csproj" />
@@ -20,6 +32,10 @@
     <ProjectReference Include="..\..\core\Akka.Remote\Akka.Remote.csproj" />
     <ProjectReference Include="..\..\core\Akka.Serialization.V2\Akka.Serialization.V2.csproj" />
     <ProjectReference Include="..\..\core\Akka.Serialization.V2.Generators\Akka.Serialization.V2.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <!-- Second reference to the SAME project, this time as an ordinary assembly reference (not an
+         analyzer), so SourceGeneratorBenchmarks.cs can call AkkaSerializerGenerator's public API
+         directly. Same pattern Akka.Serialization.V2.Tests.csproj uses. -->
+    <ProjectReference Include="..\..\core\Akka.Serialization.V2.Generators\Akka.Serialization.V2.Generators.csproj" ReferenceOutputAssembly="true" PrivateAssets="all" />
     <ProjectReference Include="..\..\core\Akka.Streams\Akka.Streams.csproj" />
     <ProjectReference Include="..\..\core\Akka\Akka.csproj" />
   </ItemGroup>

--- a/src/benchmark/Akka.Benchmarks/Configurations/Configs.cs
+++ b/src/benchmark/Akka.Benchmarks/Configurations/Configs.cs
@@ -97,6 +97,23 @@ namespace Akka.Benchmarks.Configurations
         }
     }
 
+    /// <summary>
+    /// BenchmarkDotNet configuration for benchmarks that must finish in minutes, not tens of
+    /// minutes -- <see cref="Job.ShortRun"/> (1 launch, a handful of warmup/target iterations)
+    /// traded for statistical depth. Intended for baseline/directional numbers (for example
+    /// source-generator driver timings), not for numbers a release note would cite.
+    /// </summary>
+    public class ShortRunBenchmarkConfig : ManualConfig
+    {
+        public ShortRunBenchmarkConfig()
+        {
+            AddDiagnoser(MemoryDiagnoser.Default);
+            AddExporter(MarkdownExporter.GitHub);
+            AddLogger(ConsoleLogger.Default);
+            AddJob(Job.ShortRun);
+        }
+    }
+
     public class MacroBenchmarkConfig : ManualConfig
     {
         public MacroBenchmarkConfig()

--- a/src/benchmark/Akka.Benchmarks/Serialization/SourceGeneratorBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Serialization/SourceGeneratorBenchmarks.cs
@@ -1,0 +1,281 @@
+//-----------------------------------------------------------------------
+// <copyright file="SourceGeneratorBenchmarks.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Serialization.V2.Generators;
+using BenchmarkDotNet.Attributes;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Akka.Benchmarks.Serialization;
+
+/// <summary>
+/// Baseline timings for <see cref="AkkaSerializerGenerator"/>'s incremental pipeline: a cold
+/// (fresh-driver) full run over a synthetic corpus, plus three warm-driver incremental edits. These
+/// are the numbers the Serialization.V2 generator architecture pass (PRs 2, 3, 5, 6) is measured
+/// against -- a regression here means a migration PR made the pipeline slower for a shape of edit
+/// real projects make constantly, not just moved code around.
+/// </summary>
+/// <remarks>
+/// Uses <see cref="ShortRunBenchmarkConfig"/> (<c>Job.ShortRun</c>) so the whole suite finishes in
+/// minutes: these are baseline/directional numbers to catch a regression, not final numbers for a
+/// release note.
+/// </remarks>
+[MemoryDiagnoser]
+[Config(typeof(ShortRunBenchmarkConfig))]
+public class SourceGeneratorBenchmarks
+{
+    /// <summary>Serializers in the synthetic corpus, each with its own protocol, union, nested value object, and closed-generic registration.</summary>
+    [Params(5)]
+    public int Serializers { get; set; }
+
+    /// <summary>Messages generated per serializer.</summary>
+    [Params(100)]
+    public int MessagesPerSerializer { get; set; }
+
+    private CSharpParseOptions _parseOptions = null!;
+    private ImmutableArray<MetadataReference> _references;
+
+    private CSharpCompilation _baselineCompilation = null!;
+    private CSharpCompilation _fieldRenameCompilation = null!;
+    private CSharpCompilation _whitespaceEditCompilation = null!;
+    private CSharpCompilation _unrelatedEditCompilation = null!;
+
+    // A driver that has already completed one full run over _baselineCompilation. GeneratorDriver
+    // is immutable -- RunGeneratorsAndUpdateCompilation returns a NEW driver and never mutates this
+    // one -- so building it once here and reusing it, unchanged, across every timed
+    // IncrementalXxx invocation below measures only the SECOND run's cost, not the first.
+    private GeneratorDriver _warmedDriver = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12);
+        _references = CreateMetadataReferences().ToImmutableArray();
+
+        var mainSource = SourceGeneratorBenchmarkCorpus.BuildSource(Serializers, MessagesPerSerializer);
+        var fieldRenameSource = SourceGeneratorBenchmarkCorpus.BuildSource(Serializers, MessagesPerSerializer, renameFirstScalarFieldOfMessage: (0, 0));
+        var whitespaceEditSource = mainSource + Environment.NewLine + "// a trivial trailing benchmark comment" + Environment.NewLine;
+
+        const string unrelatedSourceBefore = "namespace SourceGeneratorBenchmarkCorpus.Unrelated;\n\npublic static class Untouched\n{\n    public static int Value => 1;\n}\n";
+        const string unrelatedSourceAfter = "namespace SourceGeneratorBenchmarkCorpus.Unrelated;\n\npublic static class Untouched\n{\n    public static int Value => 2;\n}\n";
+
+        var mainTree = CSharpSyntaxTree.ParseText(mainSource, _parseOptions, path: "Main.cs");
+        var unrelatedTreeBefore = CSharpSyntaxTree.ParseText(unrelatedSourceBefore, _parseOptions, path: "Unrelated.cs");
+
+        _baselineCompilation = CSharpCompilation.Create(
+            "SourceGeneratorBenchmarks",
+            new[] { mainTree, unrelatedTreeBefore },
+            _references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+
+        _fieldRenameCompilation = _baselineCompilation.ReplaceSyntaxTree(
+            mainTree, CSharpSyntaxTree.ParseText(fieldRenameSource, _parseOptions, path: "Main.cs"));
+
+        _whitespaceEditCompilation = _baselineCompilation.ReplaceSyntaxTree(
+            mainTree, CSharpSyntaxTree.ParseText(whitespaceEditSource, _parseOptions, path: "Main.cs"));
+
+        _unrelatedEditCompilation = _baselineCompilation.ReplaceSyntaxTree(
+            unrelatedTreeBefore, CSharpSyntaxTree.ParseText(unrelatedSourceAfter, _parseOptions, path: "Unrelated.cs"));
+
+        var freshDriver = CreateDriver();
+        _warmedDriver = freshDriver.RunGeneratorsAndUpdateCompilation(_baselineCompilation, out _, out _);
+    }
+
+    [Benchmark(Description = "Fresh driver, full corpus")]
+    public Compilation FullRun()
+    {
+        var driver = CreateDriver();
+        driver = driver.RunGeneratorsAndUpdateCompilation(_baselineCompilation, out var outputCompilation, out _);
+        return outputCompilation;
+    }
+
+    [Benchmark(Description = "Warmed driver, one field renamed in one message")]
+    public Compilation IncrementalEditOneMessage()
+    {
+        var driver = _warmedDriver.RunGeneratorsAndUpdateCompilation(_fieldRenameCompilation, out var outputCompilation, out _);
+        return outputCompilation;
+    }
+
+    [Benchmark(Description = "Warmed driver, trailing whitespace/comment edit")]
+    public Compilation IncrementalWhitespaceEdit()
+    {
+        var driver = _warmedDriver.RunGeneratorsAndUpdateCompilation(_whitespaceEditCompilation, out var outputCompilation, out _);
+        return outputCompilation;
+    }
+
+    [Benchmark(Description = "Warmed driver, unrelated file edited")]
+    public Compilation IncrementalUnrelatedEdit()
+    {
+        var driver = _warmedDriver.RunGeneratorsAndUpdateCompilation(_unrelatedEditCompilation, out var outputCompilation, out _);
+        return outputCompilation;
+    }
+
+    private GeneratorDriver CreateDriver()
+    {
+        return CSharpGeneratorDriver.Create(
+            ImmutableArray.Create(new AkkaSerializerGenerator().AsSourceGenerator()),
+            parseOptions: _parseOptions);
+    }
+
+    // Same reference-gathering pattern as Akka.Serialization.V2.Tests' generator specs -- trusted
+    // platform assemblies plus the handful of explicit ones the generator's attributes and runtime
+    // types live in.
+    private static IEnumerable<MetadataReference> CreateMetadataReferences()
+    {
+        var trustedAssemblies = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))?
+            .Split(System.IO.Path.PathSeparator)
+            .Where(System.IO.File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path)) ?? Enumerable.Empty<MetadataReference>();
+
+        var explicitAssemblies = new[]
+        {
+            typeof(ActorSystem).Assembly,
+            typeof(global::Akka.Serialization.V2.AkkaSerializerAttribute<>).Assembly,
+            typeof(global::Akka.Serialization.SerializerV2).Assembly,
+            typeof(ImmutableHashSet<>).Assembly,
+        };
+
+        return trustedAssemblies
+            .Concat(explicitAssemblies.Select(assembly => MetadataReference.CreateFromFile(assembly.Location)))
+            .GroupBy(reference => reference.Display)
+            .Select(group => group.First());
+    }
+}
+
+/// <summary>
+/// Builds a synthetic <c>[AkkaSerializable]</c>/<c>[AkkaSerializer]</c> corpus of a given size, for
+/// benchmarking the generator pipeline rather than testing its correctness. Each serializer gets:
+/// a scalar-field message mix, one nested value object (a <c>readonly record struct</c>), one
+/// <c>[AkkaUnion]</c> with three members, and one closed-generic <c>[AkkaSerializable&lt;T&gt;]</c>
+/// registration.
+/// </summary>
+internal static class SourceGeneratorBenchmarkCorpus
+{
+    /// <summary>
+    /// Builds the corpus. When <paramref name="renameFirstScalarFieldOfMessage"/> is given
+    /// (serializer index, message index), that one message's first scalar field is named
+    /// "RenamedField" instead of "Name" -- a structurally distinct source used to drive
+    /// <c>IncrementalEditOneMessage</c> without any fragile string-replace over the generated text.
+    /// </summary>
+    public static string BuildSource(int serializers, int messagesPerSerializer, (int SerializerIndex, int MessageIndex)? renameFirstScalarFieldOfMessage = null)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine("using Akka.Actor;");
+        sb.AppendLine("using Akka.Serialization.V2;");
+        sb.AppendLine();
+        sb.AppendLine("namespace SourceGeneratorBenchmarkCorpus;");
+        sb.AppendLine();
+
+        for (var s = 0; s < serializers; s++)
+        {
+            AppendSerializer(sb, s, messagesPerSerializer, renameFirstScalarFieldOfMessage);
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendSerializer(StringBuilder sb, int s, int messagesPerSerializer, (int SerializerIndex, int MessageIndex)? renamed)
+    {
+        sb.AppendLine($"public interface IProtocol{s}");
+        sb.AppendLine("{");
+        sb.AppendLine("}");
+        sb.AppendLine();
+
+        // One [AkkaUnion] with three members.
+        sb.AppendLine($"[AkkaUnion(typeof(UnionMember{s}A), typeof(UnionMember{s}B), typeof(UnionMember{s}C))]");
+        sb.AppendLine($"public interface IUnion{s}");
+        sb.AppendLine("{");
+        sb.AppendLine("}");
+        sb.AppendLine();
+        sb.AppendLine($"[AkkaSerializable(Manifest = \"union{s}-a-v1\")]");
+        sb.AppendLine($"public sealed record UnionMember{s}A([property: AkkaField(1)] string Value) : IUnion{s};");
+        sb.AppendLine();
+        sb.AppendLine($"[AkkaSerializable(Manifest = \"union{s}-b-v1\")]");
+        sb.AppendLine($"public sealed record UnionMember{s}B([property: AkkaField(1)] int Value) : IUnion{s};");
+        sb.AppendLine();
+        sb.AppendLine($"[AkkaSerializable(Manifest = \"union{s}-c-v1\")]");
+        sb.AppendLine($"public sealed record UnionMember{s}C([property: AkkaField(1)] bool Value) : IUnion{s};");
+        sb.AppendLine();
+
+        // One nested value object.
+        sb.AppendLine($"[AkkaSerializable]");
+        sb.AppendLine($"public readonly record struct NestedValue{s}(");
+        sb.AppendLine("    [property: AkkaField(1)] double X,");
+        sb.AppendLine("    [property: AkkaField(2)] double Y);");
+        sb.AppendLine();
+
+        // One generic definition, registered as a closed construction on the serializer below.
+        // It implements IProtocol{s} directly, so the closed construction is reachable without
+        // needing to be referenced from any message field (see design.md Decision 13 / the golden
+        // corpus's Wrapper<T> for the same pattern).
+        sb.AppendLine($"[AkkaSerializable]");
+        sb.AppendLine($"public sealed record Wrapper{s}<T>(");
+        sb.AppendLine("    [property: AkkaField(1)] string Id,");
+        sb.AppendLine($"    [property: AkkaField(2)] T Payload) : IProtocol{s};");
+        sb.AppendLine();
+
+        for (var m = 0; m < messagesPerSerializer; m++)
+        {
+            var firstFieldName = renamed is { SerializerIndex: var rs, MessageIndex: var rm } && rs == s && rm == m
+                ? "RenamedField"
+                : "Name";
+
+            sb.AppendLine($"[AkkaSerializable(Manifest = \"msg-{s}-{m}-v1\")]");
+            sb.Append($"public sealed record Message{s}_{m}(");
+
+            if (m == 0)
+            {
+                // One message per serializer carries the nested value object field.
+                sb.AppendLine();
+                sb.AppendLine($"    [property: AkkaField(1)] string {firstFieldName},");
+                sb.AppendLine("    [property: AkkaField(2)] int Count,");
+                sb.AppendLine("    [property: AkkaField(3)] bool Flag,");
+                sb.AppendLine("    [property: AkkaField(4)] double Amount,");
+                sb.AppendLine($"    [property: AkkaField(5)] NestedValue{s} Location) : IProtocol{s};");
+            }
+            else if (m == 1)
+            {
+                // One message per serializer carries the union field.
+                sb.AppendLine();
+                sb.AppendLine($"    [property: AkkaField(1)] string {firstFieldName},");
+                sb.AppendLine("    [property: AkkaField(2)] int Count,");
+                sb.AppendLine("    [property: AkkaField(3)] bool Flag,");
+                sb.AppendLine("    [property: AkkaField(4)] double Amount,");
+                sb.AppendLine($"    [property: AkkaField(5)] IUnion{s} Event) : IProtocol{s};");
+            }
+            else
+            {
+                // Everything else: a plain scalar-field mix.
+                sb.AppendLine();
+                sb.AppendLine($"    [property: AkkaField(1)] string {firstFieldName},");
+                sb.AppendLine("    [property: AkkaField(2)] int Count,");
+                sb.AppendLine("    [property: AkkaField(3)] long Sequence,");
+                sb.AppendLine("    [property: AkkaField(4)] bool Flag,");
+                sb.AppendLine($"    [property: AkkaField(5)] double Amount) : IProtocol{s};");
+            }
+
+            sb.AppendLine();
+        }
+
+        sb.AppendLine($"[AkkaSerializer<IProtocol{s}>(\"bench-serializer-{s}\", {190000 + s})]");
+        sb.AppendLine($"[AkkaSerializable<Wrapper{s}<int>>(Manifest = \"wrapper{s}-int-v1\")]");
+        sb.AppendLine($"public sealed partial class BenchSerializer{s} : AkkaSerializer");
+        sb.AppendLine("{");
+        sb.AppendLine("    public static partial SerializerRegistration CreateRegistration();");
+        sb.AppendLine("}");
+        sb.AppendLine();
+    }
+}

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Extraction.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Extraction.cs
@@ -361,6 +361,54 @@ public sealed partial class AkkaSerializerGenerator
     }
 
     /// <summary>
+    /// Test-only entry point: extracts a <see cref="MessageInfo"/> straight from a symbol and its
+    /// <see cref="Compilation"/>, with no <see cref="GeneratorAttributeSyntaxContext"/> syntax hook
+    /// to drive it. Mirrors <see cref="ExtractMessage"/>'s attribute-argument handling exactly (the
+    /// [AkkaSerializable] Manifest/AllowEmpty named-argument read and the generic-definition
+    /// placeholder branch) -- the only extraction logic this duplicates is the small read of those
+    /// named arguments, which <see cref="ExtractMessage"/> can only obtain from
+    /// <see cref="GeneratorAttributeSyntaxContext.Attributes"/>, something this overload has no
+    /// syntax context to supply the equivalent of. Everything else delegates to the same, unmodified
+    /// <see cref="ExtractMessageCore"/> routine the real pipeline uses.
+    /// </summary>
+    internal static MessageInfo? ParseMessageForTests(INamedTypeSymbol type, Compilation compilation)
+    {
+        var serializableAttributeType = compilation.GetTypeByMetadataName(SerializableAttributeFullName);
+        var attribute = type.GetAttributes()
+            .FirstOrDefault(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, serializableAttributeType));
+        if (attribute == null)
+            return null;
+
+        var knownTypes = KnownTypes.From(compilation);
+        var manifest = string.Empty;
+        var allowEmpty = false;
+        foreach (var argument in attribute.NamedArguments)
+        {
+            if (argument.Key == "Manifest" && argument.Value.Value is string value)
+                manifest = value;
+            else if (argument.Key == "AllowEmpty" && argument.Value.Value is bool allowEmptyValue)
+                allowEmpty = allowEmptyValue;
+        }
+
+        if (type.IsGenericType)
+        {
+            return new MessageInfo(
+                type.Name,
+                GetFullyQualifiedTypeName(type),
+                manifest,
+                ImmutableArray<FieldInfo>.Empty,
+                GetProtocolNames(type),
+                allowEmpty: true,
+                isGenericDefinition: true,
+                definitionFullName: GetFullyQualifiedTypeName(type),
+                invalidFields: ImmutableArray<InvalidFieldInfo>.Empty,
+                constructionPlan: ConstructionPlan.Empty);
+        }
+
+        return ExtractMessageCore(type, GetFullyQualifiedTypeName(type), manifest, allowEmpty, knownTypes, compilation, definitionFullName: string.Empty);
+    }
+
+    /// <summary>
     /// Builds the <see cref="MessageInfo"/> for a concrete serializable type: either an ordinary
     /// non-generic <c>[AkkaSerializable]</c> declaration or a registered closed generic
     /// construction. For a closed construction, <see cref="INamedTypeSymbol.GetMembers"/> returns

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Models.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Models.cs
@@ -64,7 +64,7 @@ public sealed partial class AkkaSerializerGenerator
         }
     }
 
-    private sealed class SerializerInfo : IEquatable<SerializerInfo>
+    internal sealed class SerializerInfo : IEquatable<SerializerInfo>
     {
         public SerializerInfo(
             string ns,
@@ -170,7 +170,7 @@ public sealed partial class AkkaSerializerGenerator
         }
     }
 
-    private sealed class MessageInfo : IEquatable<MessageInfo>
+    internal sealed class MessageInfo : IEquatable<MessageInfo>
     {
         public MessageInfo(
             string simpleName,
@@ -291,7 +291,7 @@ public sealed partial class AkkaSerializerGenerator
     /// A single <c>[AkkaField]</c> property found unusable during extraction: static, or its getter
     /// is not accessible to the generated code. See AKKASG028.
     /// </summary>
-    private sealed class InvalidFieldInfo : IEquatable<InvalidFieldInfo>
+    internal sealed class InvalidFieldInfo : IEquatable<InvalidFieldInfo>
     {
         public InvalidFieldInfo(string propertyName, string reason)
         {
@@ -335,7 +335,7 @@ public sealed partial class AkkaSerializerGenerator
     /// (AKKASG026). <see cref="UncoveredDefaultedParameters"/> is advisory (AKKASG027) and can be
     /// non-empty even when <see cref="IsValid"/> is true.
     /// </summary>
-    private sealed class ConstructionPlan : IEquatable<ConstructionPlan>
+    internal sealed class ConstructionPlan : IEquatable<ConstructionPlan>
     {
         public static readonly ConstructionPlan Empty = new(
             ImmutableArray<ConstructorArgumentPlan>.Empty,
@@ -390,7 +390,7 @@ public sealed partial class AkkaSerializerGenerator
     }
 
     /// <summary>A single NAMED constructor argument: <see cref="ParameterName"/> supplied from the field named <see cref="FieldName"/>.</summary>
-    private readonly struct ConstructorArgumentPlan : IEquatable<ConstructorArgumentPlan>
+    internal readonly struct ConstructorArgumentPlan : IEquatable<ConstructorArgumentPlan>
     {
         public ConstructorArgumentPlan(string parameterName, string fieldName)
         {
@@ -423,7 +423,7 @@ public sealed partial class AkkaSerializerGenerator
     /// when the target was invalid (not a type, non-generic, unbound, or its definition lacks
     /// <c>[AkkaSerializable]</c>) so AKKASG020 fires instead of the registration silently vanishing.
     /// </summary>
-    private sealed class ClosedGenericRegistrationInfo : IEquatable<ClosedGenericRegistrationInfo>
+    internal sealed class ClosedGenericRegistrationInfo : IEquatable<ClosedGenericRegistrationInfo>
     {
         public ClosedGenericRegistrationInfo(string targetDisplayName, MessageInfo? message)
         {
@@ -457,7 +457,7 @@ public sealed partial class AkkaSerializerGenerator
         }
     }
 
-    private sealed class FieldInfo : IEquatable<FieldInfo>
+    internal sealed class FieldInfo : IEquatable<FieldInfo>
     {
         public FieldInfo(int index, string name, string typeFullName, TypeMapping mapping, bool isNullable, FormatterInfo? formatter = null, ImmutableArray<UnionMemberInfo> unionMembers = default, bool unionDeclaredOnObjectField = false)
         {
@@ -529,7 +529,7 @@ public sealed partial class AkkaSerializerGenerator
         }
     }
 
-    private readonly struct TypeMapping : IEquatable<TypeMapping>
+    internal readonly struct TypeMapping : IEquatable<TypeMapping>
     {
         public TypeMapping(
             FieldKind kind,
@@ -666,7 +666,7 @@ public sealed partial class AkkaSerializerGenerator
     /// strings/bools/enums (no <see cref="ISymbol"/> references) so it stays cheap to hold across
     /// incremental generator passes.
     /// </summary>
-    private sealed class FormatterInfo : IEquatable<FormatterInfo>
+    internal sealed class FormatterInfo : IEquatable<FormatterInfo>
     {
         public FormatterInfo(string targetTypeFullName, bool isTargetValueType, string formatterTypeFullName, bool isAbstract, FormatterCtorKind ctorKind, bool isTargetSupported)
         {
@@ -722,14 +722,14 @@ public sealed partial class AkkaSerializerGenerator
         }
     }
 
-    private enum FormatterCtorKind
+    internal enum FormatterCtorKind
     {
         None,
         Parameterless,
         System
     }
 
-    private enum FieldKind
+    internal enum FieldKind
     {
         Unsupported,
         String,
@@ -769,7 +769,7 @@ public sealed partial class AkkaSerializerGenerator
     /// extraction time; facts requiring the whole-compilation message set (serializability,
     /// manifests) are resolved later against the serializer's message dictionary.
     /// </summary>
-    private sealed class UnionMemberInfo : IEquatable<UnionMemberInfo>
+    internal sealed class UnionMemberInfo : IEquatable<UnionMemberInfo>
     {
         public UnionMemberInfo(string typeFullName, bool isValueType, bool isAssignable, bool isSupported, bool isSealed, bool isAbstract, string foreignAssemblyName = "")
         {

--- a/src/core/Akka.Serialization.V2.Tests/AkkaSerializerGeneratorDiagnosticsSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/AkkaSerializerGeneratorDiagnosticsSpec.cs
@@ -7,16 +7,11 @@
 
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
-using System.Reflection;
-using Akka.Actor;
-using Akka.Serialization.V2.Generators;
+using Akka.Serialization.V2.Tests.Harness;
 using FluentAssertions;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace Akka.Serialization.V2.Tests;
@@ -2497,42 +2492,11 @@ public sealed class AkkaSerializerGeneratorDiagnosticsSpec
         diagnostic.GetMessage(null).Contains("AkkaSerializerFormatter<", StringComparison.Ordinal).Should().BeFalse();
     }
 
+    // Delegates to the shared harness (Harness/GeneratorTestHarness.cs), which builds the base
+    // metadata reference set once per process instead of once per test. Return shape/semantics are
+    // unchanged: generator diagnostics followed by post-generation compile diagnostics.
     private static ImmutableArray<Diagnostic> RunGenerator(string source)
     {
-        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12);
-        var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
-        var compilation = CSharpCompilation.Create(
-            "AkkaSerializationGeneratorDiagnostics",
-            new[] { syntaxTree },
-            CreateMetadataReferences(),
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
-
-        GeneratorDriver driver = CSharpGeneratorDriver.Create(
-            new[] { new AkkaSerializerGenerator().AsSourceGenerator() },
-            parseOptions: parseOptions);
-        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var updatedCompilation, out var generatorDiagnostics);
-
-        return generatorDiagnostics.AddRange(updatedCompilation.GetDiagnostics());
-    }
-
-    private static IEnumerable<MetadataReference> CreateMetadataReferences()
-    {
-        var trustedAssemblies = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))?
-            .Split(Path.PathSeparator)
-            .Where(File.Exists)
-            .Select(path => MetadataReference.CreateFromFile(path)) ?? Enumerable.Empty<MetadataReference>();
-
-        var explicitAssemblies = new[]
-        {
-            typeof(ActorSystem).Assembly,
-            typeof(AkkaSerializerAttribute<>).Assembly,
-            typeof(SerializerV2).Assembly,
-            typeof(ImmutableHashSet<>).Assembly,
-            Assembly.GetExecutingAssembly()
-        };
-
-        return trustedAssemblies.Concat(explicitAssemblies.Select(assembly => MetadataReference.CreateFromFile(assembly.Location)))
-            .GroupBy(reference => reference.Display)
-            .Select(group => group.First());
+        return GeneratorTestHarness.Run(source).AllDiagnostics;
     }
 }

--- a/src/core/Akka.Serialization.V2.Tests/CrossAssemblyBaselineSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/CrossAssemblyBaselineSpec.cs
@@ -7,16 +7,12 @@
 
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
-using System.Reflection;
-using Akka.Actor;
 using Akka.Serialization.V2.Generators;
+using Akka.Serialization.V2.Tests.Harness;
 using FluentAssertions;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace Akka.Serialization.V2.Tests;
@@ -393,71 +389,24 @@ public sealed class CrossAssemblyBaselineSpec
         all.Where(d => d.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
     }
 
+    // Delegates to the shared harness (Harness/GeneratorTestHarness.cs), which builds the base
+    // metadata reference set once per process instead of once per test.
     private static MetadataReference CompileAssemblyAToReference(string source, string assemblyName)
     {
-        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12);
-        var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
-        var compilation = CSharpCompilation.Create(
-            assemblyName,
-            new[] { syntaxTree },
-            CreateMetadataReferences(),
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
-
-        var errors = compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToImmutableArray();
-        errors.Should().BeEmpty($"assembly A ('{assemblyName}') must compile with no errors -- it does no generator work, it only supplies types for B to reference");
-
-        using var stream = new MemoryStream();
-        var emitResult = compilation.Emit(stream);
-        emitResult.Success.Should().BeTrue($"assembly A ('{assemblyName}') must emit successfully");
-
-        return MetadataReference.CreateFromImage(stream.ToArray());
+        return GeneratorTestHarness.CompileToReference(source, assemblyName);
     }
 
     private static (ImmutableArray<Diagnostic> GeneratorDiagnostics, ImmutableArray<Diagnostic> CompileDiagnostics, string GeneratedSource) RunGeneratorAgainstB(
         string sourceB, MetadataReference assemblyAReference, string assemblyName)
     {
-        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12);
-        var syntaxTree = CSharpSyntaxTree.ParseText(sourceB, parseOptions);
-        var references = CreateMetadataReferences().Append(assemblyAReference);
-        var compilation = CSharpCompilation.Create(
-            assemblyName,
-            new[] { syntaxTree },
-            references,
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+        // assemblyName previously named the "B" compilation itself, purely for debugging -- it
+        // never appears in any assertion (only assembly A's name, baked into assemblyAReference by
+        // CompileAssemblyAToReference above, does). The harness names every compilation it builds
+        // uniformly, so assemblyName is unused here now.
+        _ = assemblyName;
 
-        GeneratorDriver driver = CSharpGeneratorDriver.Create(
-            new[] { new AkkaSerializerGenerator().AsSourceGenerator() },
-            parseOptions: parseOptions);
-        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var updatedCompilation, out var generatorDiagnostics);
-
-        var runResult = driver.GetRunResult();
-        var generatedSource = string.Join(
-            Environment.NewLine,
-            runResult.GeneratedTrees.Select(tree => tree.ToString()));
-
-        return (generatorDiagnostics, updatedCompilation.GetDiagnostics(), generatedSource);
-    }
-
-    // Same base reference set as AkkaSerializerGeneratorDiagnosticsSpec. The [AkkaSerializer] and
-    // [AkkaSerializable] attributes and runtime types resolve the same way here.
-    private static IEnumerable<MetadataReference> CreateMetadataReferences()
-    {
-        var trustedAssemblies = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))?
-            .Split(Path.PathSeparator)
-            .Where(File.Exists)
-            .Select(path => MetadataReference.CreateFromFile(path)) ?? Enumerable.Empty<MetadataReference>();
-
-        var explicitAssemblies = new[]
-        {
-            typeof(ActorSystem).Assembly,
-            typeof(AkkaSerializerAttribute<>).Assembly,
-            typeof(SerializerV2).Assembly,
-            typeof(ImmutableHashSet<>).Assembly,
-            Assembly.GetExecutingAssembly()
-        };
-
-        return trustedAssemblies.Concat(explicitAssemblies.Select(assembly => MetadataReference.CreateFromFile(assembly.Location)))
-            .GroupBy(reference => reference.Display)
-            .Select(group => group.First());
+        var result = GeneratorTestHarness.Run(sourceB, assemblyAReference);
+        var generatedSource = string.Join(Environment.NewLine, result.RunResult.GeneratedTrees.Select(tree => tree.ToString()));
+        return (result.GeneratorDiagnostics, result.CompileDiagnostics, generatedSource);
     }
 }

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorArchitectureSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorArchitectureSpec.cs
@@ -1,0 +1,192 @@
+//-----------------------------------------------------------------------
+// <copyright file="GeneratorArchitectureSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using Akka.Serialization.V2.Generators;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// Structural regression guard for the generator's incremental-caching discipline -- the
+/// counterpart of <see cref="GeneratorIncrementalCachingSpec"/>'s BEHAVIORAL guard (which proves the
+/// pipeline actually reuses cache across a real run). This spec inspects the MODEL TYPES
+/// THEMSELVES, by reflection:
+/// <list type="number">
+/// <item>No model type's field or property may hold a live Roslyn symbol, <see cref="Compilation"/>,
+/// syntax node/tree, or <see cref="Location"/> -- any of those breaks structural equality across
+/// compilations (a fresh <see cref="Compilation"/> is never <c>==</c> to the last one) and silently
+/// defeats incremental caching, even though the code compiles and runs fine.</item>
+/// <item>Every model type has real value equality: either a hand-written <c>Equals(object)</c>/
+/// <c>GetHashCode()</c> override pair, or it is a record/record struct (whose compiler-generated
+/// equality is already trustworthy), or an enum (whose built-in equality is a plain value compare).</item>
+/// </list>
+/// Model types are discovered by reflection -- every type nested directly under
+/// <see cref="AkkaSerializerGenerator"/> with <c>internal</c> visibility, in the generator's own
+/// namespace -- rather than hardcoded by name, so a newly added model is covered automatically
+/// without anyone remembering to update this file.
+/// </summary>
+public sealed class GeneratorArchitectureSpec
+{
+    /// <summary>
+    /// A type assignable to any of these can never be part of a cached pipeline model: all four are
+    /// tied to one specific compilation/parse and are never equal to their counterpart from the
+    /// next incremental run, even when they represent "the same" declaration.
+    /// </summary>
+    private static readonly Type[] ForbiddenBaseTypes =
+    {
+        typeof(ISymbol),
+        typeof(Compilation),
+        typeof(SyntaxNode),
+        typeof(SyntaxTree),
+        typeof(Location),
+        typeof(SyntaxReference)
+    };
+
+    private static IReadOnlyList<Type> ModelTypes { get; } = DiscoverModelTypes();
+
+    [Fact(DisplayName = "Model type discovery should find the generator's internal pipeline models")]
+    public void Should_discover_model_types()
+    {
+        // Not an exact-count pin (contrast GeneratorIncrementalScenariosSpec's tracking-step count,
+        // which deliberately IS one) -- this only guards against the discovery mechanism itself
+        // silently regressing to zero (for example if AkkaSerializerGenerator.Models.cs models ever
+        // moved to a different namespace or stopped being nested under the generator class).
+        ModelTypes.Should().HaveCountGreaterOrEqualTo(10);
+    }
+
+    [Fact(DisplayName = "No generator model type should hold a live Roslyn symbol, Compilation, syntax node/tree, or Location")]
+    public void Model_types_should_be_symbol_free()
+    {
+        var violations = new List<string>();
+        var visited = new HashSet<Type>();
+
+        foreach (var modelType in ModelTypes)
+            CheckSymbolFree(modelType, modelType.Name, visited, violations);
+
+        violations.Should().BeEmpty(
+            "every cached pipeline model must stay symbol-free for incremental caching to work, but found:" +
+            Environment.NewLine + string.Join(Environment.NewLine, violations));
+    }
+
+    [Fact(DisplayName = "Every generator model type should have real value equality (an Equals/GetHashCode override, a record, or an enum)")]
+    public void Model_types_should_have_value_equality()
+    {
+        var violations = new List<string>();
+
+        foreach (var modelType in ModelTypes)
+        {
+            // Enums get correct, symbol-free, cross-compilation-stable equality for free from
+            // System.Enum -- there is nothing for a hand-written override to improve on, and the
+            // compiler will not let an enum declare one anyway.
+            if (modelType.IsEnum)
+                continue;
+
+            // A record class/struct's compiler-generated Equals(object)/GetHashCode() ARE declared
+            // directly on the type (DeclaredOnly reflection finds them, same as a hand-written
+            // override), so no separate "is this a record" branch is needed here: the checks below
+            // already accept either origin.
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+            var declaresEquals = modelType.GetMethod(nameof(Equals), flags, binder: null, types: new[] { typeof(object) }, modifiers: null) != null;
+            var declaresGetHashCode = modelType.GetMethod(nameof(GetHashCode), flags, binder: null, types: Type.EmptyTypes, modifiers: null) != null;
+
+            if (!declaresEquals || !declaresGetHashCode)
+            {
+                violations.Add(
+                    $"{modelType.Name} is not a record/enum and does not declare both Equals(object) and GetHashCode() " +
+                    $"(Equals override present: {declaresEquals}, GetHashCode override present: {declaresGetHashCode}).");
+            }
+        }
+
+        violations.Should().BeEmpty(string.Join(Environment.NewLine, violations));
+    }
+
+    private static void CheckSymbolFree(Type type, string path, HashSet<Type> visited, List<string> violations)
+    {
+        if (!visited.Add(type))
+            return;
+
+        foreach (var (memberName, memberType) in GetDataMembers(type))
+        {
+            var memberPath = $"{path}.{memberName}";
+
+            foreach (var candidate in UnwrapCandidates(memberType))
+            {
+                if (ForbiddenBaseTypes.Any(forbidden => forbidden.IsAssignableFrom(candidate)))
+                {
+                    violations.Add($"{memberPath} : {memberType} carries a Roslyn type ({candidate}).");
+                    continue;
+                }
+
+                // Recurse into any candidate that is itself one of the generator's own model types
+                // (covers a model referencing another model, e.g. FieldInfo.Mapping : TypeMapping,
+                // or ClosedGenericRegistrationInfo.Message : MessageInfo?) so a violation buried two
+                // or more levels deep is still caught and reported at its own path.
+                if (candidate.IsNestedAssembly && candidate.DeclaringType == typeof(AkkaSerializerGenerator))
+                    CheckSymbolFree(candidate, memberPath, visited, violations);
+            }
+        }
+    }
+
+    /// <summary>Every instance field/property this type itself declares, skipping auto-property backing fields (the property covers the same type already).</summary>
+    private static IEnumerable<(string Name, Type Type)> GetDataMembers(Type type)
+    {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+
+        foreach (var property in type.GetProperties(flags))
+        {
+            if (property.GetIndexParameters().Length == 0)
+                yield return (property.Name, property.PropertyType);
+        }
+
+        foreach (var field in type.GetFields(flags))
+        {
+            if (field.Name.EndsWith(">k__BackingField", StringComparison.Ordinal))
+                continue;
+
+            yield return (field.Name, field.FieldType);
+        }
+    }
+
+    /// <summary>
+    /// A member's own type, plus (recursively) its unwrapped element type when the member is
+    /// <see cref="Nullable{T}"/> or <see cref="ImmutableArray{T}"/> -- the two generic wrappers
+    /// every model in this pipeline uses. A raw Roslyn type could otherwise hide inside either
+    /// (for example <c>ImmutableArray&lt;ISymbol&gt;</c>) without ever appearing as a member's
+    /// DECLARED type directly.
+    /// </summary>
+    private static IEnumerable<Type> UnwrapCandidates(Type type)
+    {
+        yield return type;
+
+        if (type.IsGenericType)
+        {
+            var definition = type.GetGenericTypeDefinition();
+            if (definition == typeof(Nullable<>) || definition == typeof(ImmutableArray<>))
+            {
+                foreach (var candidate in UnwrapCandidates(type.GetGenericArguments()[0]))
+                    yield return candidate;
+            }
+        }
+    }
+
+    private static List<Type> DiscoverModelTypes()
+    {
+        var generatorType = typeof(AkkaSerializerGenerator);
+        return generatorType
+            .GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic)
+            .Where(t => t.IsNestedAssembly && t.Namespace == generatorType.Namespace)
+            .ToList();
+    }
+}

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorGoldenOutputSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorGoldenOutputSpec.cs
@@ -51,7 +51,11 @@ public sealed class GeneratorGoldenOutputSpec
     /// emission path, plus a second, internal serializer covering the 'internal' accessibility
     /// keyword path.
     /// </summary>
-    private const string GoldenSource = """
+    /// <remarks>
+    /// Internal (not private) so <c>GeneratorMessageModelSnapshotSpec</c> can parse the exact same
+    /// corpus through the extraction layer instead of maintaining a parallel copy that could drift.
+    /// </remarks>
+    internal const string GoldenSource = """
         #nullable enable
         using System;
         using System.Collections.Generic;
@@ -306,7 +310,8 @@ public sealed class GeneratorGoldenOutputSpec
     /// Second syntax tree, GLOBAL namespace: covers the namespace-less emission branch (no
     /// <c>namespace ...;</c> line in the generated file).
     /// </summary>
-    private const string GlobalNamespaceSource = """
+    /// <remarks>See <see cref="GoldenSource"/>'s remarks on why this is internal, not private.</remarks>
+    internal const string GlobalNamespaceSource = """
         #nullable enable
         using Akka.Serialization.V2;
 

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorIncrementalScenariosSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorIncrementalScenariosSpec.cs
@@ -1,0 +1,298 @@
+//-----------------------------------------------------------------------
+// <copyright file="GeneratorIncrementalScenariosSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Akka.Serialization.V2.Generators;
+using Akka.Serialization.V2.Tests.Harness;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+public sealed class GeneratorIncrementalScenariosSpec
+{
+    private const string FixtureSource = """
+        #nullable enable
+        using Akka.Actor;
+        using Akka.Serialization.V2;
+
+        namespace ScenarioSample;
+
+        public interface IAlphaProtocol
+        {
+        }
+
+        public interface IBetaProtocol
+        {
+        }
+
+        [AkkaSerializable(Manifest = "alpha-one-v1")]
+        public sealed record AlphaOne([property: AkkaField(1)] string Name) : IAlphaProtocol;
+
+        [AkkaSerializable(Manifest = "alpha-two-v1")]
+        public sealed record AlphaTwo([property: AkkaField(1)] int Count) : IAlphaProtocol;
+
+        [AkkaSerializable(Manifest = "alpha-three-v1")]
+        public sealed record AlphaThree([property: AkkaField(1)] bool Flag) : IAlphaProtocol;
+
+        [AkkaSerializer<IAlphaProtocol>("scenario-alpha", 170001)]
+        public sealed partial class AlphaSerializer : AkkaSerializer
+        {
+            public static partial SerializerRegistration CreateRegistration();
+        }
+
+        [AkkaSerializable(Manifest = "beta-one-v1")]
+        public sealed record BetaOne([property: AkkaField(1)] string Label) : IBetaProtocol;
+
+        [AkkaSerializable(Manifest = "beta-two-v1")]
+        public sealed record BetaTwo([property: AkkaField(1)] long Value) : IBetaProtocol;
+
+        [AkkaSerializable(Manifest = "beta-three-v1")]
+        public sealed record BetaThree([property: AkkaField(1)] double Ratio) : IBetaProtocol;
+
+        [AkkaSerializer<IBetaProtocol>("scenario-beta", 170002)]
+        public sealed partial class BetaSerializer : AkkaSerializer
+        {
+            public static partial SerializerRegistration CreateRegistration();
+        }
+        """;
+
+    private const string UnrelatedSourceBefore = """
+        namespace ScenarioSample.Unrelated;
+
+        public static class Untouched
+        {
+            public static int Value => 1;
+        }
+        """;
+
+    private const string UnrelatedSourceAfter = """
+        namespace ScenarioSample.Unrelated;
+
+        public static class Untouched
+        {
+            public static int Value => 2;
+        }
+        """;
+
+    // As trivial an edit as SourceText allows while still being a distinct tree: one appended
+    // trailing blank line, no token anywhere is touched.
+    private static readonly string UnrelatedSourceWithTrivialKeystroke = UnrelatedSourceBefore + Environment.NewLine;
+
+    private static readonly string FixtureWithAlphaTwoFieldRenamed = FixtureSource.Replace(
+        "[property: AkkaField(1)] int Count) : IAlphaProtocol;",
+        "[property: AkkaField(1)] int Total) : IAlphaProtocol;");
+
+    private static readonly string FixtureWithCommentInsideBetaTwo = FixtureSource.Replace(
+        "[property: AkkaField(1)] long Value) : IBetaProtocol;",
+        "[property: AkkaField(1)] /* a trailing comment, no semantic change */ long Value) : IBetaProtocol;");
+
+    private const string ExtraReferenceSource = """
+        namespace ScenarioSample.ExtraReference;
+
+        public static class Unused
+        {
+        }
+        """;
+
+    [Fact(DisplayName = "Tracked pipeline stages should match TrackingNames.All exactly (a new stage must update this spec)")]
+    public void TrackingNames_should_match_expected_stage_count()
+    {
+        // Pins today's stage count. Adding a fifth (or removing one) named pipeline stage is a
+        // deliberate architectural change -- this assertion makes it fail loudly here instead of
+        // only surfacing as a silent gap in the scenarios below.
+        AkkaSerializerGenerator.TrackingNames.All.Should().HaveCount(4);
+        AkkaSerializerGenerator.TrackingNames.All.Should().BeEquivalentTo(new[]
+        {
+            AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
+            AkkaSerializerGenerator.TrackingNames.CollectedSerializers,
+            AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
+            AkkaSerializerGenerator.TrackingNames.CollectedMessages
+        });
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // The core finding, common to every scenario below: ForAttributeWithMetadataName's per-node
+    // transform is joined against the Compilation (it needs a semantic model to confirm the
+    // attribute's full metadata name), so its cache key is COMPILATION-WIDE, not per-file or
+    // per-node. Replacing ANY syntax tree in the compilation -- even one the generator never looks
+    // at -- gives every attributed node a new input identity, so EVERY node's extraction transform
+    // re-executes. A node whose resulting model still compares equal to its previous run reports
+    // Unchanged (recomputed, but the same value), never Cached (skipped without recomputing); only
+    // a node whose model actually differs reports Modified. Nothing at the per-node
+    // (ExtractedSerializers/ExtractedMessages) level is ever Cached in any scenario below -- the
+    // exact same "every node reruns" profile shows up whether the edit lands in the tracked file,
+    // an unrelated file, or is a single added reference. Only downstream, at the Collect() level,
+    // does the pipeline recover a Cached result -- and only when EVERY individual element that
+    // feeds it is Unchanged/Cached; one truly Modified element (scenario (b)) is enough to make the
+    // whole collected array report Modified instead.
+    // ------------------------------------------------------------------------------------------
+
+    [Fact(DisplayName = "Scenario (a): editing an unrelated file reuses every tracked stage and re-emits no file")]
+    public void Scenario_a_unrelated_file_edited()
+    {
+        var result = GeneratorTestHarness.RunIncremental(
+            new[] { new SourceFile("Main.cs", FixtureSource), new SourceFile("Unrelated.cs", UnrelatedSourceBefore) },
+            new[] { new SourceFile("Main.cs", FixtureSource), new SourceFile("Unrelated.cs", UnrelatedSourceAfter) });
+
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedSerializers, IncrementalStepRunReason.Cached);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
+
+        // TARGET: none -- this IS the caching discipline PR 1 pins as the baseline; PRs 2, 3, 5, 6
+        // must not regress it. No hint name's text should change.
+        ChangedHintNames(result).Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Scenario (b): renaming one message's field re-emits every serializer's output, byte-identically except the affected one")]
+    public void Scenario_b_message_field_renamed()
+    {
+        var result = GeneratorTestHarness.RunIncremental(FixtureSource, FixtureWithAlphaTwoFieldRenamed);
+
+        // Same compilation-wide rerun as every other scenario; the only difference is that
+        // AlphaTwo's OWN extracted model genuinely differs (its field name changed), so its node
+        // alone reports Modified. That is the ONE cascading effect that reaches CollectedMessages:
+        // an array with even one Modified element cannot be recognized as Cached, so the whole
+        // array reports Modified -- unlike (a)/(c)/(d)/(e), where every element is merely Unchanged
+        // and Collect() lands on Cached.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedSerializers, IncrementalStepRunReason.Cached);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Modified, IncrementalStepRunReason.Unchanged,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Modified);
+
+        // TARGET: only AlphaSerializer's generated file should change once emission is split
+        // per-serializer (PR 3/5). Today EmitSerializers is ONE RegisterSourceOutput over the whole
+        // (serializers, messages) pair, so it re-executes and re-emits BOTH generated files on any
+        // message edit -- but BetaSerializer's re-emitted text is nonetheless byte-identical to
+        // before (it does not depend on AlphaTwo), so it is correctly excluded from the CHANGED set
+        // computed here (text-equality, not "did this hint name get touched by AddSource again").
+        ChangedHintNames(result).Should().BeEquivalentTo(new[] { "AlphaSerializer.AkkaSerialization.g.cs" });
+    }
+
+    [Fact(DisplayName = "Scenario (c): a comment added inside one message's declaration reuses every tracked stage and re-emits no file")]
+    public void Scenario_c_comment_added_inside_message_body()
+    {
+        var result = GeneratorTestHarness.RunIncremental(FixtureSource, FixtureWithCommentInsideBetaTwo);
+
+        // A comment carries no semantic information, so BetaTwo's recomputed model -- like every
+        // other node's -- compares EQUAL to its previous run. This scenario's tracked-step profile
+        // is therefore indistinguishable from scenario (a)'s (an edit to a wholly unrelated file):
+        // proof that the "everything reruns" behavior described above is driven by the Compilation
+        // changing identity, not by whether the edit is textually "inside" a tracked declaration.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedSerializers, IncrementalStepRunReason.Cached);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
+
+        // TARGET: unchanged from today -- a comment-only edit re-emitting nothing is already the
+        // desired behavior; no migration PR needs to touch this.
+        ChangedHintNames(result).Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Scenario (d): a trivial keystroke in an unrelated file still re-runs the whole-compilation coverage scan")]
+    public void Scenario_d_trivial_keystroke_in_unrelated_file()
+    {
+        var result = GeneratorTestHarness.RunIncremental(
+            new[] { new SourceFile("Main.cs", FixtureSource), new SourceFile("Unrelated.cs", UnrelatedSourceBefore) },
+            new[] { new SourceFile("Main.cs", FixtureSource), new SourceFile("Unrelated.cs", UnrelatedSourceWithTrivialKeystroke) });
+
+        // Same profile as (a)/(c): a single appended blank line in a file the generator never looks
+        // at is still enough to make every node's extraction transform recompute (Unchanged), and
+        // Collect() still lands on Cached since nothing actually differs.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedSerializers, IncrementalStepRunReason.Cached);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
+        ChangedHintNames(result).Should().BeEmpty();
+
+        // TARGET: the coverage scan (AKKASG029, ReportProtocolCoverage) is registered on
+        // serializers.Combine(messages).Combine(context.CompilationProvider) with NO tracking
+        // name -- it is not gated by the same equality contract as the four named stages above, and
+        // is not observable through GetRunResult().Results[0].TrackedSteps at all. OBSERVED today:
+        // it produces the SAME (empty) diagnostics both before and after this trivial edit -- the
+        // fixture is coverage-clean -- which is the externally-visible half of "it still re-runs
+        // every time": the CompilationProvider input this output depends on changes identity on
+        // every edit, so the scan re-executes on this one too, it just has nothing new to report.
+        // PR 5/6 (moving coverage scanning onto the cached message/serializer models instead of the
+        // raw Compilation) is expected to make this scan cacheable too.
+        result.Before.CompileDiagnostics.Where(d => d.Id == "AKKASG029").Should().BeEmpty();
+        result.After.CompileDiagnostics.Where(d => d.Id == "AKKASG029").Should().BeEmpty();
+        result.Before.RunResult.Diagnostics.Where(d => d.Id == "AKKASG029").Should().BeEmpty();
+        result.After.RunResult.Diagnostics.Where(d => d.Id == "AKKASG029").Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Scenario (e): adding an unused metadata reference reuses every tracked stage and re-emits no file")]
+    public void Scenario_e_metadata_reference_added()
+    {
+        var extraReference = GeneratorTestHarness.CompileToReference(ExtraReferenceSource, "ScenarioExtraReferenceAssembly");
+
+        var result = GeneratorTestHarness.RunIncremental(
+            new[] { new SourceFile("Main.cs", FixtureSource) },
+            new[] { new SourceFile("Main.cs", FixtureSource) },
+            beforeExtraReferences: Array.Empty<MetadataReference>(),
+            afterExtraReferences: new[] { extraReference });
+
+        // Same profile again: adding a reference nothing in the fixture uses still changes the
+        // Compilation's identity, so every node recomputes (Unchanged) and Collect() lands on
+        // Cached since no extracted model actually differs.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedSerializers, IncrementalStepRunReason.Cached);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
+
+        // TARGET: unchanged from today -- an unused added reference re-emitting nothing is already
+        // the desired behavior; no migration PR needs to touch this.
+        ChangedHintNames(result).Should().BeEmpty();
+    }
+
+    private static void AssertReasons(IncrementalGeneratorRunResult result, string trackingName, params IncrementalStepRunReason[] expected)
+    {
+        var actual = ReasonsFor(result, trackingName);
+        actual.Should().BeEquivalentTo(expected, options => options.WithStrictOrdering(),
+            $"tracked step '{trackingName}' reasons were [{string.Join(", ", actual)}]");
+    }
+
+    private static List<IncrementalStepRunReason> ReasonsFor(IncrementalGeneratorRunResult result, string trackingName)
+    {
+        var trackedSteps = result.After.RunResult.Results.Single().TrackedSteps;
+        if (!trackedSteps.TryGetValue(trackingName, out var steps))
+            return new List<IncrementalStepRunReason>();
+
+        return steps.SelectMany(step => step.Outputs.Select(output => output.Reason)).ToList();
+    }
+
+    private static ImmutableHashSet<string> ChangedHintNames(IncrementalGeneratorRunResult result)
+    {
+        var allNames = result.Before.GeneratedSources.Keys.Concat(result.After.GeneratedSources.Keys).ToImmutableHashSet();
+        return allNames.Where(name =>
+                !result.Before.GeneratedSources.TryGetValue(name, out var beforeText) ||
+                !result.After.GeneratedSources.TryGetValue(name, out var afterText) ||
+                !string.Equals(beforeText, afterText, StringComparison.Ordinal))
+            .ToImmutableHashSet();
+    }
+}

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorMessageModelSnapshotSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorMessageModelSnapshotSpec.cs
@@ -1,0 +1,165 @@
+//-----------------------------------------------------------------------
+// <copyright file="GeneratorMessageModelSnapshotSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Serialization.V2.Generators;
+using Akka.Serialization.V2.Tests.Harness;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using VerifyXunit;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// Snapshot gate for the generator's EXTRACTION layer -- the counterpart of
+/// <see cref="GeneratorGoldenOutputSpec"/>, which gates the EMISSION layer. Parses every
+/// <c>[AkkaSerializable]</c>-annotated type declared in the exact same golden corpus (reused from
+/// <see cref="GeneratorGoldenOutputSpec.GoldenSource"/>/<see cref="GeneratorGoldenOutputSpec.GlobalNamespaceSource"/>,
+/// never a parallel copy) through <see cref="AkkaSerializerGenerator.ParseMessageForTests"/> -- the
+/// test-only entry point that wraps the pipeline's real, UNMODIFIED extraction routine -- and
+/// snapshots a stable, human-readable rendering of every resulting model: manifest, fields (index,
+/// kind, nullability), union members, and construction plan. A mismatch here means extraction
+/// itself changed shape; it says nothing about emitted text, which
+/// <see cref="GeneratorGoldenOutputSpec"/> covers separately.
+/// </summary>
+/// <remarks>
+/// <see cref="AkkaSerializerGenerator.ParseMessageForTests"/> extracts one message IN ISOLATION --
+/// it never sees a serializer's <c>[AkkaSerializerFormatter&lt;TTarget, TFormatter&gt;]</c>
+/// registrations, which are resolved later, per-serializer, in the emission stage. A field whose
+/// real pipeline behavior depends on such a registration (for example <c>NestedMessage.Foreign</c>,
+/// which <c>GoldenSerializer</c> resolves via <c>ForeignFormatter</c>) therefore snapshots here at
+/// its PRE-formatter-resolution kind (<c>MissingSerializableDefinition</c>), not the
+/// <c>Formatted</c> kind <see cref="GeneratorGoldenOutputSpec"/>'s emitted output actually uses.
+/// That is real, correct behavior for this test-only entry point, not a bug.
+/// </remarks>
+public sealed class GeneratorMessageModelSnapshotSpec
+{
+    [Fact(DisplayName = "Parsed message models for the golden corpus should match their committed snapshot")]
+    public Task Message_models_should_match_committed_snapshot()
+    {
+        var result = GeneratorTestHarness.Run(new[]
+        {
+            new SourceFile("GoldenSample.cs", GeneratorGoldenOutputSpec.GoldenSource),
+            new SourceFile("GlobalSample.cs", GeneratorGoldenOutputSpec.GlobalNamespaceSource)
+        });
+
+        var compilation = result.OutputCompilation;
+        var attributeType = compilation.GetTypeByMetadataName(typeof(AkkaSerializableAttribute).FullName!)
+            ?? throw new InvalidOperationException($"Could not resolve {typeof(AkkaSerializableAttribute).FullName} in the harness compilation.");
+
+        var symbols = new List<INamedTypeSymbol>();
+        foreach (var filePath in new[] { "GoldenSample.cs", "GlobalSample.cs" })
+        {
+            var tree = compilation.SyntaxTrees.Single(t => t.FilePath == filePath);
+            var model = compilation.GetSemanticModel(tree);
+            foreach (var typeDecl in tree.GetRoot().DescendantNodes().OfType<TypeDeclarationSyntax>())
+            {
+                if (model.GetDeclaredSymbol(typeDecl) is not INamedTypeSymbol symbol)
+                    continue;
+
+                if (symbol.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeType)))
+                    symbols.Add(symbol);
+            }
+        }
+
+        var document = string.Join(
+            Environment.NewLine + new string('=', 80) + Environment.NewLine,
+            symbols
+                .OrderBy(s => s.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), StringComparer.Ordinal)
+                .Select(symbol => RenderMessage(symbol, AkkaSerializerGenerator.ParseMessageForTests(symbol, compilation))));
+
+        return Verifier.Verify(document)
+            .UseDirectory("MessageModelSnapshots")
+            .UseFileName("GoldenCorpusMessageModels");
+    }
+
+    private static string RenderMessage(INamedTypeSymbol symbol, AkkaSerializerGenerator.MessageInfo? message)
+    {
+        var sb = new StringBuilder();
+
+        if (message == null)
+        {
+            sb.AppendLine($"Type: {symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}");
+            sb.AppendLine("ParseMessageForTests: null (not recognized as [AkkaSerializable])");
+            return sb.ToString();
+        }
+
+        sb.AppendLine($"Type: {message.FullyQualifiedName}");
+        sb.AppendLine($"SimpleName: {message.SimpleName}");
+        sb.AppendLine($"Manifest: {(string.IsNullOrEmpty(message.Manifest) ? "(none)" : message.Manifest)}");
+        sb.AppendLine($"AllowEmpty: {message.AllowEmpty}");
+        sb.AppendLine($"IsGenericDefinition: {message.IsGenericDefinition}");
+        if (message.IsGenericDefinition)
+            sb.AppendLine($"DefinitionFullName: {message.DefinitionFullName}");
+        sb.AppendLine($"Protocols: {(message.Protocols.IsDefaultOrEmpty ? "(none)" : string.Join(", ", message.Protocols))}");
+
+        sb.AppendLine("Fields:");
+        if (message.Fields.IsDefaultOrEmpty)
+        {
+            sb.AppendLine("  (none)");
+        }
+        else
+        {
+            foreach (var field in message.Fields.OrderBy(f => f.Index))
+            {
+                var flags = new List<string> { $"nullable: {field.IsNullable}" };
+                if (field.Mapping.IsValueType)
+                    flags.Add("valueType");
+                if (field.UnionDeclaredOnObjectField)
+                    flags.Add("unionDeclaredOnObjectField");
+
+                sb.AppendLine($"  [{field.Index}] {field.Name}: kind={field.Mapping.Kind}, type={field.TypeFullName} ({string.Join(", ", flags)})");
+
+                if (!field.UnionMembers.IsDefaultOrEmpty)
+                {
+                    foreach (var member in field.UnionMembers.OrderBy(m => m.TypeFullName, StringComparer.Ordinal))
+                    {
+                        sb.AppendLine(
+                            $"      union member: {member.TypeFullName} (valueType={member.IsValueType}, assignable={member.IsAssignable}, " +
+                            $"supported={member.IsSupported}, sealed={member.IsSealed}, abstract={member.IsAbstract})");
+                    }
+                }
+
+                if (field.Formatter != null)
+                    sb.AppendLine($"      formatter: {field.Formatter.FormatterTypeFullName} (ctorKind={field.Formatter.CtorKind})");
+            }
+        }
+
+        if (!message.InvalidFields.IsDefaultOrEmpty)
+        {
+            sb.AppendLine("InvalidFields:");
+            foreach (var invalid in message.InvalidFields)
+                sb.AppendLine($"  {invalid.PropertyName}: {invalid.Reason}");
+        }
+
+        var plan = message.ConstructionPlan;
+        sb.AppendLine($"ConstructionPlan: valid={plan.Errors.IsDefaultOrEmpty}");
+        if (!plan.Arguments.IsDefaultOrEmpty)
+        {
+            sb.AppendLine("  Arguments:");
+            foreach (var argument in plan.Arguments)
+                sb.AppendLine($"    {argument.ParameterName} <- {argument.FieldName}");
+        }
+
+        if (!plan.InitializerFieldNames.IsDefaultOrEmpty)
+            sb.AppendLine($"  InitializerFields: {string.Join(", ", plan.InitializerFieldNames)}");
+
+        if (!plan.UncoveredDefaultedParameters.IsDefaultOrEmpty)
+            sb.AppendLine($"  UncoveredDefaultedParameters: {string.Join(", ", plan.UncoveredDefaultedParameters)}");
+
+        if (!plan.Errors.IsDefaultOrEmpty)
+            sb.AppendLine($"  Errors: {string.Join(" | ", plan.Errors)}");
+
+        return sb.ToString();
+    }
+}

--- a/src/core/Akka.Serialization.V2.Tests/Harness/GeneratorTestHarness.cs
+++ b/src/core/Akka.Serialization.V2.Tests/Harness/GeneratorTestHarness.cs
@@ -1,0 +1,266 @@
+//-----------------------------------------------------------------------
+// <copyright file="GeneratorTestHarness.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Akka.Actor;
+using Akka.Serialization;
+using Akka.Serialization.V2;
+using Akka.Serialization.V2.Generators;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Akka.Serialization.V2.Tests.Harness;
+
+/// <summary>
+/// One source file fed to <see cref="GeneratorTestHarness"/>: a syntax tree's committed
+/// <see cref="Path"/> (its identity across an incremental "before"/"after" pair, so
+/// <see cref="GeneratorTestHarness.RunIncremental(System.Collections.Generic.IReadOnlyList{Akka.Serialization.V2.Tests.Harness.SourceFile},System.Collections.Generic.IReadOnlyList{Akka.Serialization.V2.Tests.Harness.SourceFile},System.Collections.Generic.IReadOnlyList{Microsoft.CodeAnalysis.MetadataReference}?,System.Collections.Generic.IReadOnlyList{Microsoft.CodeAnalysis.MetadataReference}?)"/>
+/// knows which tree to replace) and its <see cref="Text"/>.
+/// </summary>
+internal readonly record struct SourceFile(string Path, string Text);
+
+/// <summary>
+/// The outcome of one <see cref="GeneratorTestHarness.Run"/> call: everything a spec needs to
+/// assert against, gathered in one place instead of re-derived per test.
+/// </summary>
+internal sealed record GeneratorRunResult(
+    GeneratorDriver Driver,
+    GeneratorDriverRunResult RunResult,
+    Compilation OutputCompilation,
+    ImmutableArray<Diagnostic> GeneratorDiagnostics,
+    ImmutableArray<Diagnostic> CompileDiagnostics,
+    ImmutableArray<Diagnostic> AllDiagnostics,
+    IReadOnlyDictionary<string, string> GeneratedSources,
+    IReadOnlyDictionary<string, TimeSpan> ElapsedByGenerator);
+
+/// <summary>
+/// Pairs the "before" and "after" <see cref="GeneratorRunResult"/> of one
+/// <see cref="GeneratorTestHarness.RunIncremental(string,string,Microsoft.CodeAnalysis.MetadataReference[])"/>
+/// call. <see cref="After"/>'s <see cref="GeneratorRunResult.Driver"/> carries the SAME cache
+/// state <see cref="Before"/> built -- <see cref="After"/>.RunResult.Results[0].TrackedSteps
+/// reports each named step's <see cref="IncrementalStepRunReason"/> relative to that cache, which
+/// is what every incrementality assertion in this project keys off.
+/// </summary>
+internal sealed record IncrementalGeneratorRunResult(GeneratorRunResult Before, GeneratorRunResult After);
+
+/// <summary>
+/// Shared driver for every spec in this project that runs <see cref="AkkaSerializerGenerator"/>
+/// over ad-hoc source text. Three things every one of those specs used to duplicate by hand:
+/// </summary>
+/// <remarks>
+/// <list type="number">
+/// <item>Building the base <see cref="MetadataReference"/> set (every trusted platform assembly
+/// plus the handful of explicit ones the generator's attributes and runtime types live in). This
+/// is expensive (dozens of <see cref="MetadataReference.CreateFromFile(string)"/> calls) and was
+/// previously repeated by EVERY test method across three spec files. Here it is built exactly
+/// once per test process, lazily, behind <see cref="BaseReferences"/>.</item>
+/// <item>Wiring a <see cref="CSharpGeneratorDriver"/> with
+/// <c>trackIncrementalGeneratorSteps: true</c> so <see cref="GeneratorDriverRunResult.Results"/>
+/// carries tracked-step data for every run, not just the specs that remembered to ask for it.</item>
+/// <item>The two-compilation ("assembly A supplies types, assembly B runs the generator") and
+/// two-generation ("run once, edit, run again on the same driver") shapes that recur across the
+/// diagnostics, cross-assembly, and incrementality specs.</item>
+/// </list>
+/// </remarks>
+internal static class GeneratorTestHarness
+{
+    private const string DefaultAssemblyName = "AkkaSerializationGeneratorHarness";
+    private const string DefaultSourcePath = "Source.cs";
+
+    private static readonly Lazy<ImmutableArray<MetadataReference>> LazyBaseReferences =
+        new(BuildBaseReferences, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// The shared base reference set (trusted platform assemblies plus the generator's explicit
+    /// runtime dependencies), built once per process on first use.
+    /// </summary>
+    public static ImmutableArray<MetadataReference> BaseReferences => LazyBaseReferences.Value;
+
+    public static CSharpParseOptions ParseOptions { get; } =
+        CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12);
+
+    /// <summary>
+    /// Runs <see cref="AkkaSerializerGenerator"/> once over a single source file.
+    /// </summary>
+    public static GeneratorRunResult Run(string source, params MetadataReference[] extraReferences)
+    {
+        return Run(new[] { new SourceFile(DefaultSourcePath, source) }, extraReferences);
+    }
+
+    /// <summary>
+    /// Runs <see cref="AkkaSerializerGenerator"/> once over an arbitrary set of source files.
+    /// </summary>
+    public static GeneratorRunResult Run(IReadOnlyList<SourceFile> sources, params MetadataReference[] extraReferences)
+    {
+        var compilation = CreateCompilation(DefaultAssemblyName, sources, extraReferences);
+        return RunCore(CreateDriver(), compilation);
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="source"/> to an in-memory assembly and returns a
+    /// <see cref="MetadataReference"/> to it -- the "assembly A supplies types, assembly B runs the
+    /// generator" shape used by the cross-assembly baseline spec. The generator never runs over
+    /// this compilation.
+    /// </summary>
+    public static MetadataReference CompileToReference(string source, string assemblyName)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, ParseOptions, path: assemblyName + ".cs");
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { syntaxTree },
+            BaseReferences,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+
+        var errors = compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToImmutableArray();
+        if (!errors.IsEmpty)
+        {
+            throw new InvalidOperationException(
+                $"Assembly '{assemblyName}' must compile with no errors -- it supplies types only, it does no generator work: " +
+                string.Join("; ", errors.Select(e => e.ToString())));
+        }
+
+        using var stream = new MemoryStream();
+        var emitResult = compilation.Emit(stream);
+        if (!emitResult.Success)
+        {
+            throw new InvalidOperationException(
+                $"Assembly '{assemblyName}' failed to emit: " + string.Join("; ", emitResult.Diagnostics.Select(d => d.ToString())));
+        }
+
+        return MetadataReference.CreateFromImage(stream.ToArray());
+    }
+
+    /// <summary>
+    /// Runs the generator on <paramref name="before"/>, then replaces the single source file with
+    /// <paramref name="after"/> and runs again on the SAME driver, so the second run's tracked
+    /// steps reflect real incremental caching against the first.
+    /// </summary>
+    public static IncrementalGeneratorRunResult RunIncremental(string before, string after, params MetadataReference[] extraReferences)
+    {
+        return RunIncremental(
+            new[] { new SourceFile(DefaultSourcePath, before) },
+            new[] { new SourceFile(DefaultSourcePath, after) },
+            extraReferences,
+            extraReferences);
+    }
+
+    /// <summary>
+    /// General multi-file / changing-references form of <see cref="RunIncremental(string,string,MetadataReference[])"/>:
+    /// any file present in both <paramref name="beforeSources"/> and <paramref name="afterSources"/>
+    /// (matched by <see cref="SourceFile.Path"/>) is replaced; a file present only in
+    /// <paramref name="afterSources"/> is added for the second run. <paramref name="afterExtraReferences"/>,
+    /// when given, REPLACES the reference list used for the second run (so a scenario can add,
+    /// rather than only edit, a reference between runs).
+    /// </summary>
+    public static IncrementalGeneratorRunResult RunIncremental(
+        IReadOnlyList<SourceFile> beforeSources,
+        IReadOnlyList<SourceFile> afterSources,
+        IReadOnlyList<MetadataReference>? beforeExtraReferences = null,
+        IReadOnlyList<MetadataReference>? afterExtraReferences = null)
+    {
+        var beforeCompilation = CreateCompilation(DefaultAssemblyName, beforeSources, beforeExtraReferences ?? Array.Empty<MetadataReference>());
+        var driver = CreateDriver();
+        var beforeResult = RunCore(driver, beforeCompilation);
+
+        var afterByPath = afterSources.ToDictionary(s => s.Path, s => s.Text, StringComparer.Ordinal);
+        var editedCompilation = beforeCompilation;
+        foreach (var tree in beforeCompilation.SyntaxTrees)
+        {
+            if (afterByPath.TryGetValue(tree.FilePath, out var newText))
+                editedCompilation = editedCompilation.ReplaceSyntaxTree(tree, CSharpSyntaxTree.ParseText(newText, ParseOptions, path: tree.FilePath));
+        }
+
+        var beforePaths = new HashSet<string>(beforeSources.Select(s => s.Path), StringComparer.Ordinal);
+        foreach (var addedSource in afterSources.Where(s => !beforePaths.Contains(s.Path)))
+            editedCompilation = editedCompilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(addedSource.Text, ParseOptions, path: addedSource.Path));
+
+        if (afterExtraReferences != null)
+        {
+            editedCompilation = editedCompilation
+                .RemoveReferences(editedCompilation.References.Except(BaseReferences))
+                .AddReferences(afterExtraReferences);
+        }
+
+        // Re-run on beforeResult.Driver (not a fresh driver): that is what lets the second run's
+        // tracked steps report Cached/Unchanged/Modified relative to the first run's cache.
+        var afterResult = RunCore(beforeResult.Driver, editedCompilation);
+        return new IncrementalGeneratorRunResult(beforeResult, afterResult);
+    }
+
+    private static GeneratorDriver CreateDriver()
+    {
+        return CSharpGeneratorDriver.Create(
+            ImmutableArray.Create(new AkkaSerializerGenerator().AsSourceGenerator()),
+            parseOptions: ParseOptions,
+            driverOptions: new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps: true));
+    }
+
+    private static GeneratorRunResult RunCore(GeneratorDriver driver, CSharpCompilation compilation)
+    {
+        var ranDriver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var generatorDiagnostics);
+        var runResult = ranDriver.GetRunResult();
+
+        var generatedSources = runResult.GeneratedTrees
+            .ToImmutableDictionary(tree => System.IO.Path.GetFileName(tree.FilePath), tree => tree.ToString(), StringComparer.Ordinal);
+
+        var compileDiagnostics = outputCompilation.GetDiagnostics();
+
+        var elapsedByGenerator = ranDriver.GetTimingInfo().GeneratorTimes
+            .ToImmutableDictionary(timing => timing.Generator.GetType().Name, timing => timing.ElapsedTime);
+
+        return new GeneratorRunResult(
+            ranDriver,
+            runResult,
+            outputCompilation,
+            generatorDiagnostics,
+            compileDiagnostics,
+            generatorDiagnostics.AddRange(compileDiagnostics),
+            generatedSources,
+            elapsedByGenerator);
+    }
+
+    private static CSharpCompilation CreateCompilation(string assemblyName, IReadOnlyList<SourceFile> sources, IReadOnlyList<MetadataReference> extraReferences)
+    {
+        var trees = sources.Select(s => CSharpSyntaxTree.ParseText(s.Text, ParseOptions, path: s.Path));
+        return CSharpCompilation.Create(
+            assemblyName,
+            trees,
+            BaseReferences.Concat(extraReferences),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+    }
+
+    private static ImmutableArray<MetadataReference> BuildBaseReferences()
+    {
+        var trustedAssemblies = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))?
+            .Split(System.IO.Path.PathSeparator)
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path)) ?? Enumerable.Empty<MetadataReference>();
+
+        var explicitAssemblies = new[]
+        {
+            typeof(ActorSystem).Assembly,
+            typeof(AkkaSerializerAttribute<>).Assembly,
+            typeof(SerializerV2).Assembly,
+            typeof(global::MessagePack.MessagePackWriter).Assembly,
+            typeof(ImmutableHashSet<>).Assembly,
+            Assembly.GetExecutingAssembly()
+        };
+
+        return trustedAssemblies
+            .Concat(explicitAssemblies.Select(assembly => MetadataReference.CreateFromFile(assembly.Location)))
+            .GroupBy(reference => reference.Display)
+            .Select(group => group.First())
+            .ToImmutableArray();
+    }
+}

--- a/src/core/Akka.Serialization.V2.Tests/MessageModelSnapshots/GoldenCorpusMessageModels.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/MessageModelSnapshots/GoldenCorpusMessageModels.verified.txt
@@ -1,0 +1,350 @@
+﻿Type: global::GoldenSample.CollectionMessage
+SimpleName: CollectionMessage
+Manifest: collections-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IProtocol, global::System.IEquatable<global::GoldenSample.CollectionMessage>
+Fields:
+  [1] Codes: kind=Array, type=int[] (nullable: False)
+  [2] Names: kind=List, type=global::System.Collections.Generic.List<string> (nullable: False)
+  [3] Samples: kind=ReadOnlyList, type=global::System.Collections.Generic.IReadOnlyList<double> (nullable: False)
+  [4] Ids: kind=ReadOnlyCollection, type=global::System.Collections.Generic.IReadOnlyCollection<global::System.Guid> (nullable: False)
+  [5] Tags: kind=Dictionary, type=global::System.Collections.Generic.Dictionary<string, string> (nullable: False)
+  [6] ReadingsById: kind=ReadOnlyDictionary, type=global::System.Collections.Generic.IReadOnlyDictionary<int, global::GoldenSample.Reading> (nullable: False)
+  [7] Points: kind=ImmutableArray, type=global::System.Collections.Immutable.ImmutableArray<int> (nullable: False)
+  [8] Readings: kind=ImmutableList, type=global::System.Collections.Immutable.ImmutableList<global::GoldenSample.Reading> (nullable: False)
+  [9] Labels: kind=ImmutableHashSet, type=global::System.Collections.Immutable.ImmutableHashSet<string> (nullable: False)
+  [10] Counters: kind=ImmutableDictionary, type=global::System.Collections.Immutable.ImmutableDictionary<string, long> (nullable: False)
+  [11] MaybeTrack: kind=ImmutableArray, type=global::System.Collections.Immutable.ImmutableArray<global::GoldenSample.GeoPoint>? (nullable: True)
+  [12] MaybeNumbers: kind=List, type=global::System.Collections.Generic.List<int> (nullable: True)
+  [13] Matrix: kind=List, type=global::System.Collections.Generic.List<global::System.Collections.Generic.List<int>> (nullable: False)
+  [14] History: kind=Dictionary, type=global::System.Collections.Generic.Dictionary<string, global::System.Collections.Generic.List<global::GoldenSample.Reading>> (nullable: False)
+  [15] SparseReadings: kind=List, type=global::System.Collections.Generic.List<global::GoldenSample.Reading> (nullable: False)
+  [16] Track: kind=List, type=global::System.Collections.Generic.List<global::GoldenSample.GeoPoint> (nullable: False)
+  [17] SparseTrack: kind=List, type=global::System.Collections.Generic.List<global::GoldenSample.GeoPoint?> (nullable: False)
+  [18] SparseCodes: kind=List, type=global::System.Collections.Generic.List<int?> (nullable: False)
+  [19] SparseNames: kind=List, type=global::System.Collections.Generic.List<string> (nullable: False)
+  [20] Jagged: kind=Array, type=int[][] (nullable: False)
+  [21] Palette: kind=List, type=global::System.Collections.Generic.List<global::GoldenSample.Color> (nullable: False)
+ConstructionPlan: valid=True
+  Arguments:
+    Codes <- Codes
+    Names <- Names
+    Samples <- Samples
+    Ids <- Ids
+    Tags <- Tags
+    ReadingsById <- ReadingsById
+    Points <- Points
+    Readings <- Readings
+    Labels <- Labels
+    Counters <- Counters
+    MaybeTrack <- MaybeTrack
+    MaybeNumbers <- MaybeNumbers
+    Matrix <- Matrix
+    History <- History
+    SparseReadings <- SparseReadings
+    Track <- Track
+    SparseTrack <- SparseTrack
+    SparseCodes <- SparseCodes
+    SparseNames <- SparseNames
+    Jagged <- Jagged
+    Palette <- Palette
+
+================================================================================
+Type: global::GoldenSample.EnvelopeMessage
+SimpleName: EnvelopeMessage
+Manifest: envelope-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IProtocol, global::System.IEquatable<global::GoldenSample.EnvelopeMessage>
+Fields:
+  [1] CorrelationId: kind=String, type=string (nullable: False)
+  [2] Payload: kind=EnvelopePayload, type=object (nullable: False)
+  [3] MaybePayload: kind=EnvelopePayload, type=object (nullable: True)
+ConstructionPlan: valid=True
+  Arguments:
+    CorrelationId <- CorrelationId
+    Payload <- Payload
+    MaybePayload <- MaybePayload
+
+================================================================================
+Type: global::GoldenSample.EscapedManifestMessage
+SimpleName: EscapedManifestMessage
+Manifest: esc-"quote"-\-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IProtocol, global::System.IEquatable<global::GoldenSample.EscapedManifestMessage>
+Fields:
+  [1] Text: kind=String, type=string (nullable: False)
+ConstructionPlan: valid=True
+  Arguments:
+    Text <- Text
+
+================================================================================
+Type: global::GoldenSample.GeoPoint
+SimpleName: GeoPoint
+Manifest: (none)
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::System.IEquatable<global::GoldenSample.GeoPoint>
+Fields:
+  [1] Lat: kind=Double, type=double (nullable: False)
+  [2] Lon: kind=Double, type=double (nullable: False)
+ConstructionPlan: valid=True
+  Arguments:
+    Lat <- Lat
+    Lon <- Lon
+
+================================================================================
+Type: global::GoldenSample.HybridMessage
+SimpleName: HybridMessage
+Manifest: hybrid-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IProtocol
+Fields:
+  [1] Id: kind=String, type=string (nullable: False)
+  [2] Count: kind=Int32, type=int (nullable: False)
+  [3] Event: kind=String, type=string (nullable: False)
+  [4] Note: kind=String, type=string (nullable: True)
+  [5] Origin: kind=Object, type=global::GoldenSample.GeoPoint (nullable: False, valueType)
+ConstructionPlan: valid=True
+  Arguments:
+    id <- Id
+    count <- Count
+    event <- Event
+  InitializerFields: Note, Origin
+
+================================================================================
+Type: global::GoldenSample.MiniMessage
+SimpleName: MiniMessage
+Manifest: mini-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IMiniProtocol, global::System.IEquatable<global::GoldenSample.MiniMessage>
+Fields:
+  [1] Text: kind=String, type=string (nullable: False)
+ConstructionPlan: valid=True
+  Arguments:
+    Text <- Text
+
+================================================================================
+Type: global::GoldenSample.NestedMessage
+SimpleName: NestedMessage
+Manifest: nested-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IProtocol, global::System.IEquatable<global::GoldenSample.NestedMessage>
+Fields:
+  [1] Primary: kind=Object, type=global::GoldenSample.Reading (nullable: False)
+  [2] Secondary: kind=Object, type=global::GoldenSample.Reading (nullable: True)
+  [3] Location: kind=Object, type=global::GoldenSample.GeoPoint (nullable: False, valueType)
+  [4] MaybeLocation: kind=Object, type=global::GoldenSample.GeoPoint? (nullable: True, valueType)
+  [5] Foreign: kind=MissingSerializableDefinition, type=global::GoldenSample.Foreign (nullable: False)
+  [6] MaybeForeign: kind=MissingSerializableDefinition, type=global::GoldenSample.Foreign (nullable: True)
+  [7] Temperature: kind=MissingSerializableDefinition, type=global::GoldenSample.Temperature (nullable: False)
+  [8] MaybeTemperature: kind=MissingSerializableDefinition, type=global::GoldenSample.Temperature? (nullable: True)
+  [9] WrappedCount: kind=Object, type=global::GoldenSample.Wrapper<int> (nullable: False)
+ConstructionPlan: valid=True
+  Arguments:
+    Primary <- Primary
+    Secondary <- Secondary
+    Location <- Location
+    MaybeLocation <- MaybeLocation
+    Foreign <- Foreign
+    MaybeForeign <- MaybeForeign
+    Temperature <- Temperature
+    MaybeTemperature <- MaybeTemperature
+    WrappedCount <- WrappedCount
+
+================================================================================
+Type: global::GoldenSample.OrderCancelled
+SimpleName: OrderCancelled
+Manifest: order-cancelled-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IOrderEvent, global::System.IEquatable<global::GoldenSample.OrderCancelled>
+Fields:
+  [1] OrderId: kind=String, type=string (nullable: False)
+  [2] Reason: kind=String, type=string (nullable: True)
+ConstructionPlan: valid=True
+  Arguments:
+    OrderId <- OrderId
+    Reason <- Reason
+
+================================================================================
+Type: global::GoldenSample.OrderExpired
+SimpleName: OrderExpired
+Manifest: order-expired-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IOrderEvent, global::System.IEquatable<global::GoldenSample.OrderExpired>
+Fields:
+  [1] ExpiredAtTicks: kind=Int64, type=long (nullable: False)
+ConstructionPlan: valid=True
+  Arguments:
+    ExpiredAtTicks <- ExpiredAtTicks
+
+================================================================================
+Type: global::GoldenSample.OrderPlaced
+SimpleName: OrderPlaced
+Manifest: order-placed-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IOrderEvent, global::System.IEquatable<global::GoldenSample.OrderPlaced>
+Fields:
+  [1] OrderId: kind=String, type=string (nullable: False)
+ConstructionPlan: valid=True
+  Arguments:
+    OrderId <- OrderId
+
+================================================================================
+Type: global::GoldenSample.Pair
+SimpleName: Pair
+Manifest: (none)
+AllowEmpty: True
+IsGenericDefinition: True
+DefinitionFullName: global::GoldenSample.Pair
+Protocols: global::System.IEquatable<global::GoldenSample.Pair<TA, TB>>
+Fields:
+  (none)
+ConstructionPlan: valid=True
+
+================================================================================
+Type: global::GoldenSample.Ping
+SimpleName: Ping
+Manifest: ping-v1
+AllowEmpty: True
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IProtocol, global::System.IEquatable<global::GoldenSample.Ping>
+Fields:
+  (none)
+ConstructionPlan: valid=True
+
+================================================================================
+Type: global::GoldenSample.Reading
+SimpleName: Reading
+Manifest: (none)
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::System.IEquatable<global::GoldenSample.Reading>
+Fields:
+  [1] Sensor: kind=String, type=string (nullable: False)
+  [2] Value: kind=Double, type=double (nullable: False)
+ConstructionPlan: valid=True
+  Arguments:
+    Sensor <- Sensor
+    Value <- Value
+
+================================================================================
+Type: global::GoldenSample.ScalarMessage
+SimpleName: ScalarMessage
+Manifest: scalars-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IProtocol, global::System.IEquatable<global::GoldenSample.ScalarMessage>
+Fields:
+  [1] Name: kind=String, type=string (nullable: False)
+  [2] Event: kind=ByteArray, type=byte[] (nullable: False)
+  [3] Lock: kind=Int32, type=int (nullable: False)
+  [4] Params: kind=Int64, type=long (nullable: False)
+  [5] FieldCount: kind=Boolean, type=bool (nullable: False)
+  [6] EntryIndex: kind=Double, type=double (nullable: False)
+  [7] Amount: kind=Decimal, type=decimal (nullable: False)
+  [8] Id: kind=Guid, type=global::System.Guid (nullable: False)
+  [9] CreatedAt: kind=DateTime, type=global::System.DateTime (nullable: False)
+  [10] UpdatedAt: kind=DateTimeOffset, type=global::System.DateTimeOffset (nullable: False)
+  [11] Sender: kind=ActorRef, type=global::Akka.Actor.IActorRef (nullable: False)
+  [12] Color: kind=Enum, type=global::GoldenSample.Color (nullable: False)
+  [13] Priority: kind=Enum, type=global::GoldenSample.Priority (nullable: False)
+  [14] MaybeCount: kind=Int32, type=int? (nullable: True)
+  [15] MaybeId: kind=Guid, type=global::System.Guid? (nullable: True)
+  [16] MaybeColor: kind=Enum, type=global::GoldenSample.Color? (nullable: True)
+  [17] MaybeName: kind=String, type=string (nullable: True)
+  [18] Foo: kind=String, type=string (nullable: False)
+  [19] HasFoo: kind=String, type=string (nullable: False)
+ConstructionPlan: valid=True
+  Arguments:
+    Name <- Name
+    Event <- Event
+    Lock <- Lock
+    Params <- Params
+    FieldCount <- FieldCount
+    EntryIndex <- EntryIndex
+    Amount <- Amount
+    Id <- Id
+    CreatedAt <- CreatedAt
+    UpdatedAt <- UpdatedAt
+    Sender <- Sender
+    Color <- Color
+    Priority <- Priority
+    MaybeCount <- MaybeCount
+    MaybeId <- MaybeId
+    MaybeColor <- MaybeColor
+    MaybeName <- MaybeName
+    Foo <- Foo
+    HasFoo <- HasFoo
+
+================================================================================
+Type: global::GoldenSample.StructMessage
+SimpleName: StructMessage
+Manifest: struct-msg-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IProtocol, global::System.IEquatable<global::GoldenSample.StructMessage>
+Fields:
+  [1] A: kind=Int32, type=int (nullable: False)
+  [2] B: kind=String, type=string (nullable: False)
+ConstructionPlan: valid=True
+  Arguments:
+    A <- A
+    B <- B
+
+================================================================================
+Type: global::GoldenSample.UnionMessage
+SimpleName: UnionMessage
+Manifest: union-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IProtocol, global::System.IEquatable<global::GoldenSample.UnionMessage>
+Fields:
+  [1] Event: kind=Union, type=global::GoldenSample.IOrderEvent (nullable: False)
+      union member: global::GoldenSample.OrderCancelled (valueType=False, assignable=True, supported=True, sealed=True, abstract=False)
+      union member: global::GoldenSample.OrderExpired (valueType=True, assignable=True, supported=True, sealed=True, abstract=False)
+      union member: global::GoldenSample.OrderPlaced (valueType=False, assignable=True, supported=True, sealed=True, abstract=False)
+  [2] MaybeEvent: kind=Union, type=global::GoldenSample.IOrderEvent (nullable: True)
+      union member: global::GoldenSample.OrderCancelled (valueType=False, assignable=True, supported=True, sealed=True, abstract=False)
+      union member: global::GoldenSample.OrderExpired (valueType=True, assignable=True, supported=True, sealed=True, abstract=False)
+      union member: global::GoldenSample.OrderPlaced (valueType=False, assignable=True, supported=True, sealed=True, abstract=False)
+  [3] Narrowed: kind=Union, type=global::GoldenSample.IOrderEvent (nullable: False)
+      union member: global::GoldenSample.OrderPlaced (valueType=False, assignable=True, supported=True, sealed=True, abstract=False)
+ConstructionPlan: valid=True
+  Arguments:
+    Event <- Event
+    MaybeEvent <- MaybeEvent
+    Narrowed <- Narrowed
+
+================================================================================
+Type: global::GoldenSample.Wrapper
+SimpleName: Wrapper
+Manifest: (none)
+AllowEmpty: True
+IsGenericDefinition: True
+DefinitionFullName: global::GoldenSample.Wrapper
+Protocols: global::GoldenSample.IProtocol, global::System.IEquatable<global::GoldenSample.Wrapper<T>>
+Fields:
+  (none)
+ConstructionPlan: valid=True
+
+================================================================================
+Type: global::RootMessage
+SimpleName: RootMessage
+Manifest: root-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::IRootProtocol, global::System.IEquatable<global::RootMessage>
+Fields:
+  [1] Value: kind=String, type=string (nullable: False)
+ConstructionPlan: valid=True
+  Arguments:
+    Value <- Value


### PR DESCRIPTION
## Summary

Part of #8384. Step S1 of the generator architecture pass: the measurement scaffolding, with no change to generator behavior. Emitted output is byte-identical; `GoldenOutput/` and `WireSnapshots/` are untouched. The only generator-project edits are `private` to `internal` on twelve model types and a 48-line `internal static` parse entry point that wraps the existing extraction routine.

## What it adds

- **A shared test harness** (`Tests/Harness/GeneratorTestHarness.cs`) that builds the metadata reference set once per process and exposes `Run`, `CompileToReference`, and `RunIncremental`, with the driver's tracked steps and timing info. The diagnostics and cross-assembly specs are migrated to it mechanically; every DisplayName and assertion is unchanged. The diagnostics spec went from about 10 s to about 2 s.
- **A model snapshot** (`GeneratorMessageModelSnapshotSpec`): parses all 18 serializable types in the golden corpus through the new entry point and snapshots the extracted models with Verify, so an extraction regression is visible without reading emitted text.
- **Five incrementality scenarios** (`GeneratorIncrementalScenariosSpec`), pinned to today's behavior, each commented with the target and the later PR expected to flip it, plus a tracked-step count guard.
- **Two architecture guards** (`GeneratorArchitectureSpec`): no Roslyn symbol, compilation, syntax, or location type in any model, checked by reflection over every model type; and value equality on every model. The first guard caught a deliberately planted symbol field during a negative test.
- **A baseline benchmark** (`Akka.Benchmarks/Serialization/SourceGeneratorBenchmarks.cs`, memory diagnoser, short-run config): a synthetic corpus of 5 serializers x 100 messages, measuring a cold full run and three kinds of incremental edit on a warm driver.

## Baseline numbers

| Benchmark, 5 x 100 messages, short run | Mean | Allocated |
|---|---:|---:|
| Fresh driver, full corpus | 75.3 ms | 23.2 MB |
| Warm driver, one field renamed | 114.8 ms | 23.2 MB |
| Warm driver, comment edit inside a message | 60.4 ms | 7.8 MB |
| Warm driver, unrelated file edited | 70.1 ms | 7.8 MB |

A single-field rename costs more than a cold run, because the per-node recompute is paid on top of full re-emission rather than instead of it. An edit that changes no model still costs most of a cold run's time, because every attributed type's transform re-runs on any compilation change and only the collect step downstream recovers a cached result.

## Pinned scenarios, today

| Scenario | Extracted steps | Collected steps | Files whose text changed |
|---|---|---|---|
| Unrelated file edited | Unchanged | Cached | none |
| One field renamed | 1 Modified, rest Unchanged | Modified | the owning serializer only |
| Comment added inside a message | Unchanged | Cached | none |
| Keystroke in an unrelated file | Unchanged | Cached | none |
| Metadata reference added | Unchanged | Cached | none |

S3, the resolve stage, targets the rename row; S5, the compilation-facts stage, targets the allocation floor on the no-change rows; S6 targets locations.

## Testing

`dotnet test src/core/Akka.Serialization.V2.Tests -c Release`: 278 passed. Generator builds with warnings as errors. `Akka.Benchmarks` builds. No golden or wire snapshot changes.
