### PR TITLE
Serialization.V2: validation returns diagnostics; one gate ladder shared by both outputs (S2, stacked on #8521)

### DIFF
--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Diagnostics.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Diagnostics.cs
@@ -365,4 +365,68 @@ public sealed partial class AkkaSerializerGenerator
         "Akka.Serialization.V2",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    /// <summary>
+    /// Resolves a <see cref="DiagnosticKey"/> to the exact <see cref="DiagnosticDescriptor"/> field
+    /// above it names, and turns a <see cref="DiagnosticSpec"/> into a real <see cref="Diagnostic"/>
+    /// -- the ONE place in this generator that happens. Private, not a cached pipeline model: it
+    /// never needs to cross the incremental boundary or appear in a test assertion, since every
+    /// caller either builds a <see cref="DiagnosticSpec"/> for this to resolve, or -- in tests --
+    /// asserts on the <see cref="DiagnosticSpec"/> itself and never calls this at all.
+    /// </summary>
+    private static class DiagnosticRegistry
+    {
+        public static DiagnosticDescriptor Resolve(DiagnosticKey key) => key switch
+        {
+            DiagnosticKey.InvalidSerializerName => InvalidSerializerName,
+            DiagnosticKey.InvalidSerializerId => InvalidSerializerId,
+            DiagnosticKey.UnsupportedFieldType => UnsupportedFieldType,
+            DiagnosticKey.UnsupportedFieldTypePolymorphic => UnsupportedFieldTypePolymorphic,
+            DiagnosticKey.MissingFields => MissingFields,
+            DiagnosticKey.DuplicateFieldIndex => DuplicateFieldIndex,
+            DiagnosticKey.MissingManifest => MissingManifest,
+            DiagnosticKey.MissingNestedSerializableDefinition => MissingNestedSerializableDefinition,
+            DiagnosticKey.MissingNestedSerializableDefinitionCrossAssembly => MissingNestedSerializableDefinitionCrossAssembly,
+            DiagnosticKey.InvalidFormatterType => InvalidFormatterType,
+            DiagnosticKey.DuplicateFormatterRegistration => DuplicateFormatterRegistration,
+            DiagnosticKey.FormatterConstructorNotUsable => FormatterConstructorNotUsable,
+            DiagnosticKey.FormatterTargetNotSupported => FormatterTargetNotSupported,
+            DiagnosticKey.DuplicateManifest => DuplicateManifest,
+            DiagnosticKey.DuplicateSerializerId => DuplicateSerializerId,
+            DiagnosticKey.UnsupportedEnumUnderlyingType => UnsupportedEnumUnderlyingType,
+            DiagnosticKey.UnionMemberNotSerializable => UnionMemberNotSerializable,
+            DiagnosticKey.UnionMemberNotSerializableCrossAssembly => UnionMemberNotSerializableCrossAssembly,
+            DiagnosticKey.UnionMemberMissingManifest => UnionMemberMissingManifest,
+            DiagnosticKey.UnionMemberManifestCollision => UnionMemberManifestCollision,
+            DiagnosticKey.UnionMemberNotAssignable => UnionMemberNotAssignable,
+            DiagnosticKey.InvalidUnionMemberSet => InvalidUnionMemberSet,
+            DiagnosticKey.InvalidClosedGenericRegistration => InvalidClosedGenericRegistration,
+            DiagnosticKey.DuplicateClosedGenericRegistration => DuplicateClosedGenericRegistration,
+            DiagnosticKey.GenericSerializableRequiresRegistration => GenericSerializableRequiresRegistration,
+            DiagnosticKey.UnregisteredClosedGenericField => UnregisteredClosedGenericField,
+            DiagnosticKey.DuplicateGeneratedName => DuplicateGeneratedName,
+            DiagnosticKey.UnionMemberNotSealed => UnionMemberNotSealed,
+            DiagnosticKey.NoMatchingConstructor => NoMatchingConstructor,
+            DiagnosticKey.ConstructorParameterNotCovered => ConstructorParameterNotCovered,
+            DiagnosticKey.FieldPropertyNotAccessible => FieldPropertyNotAccessible,
+            DiagnosticKey.ProtocolMessageNotSerializable => ProtocolMessageNotSerializable,
+            DiagnosticKey.DuplicateProtocolBinding => DuplicateProtocolBinding,
+            DiagnosticKey.InvalidSerializerShape => InvalidSerializerShape,
+            DiagnosticKey.ProtocolTypeMustBeInterface => ProtocolTypeMustBeInterface,
+            DiagnosticKey.ClosedGenericRegistrationNotInProtocol => ClosedGenericRegistrationNotInProtocol,
+            DiagnosticKey.UnionMemberAbstract => UnionMemberAbstract,
+            DiagnosticKey.ManifestIgnoredOnGenericDefinition => ManifestIgnoredOnGenericDefinition,
+            DiagnosticKey.UnionDeclaredOnObjectField => UnionDeclaredOnObjectField,
+            _ => throw new ArgumentOutOfRangeException(nameof(key), key, "Unknown DiagnosticKey: add a case mapping it to its DiagnosticDescriptor.")
+        };
+
+        public static Diagnostic ToDiagnostic(DiagnosticSpec spec)
+        {
+            var args = new object[spec.MessageArgs.Length];
+            for (var i = 0; i < spec.MessageArgs.Length; i++)
+                args[i] = spec.MessageArgs[i];
+
+            return Diagnostic.Create(Resolve(spec.Key), Location.None, args);
+        }
+    }
 }

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Emission.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Emission.cs
@@ -18,6 +18,35 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Akka.Serialization.V2.Generators;
+
+/// <summary>
+/// The per-serializer view of the message table computed by <see cref="AkkaSerializerGenerator.ResolveSerializerMessages"/>:
+/// every message with hand-written formatters swapped in (<see cref="ResolvedMessagesByType"/>),
+/// which of those are top-level (dispatched directly by this serializer's Manifest/Serialize/
+/// Deserialize switches), and which are reachable from a top-level message (and therefore need
+/// generated Write/Read/SizeOf methods at all). Computed once per gate-passing serializer and shared
+/// between validation (<see cref="AkkaSerializerGenerator.Validate"/>) and emission
+/// (<see cref="AkkaSerializerGenerator.EmitSerializers"/>) so the two never see a different message
+/// table for the same input. Not a cached pipeline model -- like <see cref="SerializerGate"/>, it
+/// lives at namespace scope instead of nested under <see cref="AkkaSerializerGenerator"/>.
+/// </summary>
+internal readonly struct ResolvedSerializerMessages
+{
+    public ResolvedSerializerMessages(
+        ImmutableArray<AkkaSerializerGenerator.MessageInfo> topLevelMessages,
+        ImmutableArray<AkkaSerializerGenerator.MessageInfo> reachableMessages,
+        ImmutableDictionary<string, AkkaSerializerGenerator.MessageInfo> resolvedMessagesByType)
+    {
+        TopLevelMessages = topLevelMessages;
+        ReachableMessages = reachableMessages;
+        ResolvedMessagesByType = resolvedMessagesByType;
+    }
+
+    public ImmutableArray<AkkaSerializerGenerator.MessageInfo> TopLevelMessages { get; }
+    public ImmutableArray<AkkaSerializerGenerator.MessageInfo> ReachableMessages { get; }
+    public ImmutableDictionary<string, AkkaSerializerGenerator.MessageInfo> ResolvedMessagesByType { get; }
+}
+
 public sealed partial class AkkaSerializerGenerator
 {
     private static void EmitSerializers(
@@ -68,61 +97,58 @@ public sealed partial class AkkaSerializerGenerator
             if (serializer == null)
                 continue;
 
-            if (string.IsNullOrWhiteSpace(serializer.Name))
-            {
-                context.ReportDiagnostic(Diagnostic.Create(InvalidSerializerName, Location.None, serializer.ClassName));
-                continue;
-            }
+            // One gate ladder, shared with ReportProtocolCoverage below: is this serializer's own
+            // declaration usable as a codegen target at all? See EvaluateGate's doc comment in
+            // AkkaSerializerGenerator.Validation.cs.
+            var gate = EvaluateGate(serializer, duplicateSerializerIds, duplicateProtocolBindings, genericDefinitions);
+            foreach (var gateDiagnostic in gate.Diagnostics)
+                context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(gateDiagnostic));
 
-            if (serializer.SerializerId <= 0)
-            {
-                context.ReportDiagnostic(Diagnostic.Create(InvalidSerializerId, Location.None, serializer.ClassName, serializer.SerializerId));
-                continue;
-            }
-
-            if (duplicateSerializerIds.ContainsKey(serializer.SerializerId))
+            if (!gate.IsEmittable)
                 continue;
 
-            if (duplicateProtocolBindings.ContainsKey(serializer.ProtocolTypeFullName))
+            var resolved = ResolveSerializerMessages(serializer, declaredMessages);
+            var validationDiagnostics = ImmutableArray.CreateBuilder<DiagnosticSpec>();
+            ValidateResolved(serializer, resolved, validationDiagnostics);
+
+            var reportable = validationDiagnostics.ToImmutable();
+            foreach (var diagnostic in reportable)
+                context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(diagnostic));
+
+            // Emission is suppressed by an ERROR-severity diagnostic only -- a Warning (e.g.
+            // AKKASG027) or Info (e.g. AKKASG025) still lets the serializer generate normally, exactly
+            // as the old isValid-returning Validate* chain already behaved (see ValidateResolved).
+            if (reportable.Any(diagnostic => DiagnosticRegistry.Resolve(diagnostic.Key).DefaultSeverity == DiagnosticSeverity.Error))
                 continue;
 
-            if (!ValidateSerializerShape(serializer, context.ReportDiagnostic))
-                continue;
-
-            if (!ValidateProtocolType(serializer, context.ReportDiagnostic))
-                continue;
-
-            if (!ValidateFormatters(serializer, context.ReportDiagnostic))
-                continue;
-
-            if (!ValidateClosedGenericRegistrations(serializer, context.ReportDiagnostic))
-                continue;
-
-            if (!ValidateGenericDefinitions(serializer, genericDefinitions, context.ReportDiagnostic))
-                continue;
-
-            var allMessages = declaredMessages
-                .Where(message => !message.IsGenericDefinition)
-                .Concat(serializer.ClosedGenericRegistrations
-                    .Where(registration => registration.Message != null)
-                    .Select(registration => registration.Message!))
-                .ToImmutableArray();
-            var allMessagesByType = allMessages.ToImmutableDictionary(message => message.FullyQualifiedName);
-            var resolvedMessagesByType = ResolveMessages(allMessagesByType, serializer.Formatters);
-            var topLevelMessages = allMessages
-                .Where(message => serializer.ProtocolTypeFullName.Length > 0 && message.Protocols.Contains(serializer.ProtocolTypeFullName))
-                .Select(message => resolvedMessagesByType[message.FullyQualifiedName])
-                .ToImmutableArray();
-            var reachableMessages = CollectReachableMessages(topLevelMessages, resolvedMessagesByType);
-
-            if (!ValidateMessages(context, serializer, topLevelMessages, reachableMessages, resolvedMessagesByType))
-                continue;
-
-            if (!ValidateClosedGenericProtocolCoverage(context, serializer, reachableMessages))
-                continue;
-
-            context.AddSource(serializer.ClassName + ".AkkaSerialization.g.cs", Generate(serializer, topLevelMessages, reachableMessages, resolvedMessagesByType));
+            context.AddSource(serializer.ClassName + ".AkkaSerialization.g.cs", Generate(serializer, resolved.TopLevelMessages, resolved.ReachableMessages, resolved.ResolvedMessagesByType));
         }
+    }
+
+    /// <summary>
+    /// Resolves one serializer's message table -- formatter substitution, top-level selection,
+    /// reachability -- into the shape both validation (<see cref="ValidateResolved"/>/<see cref="Validate"/>)
+    /// and code generation (<see cref="Generate"/>) need. Extracted so the two never risk seeing a
+    /// different table for the same input: <see cref="EmitSerializers"/> computes it once per
+    /// gate-passing serializer and passes the SAME <see cref="ResolvedSerializerMessages"/> to both.
+    /// </summary>
+    private static ResolvedSerializerMessages ResolveSerializerMessages(SerializerInfo serializer, ImmutableArray<MessageInfo> declaredMessages)
+    {
+        var allMessages = declaredMessages
+            .Where(message => !message.IsGenericDefinition)
+            .Concat(serializer.ClosedGenericRegistrations
+                .Where(registration => registration.Message != null)
+                .Select(registration => registration.Message!))
+            .ToImmutableArray();
+        var allMessagesByType = allMessages.ToImmutableDictionary(message => message.FullyQualifiedName);
+        var resolvedMessagesByType = ResolveMessages(allMessagesByType, serializer.Formatters);
+        var topLevelMessages = allMessages
+            .Where(message => serializer.ProtocolTypeFullName.Length > 0 && message.Protocols.Contains(serializer.ProtocolTypeFullName))
+            .Select(message => resolvedMessagesByType[message.FullyQualifiedName])
+            .ToImmutableArray();
+        var reachableMessages = CollectReachableMessages(topLevelMessages, resolvedMessagesByType);
+
+        return new ResolvedSerializerMessages(topLevelMessages, reachableMessages, resolvedMessagesByType);
     }
 
     private static ImmutableDictionary<string, MessageInfo> ResolveMessages(

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Models.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Models.cs
@@ -839,4 +839,105 @@ public sealed partial class AkkaSerializerGenerator
             return hash;
         }
     }
+
+    /// <summary>
+    /// Identifies exactly one <see cref="DiagnosticDescriptor"/> field declared in
+    /// AkkaSerializerGenerator.Diagnostics.cs -- by DESCRIPTOR FIELD, not by public diagnostic id.
+    /// Key scheme: three ids are each backed by TWO distinct descriptor fields with the same
+    /// id/title/severity but different message text (AKKASG003: plain vs. the polymorphic-hint
+    /// variant for an interface/abstract/type-parameter field; AKKASG007 and AKKASG015: same-assembly
+    /// vs. the cross-assembly-hint variant), so the public id alone cannot tell a
+    /// <see cref="DiagnosticSpec"/> apart from its sibling variant. Every member below is named
+    /// IDENTICALLY to the descriptor field it resolves to (see the private DiagnosticRegistry in
+    /// AkkaSerializerGenerator.Diagnostics.cs), so the 1:1 mapping is obvious at both ends.
+    /// </summary>
+    internal enum DiagnosticKey
+    {
+        InvalidSerializerName,
+        InvalidSerializerId,
+        UnsupportedFieldType,
+        UnsupportedFieldTypePolymorphic,
+        MissingFields,
+        DuplicateFieldIndex,
+        MissingManifest,
+        MissingNestedSerializableDefinition,
+        MissingNestedSerializableDefinitionCrossAssembly,
+        InvalidFormatterType,
+        DuplicateFormatterRegistration,
+        FormatterConstructorNotUsable,
+        FormatterTargetNotSupported,
+        DuplicateManifest,
+        DuplicateSerializerId,
+        UnsupportedEnumUnderlyingType,
+        UnionMemberNotSerializable,
+        UnionMemberNotSerializableCrossAssembly,
+        UnionMemberMissingManifest,
+        UnionMemberManifestCollision,
+        UnionMemberNotAssignable,
+        InvalidUnionMemberSet,
+        InvalidClosedGenericRegistration,
+        DuplicateClosedGenericRegistration,
+        GenericSerializableRequiresRegistration,
+        UnregisteredClosedGenericField,
+        DuplicateGeneratedName,
+        UnionMemberNotSealed,
+        NoMatchingConstructor,
+        ConstructorParameterNotCovered,
+        FieldPropertyNotAccessible,
+        ProtocolMessageNotSerializable,
+        DuplicateProtocolBinding,
+        InvalidSerializerShape,
+        ProtocolTypeMustBeInterface,
+        ClosedGenericRegistrationNotInProtocol,
+        UnionMemberAbstract,
+        ManifestIgnoredOnGenericDefinition,
+        UnionDeclaredOnObjectField
+    }
+
+    /// <summary>
+    /// A diagnostic to report, with no live <see cref="Diagnostic"/>, <see cref="Location"/>, or
+    /// symbol reference: just <see cref="Key"/> (which <see cref="DiagnosticDescriptor"/> field --
+    /// see <see cref="DiagnosticKey"/>) and the already display-formatted message arguments (a
+    /// numeric argument, e.g. AKKASG002's serializer id or AKKASG005's field index, is converted to
+    /// its decimal string ahead of time, since <see cref="MessageArgs"/> is homogeneous). Pure
+    /// validation functions in AkkaSerializerGenerator.Validation.cs return these instead of calling
+    /// <c>SourceProductionContext.ReportDiagnostic</c> directly, so validation runs -- and can be
+    /// asserted against directly, by <see cref="Key"/> and <see cref="MessageArgs"/> rather than by
+    /// message substring -- with no driver, context, or <see cref="Compilation"/> at all. The private
+    /// DiagnosticRegistry in AkkaSerializerGenerator.Diagnostics.cs is the one place a
+    /// <see cref="DiagnosticSpec"/> is turned into a real <see cref="Diagnostic"/>, always at
+    /// <see cref="Location.None"/> (every diagnostic this generator has ever reported already was).
+    /// </summary>
+    internal sealed class DiagnosticSpec : IEquatable<DiagnosticSpec>
+    {
+        public DiagnosticSpec(DiagnosticKey key, params string[] messageArgs)
+        {
+            Key = key;
+            MessageArgs = messageArgs.Length == 0 ? ImmutableArray<string>.Empty : ImmutableArray.Create(messageArgs);
+        }
+
+        public DiagnosticKey Key { get; }
+        public ImmutableArray<string> MessageArgs { get; }
+
+        public bool Equals(DiagnosticSpec? other)
+        {
+            if (ReferenceEquals(this, other))
+                return true;
+
+            if (other is null)
+                return false;
+
+            return Key == other.Key && ValueEquality.SequenceEquals(MessageArgs, other.MessageArgs);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as DiagnosticSpec);
+
+        public override int GetHashCode()
+        {
+            var hash = ValueEquality.Seed;
+            hash = ValueEquality.Combine(hash, (int)Key);
+            hash = ValueEquality.Combine(hash, MessageArgs);
+            return hash;
+        }
+    }
 }

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Validation.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Validation.cs
@@ -18,15 +18,40 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Akka.Serialization.V2.Generators;
+
+/// <summary>
+/// The result of <see cref="AkkaSerializerGenerator.EvaluateGate"/>: whether a serializer's own
+/// declaration is usable as a codegen target at all (<see cref="IsEmittable"/>), plus every
+/// diagnostic that check produced, as <see cref="AkkaSerializerGenerator.DiagnosticSpec"/> values
+/// rather than live <see cref="Diagnostic"/>s. <see cref="Diagnostics"/> is empty whenever the gate
+/// fails for a reason that carries no diagnostic of its own here (a duplicate serializer id or
+/// protocol binding -- those are reported once, in bulk, by the caller, before the gate ever runs
+/// per-serializer). Not a cached pipeline model: it is built and consumed entirely within one
+/// <c>RegisterSourceOutput</c> callback and never crosses an incremental boundary, so -- like
+/// <c>Local</c>/<c>ValueExpr</c>/<c>TypeName</c> in CodeWriter.cs -- it lives at namespace scope
+/// instead of nested under <see cref="AkkaSerializerGenerator"/>.
+/// </summary>
+internal readonly struct SerializerGate
+{
+    public SerializerGate(bool isEmittable, ImmutableArray<AkkaSerializerGenerator.DiagnosticSpec> diagnostics)
+    {
+        IsEmittable = isEmittable;
+        Diagnostics = diagnostics;
+    }
+
+    public bool IsEmittable { get; }
+    public ImmutableArray<AkkaSerializerGenerator.DiagnosticSpec> Diagnostics { get; }
+}
+
 public sealed partial class AkkaSerializerGenerator
 {
     /// <summary>
     /// Diagnostics-only output for AKKASG029 (see the comment in <see cref="Initialize"/>). To
     /// preserve the old terminal stage's semantics, a serializer only reaches the coverage scan
-    /// after it passes every check that used to precede <see cref="ValidateProtocolCoverage"/> in
-    /// the single-output pipeline -- those checks run here SILENTLY (null reporter): the emission
-    /// output above is the one that reports them, and reporting them twice would duplicate every
-    /// pre-coverage diagnostic.
+    /// after it passes the same gate <see cref="EmitSerializers"/> runs (see <see cref="EvaluateGate"/>)
+    /// -- evaluated here SILENTLY (its <see cref="SerializerGate.Diagnostics"/> are discarded): the
+    /// emission output above is the one that reports them, and reporting them twice would duplicate
+    /// every pre-coverage diagnostic.
     /// </summary>
     private static void ReportProtocolCoverage(
         SourceProductionContext context,
@@ -47,31 +72,13 @@ public sealed partial class AkkaSerializerGenerator
             if (serializer == null)
                 continue;
 
-            if (string.IsNullOrWhiteSpace(serializer.Name) || serializer.SerializerId <= 0)
+            var gate = EvaluateGate(serializer, duplicateSerializerIds, duplicateProtocolBindings, genericDefinitions);
+            if (!gate.IsEmittable)
                 continue;
 
-            if (duplicateSerializerIds.ContainsKey(serializer.SerializerId))
-                continue;
-
-            if (duplicateProtocolBindings.ContainsKey(serializer.ProtocolTypeFullName))
-                continue;
-
-            if (!ValidateSerializerShape(serializer, report: null))
-                continue;
-
-            if (!ValidateProtocolType(serializer, report: null))
-                continue;
-
-            if (!ValidateFormatters(serializer, report: null))
-                continue;
-
-            if (!ValidateClosedGenericRegistrations(serializer, report: null))
-                continue;
-
-            if (!ValidateGenericDefinitions(serializer, genericDefinitions, report: null))
-                continue;
-
-            ValidateProtocolCoverage(context, serializer, compilation);
+            var protocolCoverageDiagnostics = ValidateProtocolCoverage(serializer, compilation, context.CancellationToken);
+            foreach (var diagnostic in protocolCoverageDiagnostics)
+                context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(diagnostic));
         }
     }
 
@@ -98,35 +105,128 @@ public sealed partial class AkkaSerializerGenerator
     }
 
     /// <summary>
+    /// The per-serializer gate every codegen target must clear before its message table is even
+    /// looked at: is the declaration itself usable (name, id, uniqueness, shape, protocol type,
+    /// formatters, closed-generic registrations, generic-definition coverage)? Both
+    /// <see cref="EmitSerializers"/> (which reports <see cref="SerializerGate.Diagnostics"/>) and
+    /// <see cref="ReportProtocolCoverage"/> (which discards them, silently replicating the gate) call
+    /// this SAME method, so the two outputs can never disagree about which serializers are gated out.
+    /// Mirrors the old single-output stage's check order exactly: each step below short-circuits the
+    /// ones after it, but a single step (formatters, closed-generic registrations, generic
+    /// definitions) can itself append more than one diagnostic before failing.
+    /// <paramref name="duplicateSerializerIds"/> and <paramref name="duplicateProtocolBindings"/> are
+    /// precomputed by the caller (each output computes its own copy from the same input array) so a
+    /// serializer that is part of either duplicate group is gated out WITHOUT a diagnostic here --
+    /// that diagnostic was already reported once, in bulk, by the caller.
+    /// </summary>
+    internal static SerializerGate EvaluateGate(
+        SerializerInfo serializer,
+        ImmutableDictionary<int, string> duplicateSerializerIds,
+        ImmutableDictionary<string, string> duplicateProtocolBindings,
+        ImmutableArray<MessageInfo> genericDefinitions)
+    {
+        var diagnostics = ImmutableArray.CreateBuilder<DiagnosticSpec>();
+
+        if (string.IsNullOrWhiteSpace(serializer.Name))
+        {
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerName, serializer.ClassName));
+            return new SerializerGate(false, diagnostics.ToImmutable());
+        }
+
+        if (serializer.SerializerId <= 0)
+        {
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerId, serializer.ClassName, serializer.SerializerId.ToString()));
+            return new SerializerGate(false, diagnostics.ToImmutable());
+        }
+
+        if (duplicateSerializerIds.ContainsKey(serializer.SerializerId))
+            return new SerializerGate(false, ImmutableArray<DiagnosticSpec>.Empty);
+
+        if (duplicateProtocolBindings.ContainsKey(serializer.ProtocolTypeFullName))
+            return new SerializerGate(false, ImmutableArray<DiagnosticSpec>.Empty);
+
+        if (!ValidateSerializerShape(serializer, diagnostics))
+            return new SerializerGate(false, diagnostics.ToImmutable());
+
+        if (!ValidateProtocolType(serializer, diagnostics))
+            return new SerializerGate(false, diagnostics.ToImmutable());
+
+        if (!ValidateFormatters(serializer, diagnostics))
+            return new SerializerGate(false, diagnostics.ToImmutable());
+
+        if (!ValidateClosedGenericRegistrations(serializer, diagnostics))
+            return new SerializerGate(false, diagnostics.ToImmutable());
+
+        if (!ValidateGenericDefinitions(serializer, genericDefinitions, diagnostics))
+            return new SerializerGate(false, diagnostics.ToImmutable());
+
+        return new SerializerGate(true, diagnostics.ToImmutable());
+    }
+
+    /// <summary>
+    /// Runs every model-only validation check for one serializer against its message table -- the
+    /// SECOND half of the per-serializer pipeline, after <see cref="EvaluateGate"/> has already
+    /// passed (there is no reason to validate a message table for a serializer whose own declaration
+    /// is broken). Mirrors the call sequence the old single-output emission stage ran inline: resolve
+    /// formatters, pick out this serializer's top-level messages, walk to everything reachable from
+    /// them, validate the result, then check closed-generic registrations against it. Takes only
+    /// symbol-free models -- no <see cref="SourceProductionContext"/>, <see cref="Compilation"/>, or
+    /// driver of any kind -- so a test can call it directly on hand-built models (see
+    /// GeneratorValidatorSpec.cs) with no generator run at all.
+    /// </summary>
+    internal static ImmutableArray<DiagnosticSpec> Validate(SerializerInfo serializer, ImmutableArray<MessageInfo> messages)
+    {
+        var resolved = ResolveSerializerMessages(serializer, messages);
+        var diagnostics = ImmutableArray.CreateBuilder<DiagnosticSpec>();
+        ValidateResolved(serializer, resolved, diagnostics);
+        return diagnostics.ToImmutable();
+    }
+
+    /// <summary>
+    /// Shared by <see cref="Validate"/> and <see cref="EmitSerializers"/> so both run the exact same
+    /// validation over the exact same <see cref="ResolvedSerializerMessages"/> -- emission calls this
+    /// with a table it also reuses for code generation; <see cref="Validate"/> computes one just for
+    /// the call. <see cref="ValidateClosedGenericProtocolCoverage"/> runs only when
+    /// <see cref="ValidateMessages"/> found no error, mirroring the old stage's short-circuit exactly
+    /// (a message-level error already means nothing will be emitted, so the AKKASG034 coverage scan
+    /// over a table already known to be broken is skipped, exactly as before).
+    /// </summary>
+    private static void ValidateResolved(SerializerInfo serializer, ResolvedSerializerMessages resolved, ImmutableArray<DiagnosticSpec>.Builder diagnostics)
+    {
+        if (!ValidateMessages(serializer, resolved.TopLevelMessages, resolved.ReachableMessages, resolved.ResolvedMessagesByType, diagnostics))
+            return;
+
+        ValidateClosedGenericProtocolCoverage(serializer, resolved.ReachableMessages, diagnostics);
+    }
+
+    /// <summary>
     /// Fires AKKASG032 for each way the [AkkaSerializer] class declaration itself is unusable as
     /// a codegen target: not partial, not derived from the AkkaSerializer base class, or generic.
     /// Today each of these produces a wall of raw CS errors (CS0260/CS0759/CS0115/CS0264) pointing
     /// at the GENERATED file instead of the user's declaration; this replaces that with one direct
     /// diagnostic per violated rule, still on the user's class.
-    /// A null <paramref name="report"/> evaluates the check silently -- the coverage output uses
-    /// that to replicate the emission stage's gating without duplicating its diagnostics.
     /// </summary>
-    private static bool ValidateSerializerShape(SerializerInfo serializer, Action<Diagnostic>? report)
+    private static bool ValidateSerializerShape(SerializerInfo serializer, ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
         var isValid = true;
 
         if (!serializer.IsPartial)
         {
-            report?.Invoke(Diagnostic.Create(InvalidSerializerShape, Location.None, serializer.ClassName,
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerShape, serializer.ClassName,
                 "must be declared 'partial': the generator emits a second declaration of this class"));
             isValid = false;
         }
 
         if (!serializer.DerivesFromAkkaSerializerBase)
         {
-            report?.Invoke(Diagnostic.Create(InvalidSerializerShape, Location.None, serializer.ClassName,
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerShape, serializer.ClassName,
                 "must derive from Akka.Serialization.V2.AkkaSerializer: the generated members (Identifier, Manifest, Serialize, Deserialize, SizeHint) are declared as overrides of that base"));
             isValid = false;
         }
 
         if (serializer.IsGeneric)
         {
-            report?.Invoke(Diagnostic.Create(InvalidSerializerShape, Location.None, serializer.ClassName,
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerShape, serializer.ClassName,
                 "cannot be a generic type: the generator emits one concrete, closed partial class per [AkkaSerializer] declaration"));
             isValid = false;
         }
@@ -144,12 +244,12 @@ public sealed partial class AkkaSerializerGenerator
     /// argument was not a named type at all (the extraction stored no name for it) and is exempt,
     /// exactly as the former null-symbol check was.
     /// </summary>
-    private static bool ValidateProtocolType(SerializerInfo serializer, Action<Diagnostic>? report)
+    private static bool ValidateProtocolType(SerializerInfo serializer, ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
         if (serializer.ProtocolTypeFullName.Length == 0 || serializer.ProtocolTypeIsInterface)
             return true;
 
-        report?.Invoke(Diagnostic.Create(ProtocolTypeMustBeInterface, Location.None, serializer.ClassName, ToDisplayName(serializer.ProtocolTypeFullName)));
+        diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ProtocolTypeMustBeInterface, serializer.ClassName, ToDisplayName(serializer.ProtocolTypeFullName)));
         return false;
     }
 
@@ -168,21 +268,28 @@ public sealed partial class AkkaSerializerGenerator
     /// deliberately symbol-free, and within one compilation a fully-qualified name identifies
     /// exactly one type, so the string comparison is equivalent to the former
     /// <see cref="SymbolEqualityComparer.Default"/> lookup.
+    /// This is the one validation step that genuinely needs a <see cref="Compilation"/> (the
+    /// whole-compilation type scan below), so unlike its neighbors it is not "model-only" -- but it
+    /// still returns <see cref="DiagnosticSpec"/> values rather than reporting through a
+    /// <see cref="SourceProductionContext"/> directly, so it can be driven by a plain
+    /// <see cref="CancellationToken"/> and asserted against directly in tests.
     /// </summary>
-    private static void ValidateProtocolCoverage(SourceProductionContext context, SerializerInfo serializer, Compilation compilation)
+    internal static ImmutableArray<DiagnosticSpec> ValidateProtocolCoverage(SerializerInfo serializer, Compilation compilation, CancellationToken cancellationToken)
     {
+        var diagnostics = ImmutableArray.CreateBuilder<DiagnosticSpec>();
+
         if (serializer.ProtocolTypeFullName.Length == 0)
-            return;
+            return diagnostics.ToImmutable();
 
         var knownTypes = KnownTypes.From(compilation);
         if (knownTypes.SerializableAttribute == null)
-            return;
+            return diagnostics.ToImmutable();
 
         foreach (var candidate in GetSourceDeclaredTypes(compilation))
         {
             // This whole-compilation walk re-runs on every edit (its output combines the
             // CompilationProvider by necessity); honor IDE cancellation between candidates.
-            context.CancellationToken.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (candidate.TypeKind is not (TypeKind.Class or TypeKind.Struct))
                 continue;
@@ -198,9 +305,11 @@ public sealed partial class AkkaSerializerGenerator
             if (isMarked)
                 continue;
 
-            context.ReportDiagnostic(Diagnostic.Create(ProtocolMessageNotSerializable, Location.None,
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ProtocolMessageNotSerializable,
                 ToDisplayName(GetFullyQualifiedTypeName(candidate)), ToDisplayName(serializer.ProtocolTypeFullName), serializer.ClassName));
         }
+
+        return diagnostics.ToImmutable();
     }
 
     private static bool ImplementsProtocol(INamedTypeSymbol candidate, string protocolTypeFullName)
@@ -250,7 +359,7 @@ public sealed partial class AkkaSerializerGenerator
         }
     }
 
-    private static bool ValidateFormatters(SerializerInfo serializer, Action<Diagnostic>? report)
+    private static bool ValidateFormatters(SerializerInfo serializer, ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
         if (serializer.Formatters.IsDefaultOrEmpty)
             return true;
@@ -260,21 +369,21 @@ public sealed partial class AkkaSerializerGenerator
         {
             if (!formatter.IsTargetSupported)
             {
-                report?.Invoke(Diagnostic.Create(FormatterTargetNotSupported, Location.None, ToDisplayName(formatter.TargetTypeFullName), serializer.ClassName));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.FormatterTargetNotSupported, ToDisplayName(formatter.TargetTypeFullName), serializer.ClassName));
                 isValid = false;
                 continue;
             }
 
             if (formatter.IsAbstract)
             {
-                report?.Invoke(Diagnostic.Create(InvalidFormatterType, Location.None, ToDisplayName(formatter.FormatterTypeFullName), serializer.ClassName, ToDisplayName(formatter.TargetTypeFullName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidFormatterType, ToDisplayName(formatter.FormatterTypeFullName), serializer.ClassName, ToDisplayName(formatter.TargetTypeFullName)));
                 isValid = false;
                 continue;
             }
 
             if (formatter.CtorKind == FormatterCtorKind.None)
             {
-                report?.Invoke(Diagnostic.Create(FormatterConstructorNotUsable, Location.None, ToDisplayName(formatter.FormatterTypeFullName), serializer.ClassName));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.FormatterConstructorNotUsable, ToDisplayName(formatter.FormatterTypeFullName), serializer.ClassName));
                 isValid = false;
             }
         }
@@ -284,14 +393,14 @@ public sealed partial class AkkaSerializerGenerator
                      .GroupBy(formatter => formatter.TargetTypeFullName, StringComparer.Ordinal)
                      .Where(group => group.Count() > 1))
         {
-            report?.Invoke(Diagnostic.Create(DuplicateFormatterRegistration, Location.None, serializer.ClassName, ToDisplayName(duplicate.Key)));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateFormatterRegistration, serializer.ClassName, ToDisplayName(duplicate.Key)));
             isValid = false;
         }
 
         return isValid;
     }
 
-    private static bool ValidateClosedGenericRegistrations(SerializerInfo serializer, Action<Diagnostic>? report)
+    private static bool ValidateClosedGenericRegistrations(SerializerInfo serializer, ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
         if (serializer.ClosedGenericRegistrations.IsDefaultOrEmpty)
             return true;
@@ -299,7 +408,7 @@ public sealed partial class AkkaSerializerGenerator
         var isValid = true;
         foreach (var registration in serializer.ClosedGenericRegistrations.Where(registration => registration.Message == null))
         {
-            report?.Invoke(Diagnostic.Create(InvalidClosedGenericRegistration, Location.None, ToDisplayName(registration.TargetDisplayName), serializer.ClassName));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidClosedGenericRegistration, ToDisplayName(registration.TargetDisplayName), serializer.ClassName));
             isValid = false;
         }
 
@@ -308,7 +417,7 @@ public sealed partial class AkkaSerializerGenerator
                      .GroupBy(registration => registration.TargetDisplayName, StringComparer.Ordinal)
                      .Where(group => group.Count() > 1))
         {
-            report?.Invoke(Diagnostic.Create(DuplicateClosedGenericRegistration, Location.None, serializer.ClassName, ToDisplayName(duplicate.Key)));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateClosedGenericRegistration, serializer.ClassName, ToDisplayName(duplicate.Key)));
             isValid = false;
         }
 
@@ -321,7 +430,7 @@ public sealed partial class AkkaSerializerGenerator
     /// registration the type would silently never serialize, which is exactly the confusing
     /// broken-codegen failure mode this diagnostic replaces.
     /// </summary>
-    private static bool ValidateGenericDefinitions(SerializerInfo serializer, ImmutableArray<MessageInfo> genericDefinitions, Action<Diagnostic>? report)
+    private static bool ValidateGenericDefinitions(SerializerInfo serializer, ImmutableArray<MessageInfo> genericDefinitions, ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
         if (genericDefinitions.IsDefaultOrEmpty || serializer.ProtocolTypeFullName.Length == 0)
             return true;
@@ -338,7 +447,7 @@ public sealed partial class AkkaSerializerGenerator
             if (hasRegistration)
                 continue;
 
-            report?.Invoke(Diagnostic.Create(GenericSerializableRequiresRegistration, Location.None, ToDisplayName(definition.FullyQualifiedName), ToDisplayName(serializer.ProtocolTypeFullName), serializer.ClassName));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.GenericSerializableRequiresRegistration, ToDisplayName(definition.FullyQualifiedName), ToDisplayName(serializer.ProtocolTypeFullName), serializer.ClassName));
             isValid = false;
         }
 
@@ -401,12 +510,17 @@ public sealed partial class AkkaSerializerGenerator
         }
     }
 
-    private static bool ValidateMessages(SourceProductionContext context, SerializerInfo serializer, ImmutableArray<MessageInfo> topLevelMessages, ImmutableArray<MessageInfo> reachableMessages, ImmutableDictionary<string, MessageInfo> messagesByType)
+    private static bool ValidateMessages(
+        SerializerInfo serializer,
+        ImmutableArray<MessageInfo> topLevelMessages,
+        ImmutableArray<MessageInfo> reachableMessages,
+        ImmutableDictionary<string, MessageInfo> messagesByType,
+        ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
         var isValid = true;
         foreach (var message in topLevelMessages.Where(message => string.IsNullOrWhiteSpace(message.Manifest)))
         {
-            context.ReportDiagnostic(Diagnostic.Create(MissingManifest, Location.None, ToDisplayName(message.FullyQualifiedName)));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.MissingManifest, ToDisplayName(message.FullyQualifiedName)));
             isValid = false;
         }
 
@@ -416,7 +530,7 @@ public sealed partial class AkkaSerializerGenerator
                      .Where(group => group.Count() > 1))
         {
             var typeNames = string.Join(", ", duplicate.Select(m => ToDisplayName(m.FullyQualifiedName)));
-            context.ReportDiagnostic(Diagnostic.Create(DuplicateManifest, Location.None, serializer.ClassName, duplicate.Key, typeNames));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateManifest, serializer.ClassName, duplicate.Key, typeNames));
             isValid = false;
         }
 
@@ -424,13 +538,13 @@ public sealed partial class AkkaSerializerGenerator
         {
             if (message.Fields.Length == 0 && !message.AllowEmpty)
             {
-                context.ReportDiagnostic(Diagnostic.Create(MissingFields, Location.None, ToDisplayName(message.FullyQualifiedName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.MissingFields, ToDisplayName(message.FullyQualifiedName)));
                 isValid = false;
             }
 
             foreach (var duplicate in message.Fields.GroupBy(field => field.Index).Where(group => group.Count() > 1))
             {
-                context.ReportDiagnostic(Diagnostic.Create(DuplicateFieldIndex, Location.None, ToDisplayName(message.FullyQualifiedName), duplicate.Key));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateFieldIndex, ToDisplayName(message.FullyQualifiedName), duplicate.Key.ToString()));
                 isValid = false;
             }
 
@@ -439,7 +553,7 @@ public sealed partial class AkkaSerializerGenerator
             // message.Fields, so they cannot double-report through any of the checks below.
             foreach (var invalidField in message.InvalidFields)
             {
-                context.ReportDiagnostic(Diagnostic.Create(FieldPropertyNotAccessible, Location.None, invalidField.PropertyName, ToDisplayName(message.FullyQualifiedName), invalidField.Reason));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.FieldPropertyNotAccessible, invalidField.PropertyName, ToDisplayName(message.FullyQualifiedName), invalidField.Reason));
                 isValid = false;
             }
 
@@ -448,7 +562,7 @@ public sealed partial class AkkaSerializerGenerator
             // back on -- both make deserialize impossible to generate.
             foreach (var error in message.ConstructionPlan.Errors)
             {
-                context.ReportDiagnostic(Diagnostic.Create(NoMatchingConstructor, Location.None, ToDisplayName(message.FullyQualifiedName), error));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.NoMatchingConstructor, ToDisplayName(message.FullyQualifiedName), error));
                 isValid = false;
             }
 
@@ -457,7 +571,7 @@ public sealed partial class AkkaSerializerGenerator
             // deserialize because no [AkkaField] property feeds it.
             foreach (var parameterName in message.ConstructionPlan.UncoveredDefaultedParameters)
             {
-                context.ReportDiagnostic(Diagnostic.Create(ConstructorParameterNotCovered, Location.None, parameterName, ToDisplayName(message.FullyQualifiedName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ConstructorParameterNotCovered, parameterName, ToDisplayName(message.FullyQualifiedName)));
             }
 
             // Error (AKKASG038): an object-typed property is always the envelope-payload boundary
@@ -465,33 +579,33 @@ public sealed partial class AkkaSerializerGenerator
             // never take effect, so this is contradictory author intent, not a harmless no-op.
             foreach (var field in message.Fields.Where(field => field.UnionDeclaredOnObjectField))
             {
-                context.ReportDiagnostic(Diagnostic.Create(UnionDeclaredOnObjectField, Location.None, field.Name, ToDisplayName(message.FullyQualifiedName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionDeclaredOnObjectField, field.Name, ToDisplayName(message.FullyQualifiedName)));
                 isValid = false;
             }
 
             foreach (var field in message.Fields.Where(field => field.Mapping.Kind == FieldKind.Unsupported))
             {
-                context.ReportDiagnostic(field.Mapping.SuggestsEnvelopeOrUnion
-                    ? Diagnostic.Create(UnsupportedFieldTypePolymorphic, Location.None, field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.TypeFullName))
-                    : Diagnostic.Create(UnsupportedFieldType, Location.None, field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.TypeFullName)));
+                diagnostics.Add(field.Mapping.SuggestsEnvelopeOrUnion
+                    ? new DiagnosticSpec(DiagnosticKey.UnsupportedFieldTypePolymorphic, field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.TypeFullName))
+                    : new DiagnosticSpec(DiagnosticKey.UnsupportedFieldType, field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.TypeFullName)));
                 isValid = false;
             }
 
             foreach (var field in message.Fields.Where(field => field.Mapping.Kind == FieldKind.MissingSerializableDefinition))
             {
-                ReportMissingNestedSchema(context, message, field.Name, field.TypeFullName, field.Mapping, serializer.ClassName);
+                ReportMissingNestedSchema(message, field.Name, field.TypeFullName, field.Mapping, serializer.ClassName, diagnostics);
                 isValid = false;
             }
 
             foreach (var field in message.Fields.Where(field => field.Mapping.Kind == FieldKind.UnsupportedEnumUnderlyingType))
             {
-                context.ReportDiagnostic(Diagnostic.Create(UnsupportedEnumUnderlyingType, Location.None, field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.Mapping.TypeFullName), ToDisplayName(field.Mapping.EnumUnderlyingTypeName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnsupportedEnumUnderlyingType, field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.Mapping.TypeFullName), ToDisplayName(field.Mapping.EnumUnderlyingTypeName)));
                 isValid = false;
             }
 
             foreach (var field in message.Fields.Where(field => field.Mapping.Kind == FieldKind.Union))
             {
-                if (!ValidateUnionField(context, message, field, messagesByType, serializer.ClassName))
+                if (!ValidateUnionField(message, field, messagesByType, serializer.ClassName, diagnostics))
                     isValid = false;
             }
 
@@ -508,7 +622,7 @@ public sealed partial class AkkaSerializerGenerator
                     if (!seenTypeNames.Add(objectMapping.TypeFullName) || messagesByType.ContainsKey(objectMapping.TypeFullName))
                         continue;
 
-                    ReportMissingNestedSchema(context, message, field.Name, objectMapping.TypeFullName, objectMapping, serializer.ClassName);
+                    ReportMissingNestedSchema(message, field.Name, objectMapping.TypeFullName, objectMapping, serializer.ClassName, diagnostics);
                     isValid = false;
                 }
             }
@@ -522,7 +636,7 @@ public sealed partial class AkkaSerializerGenerator
                      .Where(group => group.Select(m => m.FullyQualifiedName).Distinct(StringComparer.Ordinal).Count() > 1))
         {
             var typeNames = string.Join(", ", collision.Select(m => ToDisplayName(m.FullyQualifiedName)));
-            context.ReportDiagnostic(Diagnostic.Create(DuplicateGeneratedName, Location.None, serializer.ClassName, collision.Key, typeNames));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateGeneratedName, serializer.ClassName, collision.Key, typeNames));
             isValid = false;
         }
 
@@ -534,22 +648,22 @@ public sealed partial class AkkaSerializerGenerator
     // referenced assembly reports the AKKASG007 cross-assembly wording; anything else reports the
     // plain AKKASG007 message.
     private static void ReportMissingNestedSchema(
-        SourceProductionContext context,
         MessageInfo message,
         string fieldName,
         string typeFullName,
         TypeMapping mapping,
-        string serializerClassName)
+        string serializerClassName,
+        ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
         if (mapping.IsGenericConstruction)
         {
-            context.ReportDiagnostic(Diagnostic.Create(UnregisteredClosedGenericField, Location.None, fieldName, ToDisplayName(message.FullyQualifiedName), ToDisplayName(typeFullName), serializerClassName));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnregisteredClosedGenericField, fieldName, ToDisplayName(message.FullyQualifiedName), ToDisplayName(typeFullName), serializerClassName));
             return;
         }
 
-        context.ReportDiagnostic(mapping.ForeignAssemblyName.Length > 0
-            ? Diagnostic.Create(MissingNestedSerializableDefinitionCrossAssembly, Location.None, fieldName, ToDisplayName(message.FullyQualifiedName), ToDisplayName(typeFullName), mapping.ForeignAssemblyName, serializerClassName)
-            : Diagnostic.Create(MissingNestedSerializableDefinition, Location.None, fieldName, ToDisplayName(message.FullyQualifiedName), ToDisplayName(typeFullName)));
+        diagnostics.Add(mapping.ForeignAssemblyName.Length > 0
+            ? new DiagnosticSpec(DiagnosticKey.MissingNestedSerializableDefinitionCrossAssembly, fieldName, ToDisplayName(message.FullyQualifiedName), ToDisplayName(typeFullName), mapping.ForeignAssemblyName, serializerClassName)
+            : new DiagnosticSpec(DiagnosticKey.MissingNestedSerializableDefinition, fieldName, ToDisplayName(message.FullyQualifiedName), ToDisplayName(typeFullName)));
     }
 
     /// <summary>
@@ -562,7 +676,7 @@ public sealed partial class AkkaSerializerGenerator
     /// registered ONLY for nested-field use (legitimate; it need not implement the protocol) is
     /// exempt as long as it is actually reachable.
     /// </summary>
-    private static bool ValidateClosedGenericProtocolCoverage(SourceProductionContext context, SerializerInfo serializer, ImmutableArray<MessageInfo> reachableMessages)
+    private static bool ValidateClosedGenericProtocolCoverage(SerializerInfo serializer, ImmutableArray<MessageInfo> reachableMessages, ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
         if (serializer.ClosedGenericRegistrations.IsDefaultOrEmpty || serializer.ProtocolTypeFullName.Length == 0)
             return true;
@@ -580,7 +694,7 @@ public sealed partial class AkkaSerializerGenerator
             if (reachableNames.Contains(registration.Message.FullyQualifiedName))
                 continue;
 
-            context.ReportDiagnostic(Diagnostic.Create(ClosedGenericRegistrationNotInProtocol, Location.None,
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ClosedGenericRegistrationNotInProtocol,
                 ToDisplayName(registration.TargetDisplayName), serializer.ClassName, ToDisplayName(serializer.ProtocolTypeFullName)));
             isValid = false;
         }
@@ -590,19 +704,19 @@ public sealed partial class AkkaSerializerGenerator
 
     // Reports AKKASG015 for a union member with no known message. A referenced-assembly member
     // gets the cross-assembly wording; a same-assembly member gets the plain message.
-    private static void ReportUnionMemberNotSerializable(SourceProductionContext context, MessageInfo message, string fieldName, UnionMemberInfo member, string serializerClassName)
+    private static void ReportUnionMemberNotSerializable(MessageInfo message, string fieldName, UnionMemberInfo member, string serializerClassName, ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
-        context.ReportDiagnostic(member.ForeignAssemblyName.Length > 0
-            ? Diagnostic.Create(UnionMemberNotSerializableCrossAssembly, Location.None, ToDisplayName(member.TypeFullName), fieldName, ToDisplayName(message.FullyQualifiedName), member.ForeignAssemblyName, serializerClassName)
-            : Diagnostic.Create(UnionMemberNotSerializable, Location.None, ToDisplayName(member.TypeFullName), fieldName, ToDisplayName(message.FullyQualifiedName)));
+        diagnostics.Add(member.ForeignAssemblyName.Length > 0
+            ? new DiagnosticSpec(DiagnosticKey.UnionMemberNotSerializableCrossAssembly, ToDisplayName(member.TypeFullName), fieldName, ToDisplayName(message.FullyQualifiedName), member.ForeignAssemblyName, serializerClassName)
+            : new DiagnosticSpec(DiagnosticKey.UnionMemberNotSerializable, ToDisplayName(member.TypeFullName), fieldName, ToDisplayName(message.FullyQualifiedName)));
     }
 
     private static bool ValidateUnionField(
-        SourceProductionContext context,
         MessageInfo message,
         FieldInfo field,
         ImmutableDictionary<string, MessageInfo> messagesByType,
-        string serializerClassName)
+        string serializerClassName,
+        ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
         var isValid = true;
 
@@ -614,7 +728,7 @@ public sealed partial class AkkaSerializerGenerator
                      .GroupBy(member => member.TypeFullName, StringComparer.Ordinal)
                      .Where(group => group.Count() > 1))
         {
-            context.ReportDiagnostic(Diagnostic.Create(InvalidUnionMemberSet, Location.None, field.Name, ToDisplayName(message.FullyQualifiedName), $"member type '{ToDisplayName(duplicate.Key)}' is declared more than once"));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidUnionMemberSet, field.Name, ToDisplayName(message.FullyQualifiedName), $"member type '{ToDisplayName(duplicate.Key)}' is declared more than once"));
             isValid = false;
         }
 
@@ -623,14 +737,14 @@ public sealed partial class AkkaSerializerGenerator
         {
             if (!member.IsSupported || !messagesByType.TryGetValue(member.TypeFullName, out var memberMessage))
             {
-                ReportUnionMemberNotSerializable(context, message, field.Name, member, serializerClassName);
+                ReportUnionMemberNotSerializable(message, field.Name, member, serializerClassName, diagnostics);
                 isValid = false;
                 continue;
             }
 
             if (!member.IsAssignable)
             {
-                context.ReportDiagnostic(Diagnostic.Create(UnionMemberNotAssignable, Location.None, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.TypeFullName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberNotAssignable, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.TypeFullName)));
                 isValid = false;
             }
 
@@ -642,13 +756,13 @@ public sealed partial class AkkaSerializerGenerator
             // An abstract member fires AKKASG036 ONLY: it is definitionally unsealed, and stacking
             // the weaker AKKASG025 on top of it would be noise.
             if (member.IsAbstract)
-                context.ReportDiagnostic(Diagnostic.Create(UnionMemberAbstract, Location.None, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberAbstract, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName)));
             else if (!member.IsSealed)
-                context.ReportDiagnostic(Diagnostic.Create(UnionMemberNotSealed, Location.None, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberNotSealed, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName)));
 
             if (string.IsNullOrWhiteSpace(memberMessage.Manifest))
             {
-                context.ReportDiagnostic(Diagnostic.Create(UnionMemberMissingManifest, Location.None, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberMissingManifest, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName)));
                 isValid = false;
                 continue;
             }
@@ -664,7 +778,7 @@ public sealed partial class AkkaSerializerGenerator
 
         foreach (var collision in manifests.Where(pair => pair.Value.Distinct(StringComparer.Ordinal).Count() > 1))
         {
-            context.ReportDiagnostic(Diagnostic.Create(UnionMemberManifestCollision, Location.None, field.Name, ToDisplayName(message.FullyQualifiedName), collision.Key, string.Join(", ", collision.Value.Select(ToDisplayName))));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberManifestCollision, field.Name, ToDisplayName(message.FullyQualifiedName), collision.Key, string.Join(", ", collision.Value.Select(ToDisplayName))));
             isValid = false;
         }
 
@@ -677,7 +791,7 @@ public sealed partial class AkkaSerializerGenerator
     /// dictionary keys, equality/grouping comparisons, and text appended into emitted source --
     /// keeps the raw <c>global::</c>-qualified form produced by <see cref="GetFullyQualifiedTypeName"/>
     /// and <see cref="SymbolDisplayFormat.FullyQualifiedFormat"/>; this helper must be applied only
-    /// to the arguments passed to <c>Diagnostic.Create(...)</c> at each reporting call site.
+    /// to the arguments carried by a <see cref="DiagnosticSpec"/> at each call site above.
     /// </summary>
     private static string ToDisplayName(string fullyQualifiedName)
     {

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorValidatorSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorValidatorSpec.cs
@@ -1,0 +1,369 @@
+//-----------------------------------------------------------------------
+// <copyright file="GeneratorValidatorSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using Akka.Serialization.V2.Generators;
+using Akka.Serialization.V2.Tests.Harness;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// Exercises the generator's PURE validation entry points -- <see cref="AkkaSerializerGenerator.EvaluateGate"/>,
+/// <see cref="AkkaSerializerGenerator.Validate"/>, and <see cref="AkkaSerializerGenerator.ValidateProtocolCoverage"/>
+/// -- directly on models, with no <see cref="SourceProductionContext"/>, driver, or generator run at
+/// all. Message models come from <see cref="AkkaSerializerGenerator.ParseMessageForTests"/> (the same
+/// test-only extraction entry point <see cref="GeneratorMessageModelSnapshotSpec"/> uses) against a
+/// <see cref="Compilation"/> built by <see cref="GeneratorTestHarness"/>; <see cref="AkkaSerializerGenerator.SerializerInfo"/>
+/// values are hand-built (there is no test-only serializer-extraction entry point, and none of these
+/// scenarios need a real <c>[AkkaSerializer]</c> declaration). Every assertion below is on the
+/// returned <see cref="AkkaSerializerGenerator.DiagnosticSpec"/> values themselves -- key and message
+/// arguments -- never on rendered message text, which the driver-based
+/// <see cref="AkkaSerializerGeneratorDiagnosticsSpec"/> already covers end to end.
+/// </summary>
+public sealed class GeneratorValidatorSpec
+{
+    private const string ProtocolMetadataName = "ValidatorSample.IProtocol";
+
+    [Fact(DisplayName = "Validate should report no diagnostics for a well-formed top-level message")]
+    public void Validate_should_report_no_diagnostics_for_a_valid_pair()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Serialization.V2;
+
+            namespace ValidatorSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializable(Manifest = "outer-v1")]
+            public sealed record Outer([property: AkkaField(1)] string Value) : IProtocol;
+            """;
+
+        var compilation = Compile(source);
+        var serializer = BuildSerializerInfo(ProtocolFullName(compilation));
+        var outer = ParseMessage(compilation, "ValidatorSample.Outer");
+
+        var diagnostics = AkkaSerializerGenerator.Validate(serializer, ImmutableArray.Create(outer));
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Validate should report AKKASG005 when two fields of a message share an index")]
+    public void Validate_should_report_AKKASG005_when_fields_share_index()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Serialization.V2;
+
+            namespace ValidatorSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializable(Manifest = "dup-index-v1")]
+            public sealed record DupIndex([property: AkkaField(1)] string A, [property: AkkaField(1)] string B) : IProtocol;
+            """;
+
+        var compilation = Compile(source);
+        var serializer = BuildSerializerInfo(ProtocolFullName(compilation));
+        var dupIndex = ParseMessage(compilation, "ValidatorSample.DupIndex");
+
+        var diagnostics = AkkaSerializerGenerator.Validate(serializer, ImmutableArray.Create(dupIndex));
+
+        diagnostics.Should().Contain(new AkkaSerializerGenerator.DiagnosticSpec(
+            AkkaSerializerGenerator.DiagnosticKey.DuplicateFieldIndex, "ValidatorSample.DupIndex", "1"));
+    }
+
+    [Fact(DisplayName = "Validate should report AKKASG006 when a top-level message has no manifest")]
+    public void Validate_should_report_AKKASG006_when_manifest_missing()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Serialization.V2;
+
+            namespace ValidatorSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializable]
+            public sealed record NoManifest([property: AkkaField(1)] string Value) : IProtocol;
+            """;
+
+        var compilation = Compile(source);
+        var serializer = BuildSerializerInfo(ProtocolFullName(compilation));
+        var noManifest = ParseMessage(compilation, "ValidatorSample.NoManifest");
+
+        var diagnostics = AkkaSerializerGenerator.Validate(serializer, ImmutableArray.Create(noManifest));
+
+        diagnostics.Should().Contain(new AkkaSerializerGenerator.DiagnosticSpec(
+            AkkaSerializerGenerator.DiagnosticKey.MissingManifest, "ValidatorSample.NoManifest"));
+    }
+
+    [Fact(DisplayName = "Validate should report AKKASG012 when two top-level messages of the same serializer duplicate a manifest")]
+    public void Validate_should_report_AKKASG012_when_manifests_duplicate()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Serialization.V2;
+
+            namespace ValidatorSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializable(Manifest = "shared-v1")]
+            public sealed record MessageA([property: AkkaField(1)] string Value) : IProtocol;
+
+            [AkkaSerializable(Manifest = "shared-v1")]
+            public sealed record MessageB([property: AkkaField(1)] string Value) : IProtocol;
+            """;
+
+        var compilation = Compile(source);
+        var serializer = BuildSerializerInfo(ProtocolFullName(compilation));
+        var messageA = ParseMessage(compilation, "ValidatorSample.MessageA");
+        var messageB = ParseMessage(compilation, "ValidatorSample.MessageB");
+
+        var diagnostics = AkkaSerializerGenerator.Validate(serializer, ImmutableArray.Create(messageA, messageB));
+
+        diagnostics.Should().Contain(new AkkaSerializerGenerator.DiagnosticSpec(
+            AkkaSerializerGenerator.DiagnosticKey.DuplicateManifest,
+            "TestSerializer", "shared-v1", "ValidatorSample.MessageA, ValidatorSample.MessageB"));
+    }
+
+    [Fact(DisplayName = "Validate should report AKKASG015 when a union member is not serializable")]
+    public void Validate_should_report_AKKASG015_when_union_member_not_serializable()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Serialization.V2;
+
+            namespace ValidatorSample;
+
+            public interface IProtocol
+            {
+            }
+
+            public interface IEvent
+            {
+            }
+
+            public sealed record NotSerializable(string Value) : IEvent;
+
+            [AkkaSerializable(Manifest = "outer-v1")]
+            public sealed record Outer(
+                [property: AkkaField(1), AkkaUnion(typeof(NotSerializable))] IEvent Event) : IProtocol;
+            """;
+
+        var compilation = Compile(source);
+        var serializer = BuildSerializerInfo(ProtocolFullName(compilation));
+        var outer = ParseMessage(compilation, "ValidatorSample.Outer");
+
+        var diagnostics = AkkaSerializerGenerator.Validate(serializer, ImmutableArray.Create(outer));
+
+        diagnostics.Should().Contain(new AkkaSerializerGenerator.DiagnosticSpec(
+            AkkaSerializerGenerator.DiagnosticKey.UnionMemberNotSerializable,
+            "ValidatorSample.NotSerializable", "Event", "ValidatorSample.Outer"));
+    }
+
+    [Fact(DisplayName = "Validate should report AKKASG023 when a closed generic field type is not registered")]
+    public void Validate_should_report_AKKASG023_when_closed_generic_field_not_registered()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Serialization.V2;
+
+            namespace ValidatorSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializable]
+            public sealed record Wrapper<T>(
+                [property: AkkaField(1)] string Id,
+                [property: AkkaField(2)] T Payload);
+
+            [AkkaSerializable]
+            public sealed record Payload([property: AkkaField(1)] string Value);
+
+            [AkkaSerializable(Manifest = "outer-v1")]
+            public sealed record Outer(
+                [property: AkkaField(1)] Wrapper<Payload> Inner) : IProtocol;
+            """;
+
+        var compilation = Compile(source);
+        var serializer = BuildSerializerInfo(ProtocolFullName(compilation));
+
+        // Deliberately NOT including Wrapper<T>'s or Payload's models: the pipeline never needs
+        // Wrapper<Payload> to be separately extracted to notice it is unregistered -- Outer's own
+        // field mapping already carries IsGenericConstruction=true (from Wrapper<T>'s own
+        // [AkkaSerializable]) purely from extracting Outer.
+        var outer = ParseMessage(compilation, "ValidatorSample.Outer");
+
+        var diagnostics = AkkaSerializerGenerator.Validate(serializer, ImmutableArray.Create(outer));
+
+        diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Key == AkkaSerializerGenerator.DiagnosticKey.UnregisteredClosedGenericField &&
+            diagnostic.MessageArgs[0] == "Inner" &&
+            diagnostic.MessageArgs[1] == "ValidatorSample.Outer" &&
+            diagnostic.MessageArgs[3] == "TestSerializer");
+    }
+
+    [Fact(DisplayName = "Validate should report AKKASG034 when a closed generic registration is orphaned")]
+    public void Validate_should_report_AKKASG034_when_registration_is_orphaned()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Serialization.V2;
+
+            namespace ValidatorSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializable(Manifest = "outer-v1")]
+            public sealed record Outer([property: AkkaField(1)] string Value) : IProtocol;
+            """;
+
+        var compilation = Compile(source);
+
+        // Hand-built rather than parsed: AkkaSerializerGenerator.ParseMessageForTests treats ANY
+        // generic symbol (INamedTypeSymbol.IsGenericType is true for a CLOSED construction too, not
+        // only an open definition) as a generic-definition placeholder, so it cannot produce a real
+        // closed-construction model like this one -- exactly the shape ExtractClosedGenericRegistrations
+        // builds via the (non-test-exposed) ExtractMessageCore in the real pipeline. Building it by
+        // hand is simpler and more direct than constructing the Wrapper<int> symbol through Roslyn.
+        var wrapperInt = new AkkaSerializerGenerator.MessageInfo(
+            simpleName: "Wrapper",
+            fullyQualifiedName: "global::ValidatorSample.Wrapper<int>",
+            manifest: "wrapper-int-v1",
+            fields: ImmutableArray.Create(
+                new AkkaSerializerGenerator.FieldInfo(1, "Id", "string", new AkkaSerializerGenerator.TypeMapping(AkkaSerializerGenerator.FieldKind.String), isNullable: false),
+                new AkkaSerializerGenerator.FieldInfo(2, "Payload", "int", new AkkaSerializerGenerator.TypeMapping(AkkaSerializerGenerator.FieldKind.Int32), isNullable: false)),
+            protocols: ImmutableArray<string>.Empty, // does not implement IProtocol
+            allowEmpty: false,
+            invalidFields: ImmutableArray<AkkaSerializerGenerator.InvalidFieldInfo>.Empty,
+            constructionPlan: AkkaSerializerGenerator.ConstructionPlan.Empty,
+            isGenericDefinition: false,
+            definitionFullName: "global::ValidatorSample.Wrapper<T>");
+
+        var registration = new AkkaSerializerGenerator.ClosedGenericRegistrationInfo("global::ValidatorSample.Wrapper<int>", wrapperInt);
+        var serializer = BuildSerializerInfo(ProtocolFullName(compilation), closedGenericRegistrations: ImmutableArray.Create(registration));
+
+        // Outer neither references Wrapper<int> nor is related to it -- the registration is
+        // reachable from nothing, which is exactly the "orphaned" condition AKKASG034 flags.
+        var outer = ParseMessage(compilation, "ValidatorSample.Outer");
+
+        var diagnostics = AkkaSerializerGenerator.Validate(serializer, ImmutableArray.Create(outer));
+
+        diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Key == AkkaSerializerGenerator.DiagnosticKey.ClosedGenericRegistrationNotInProtocol &&
+            diagnostic.MessageArgs[0] == "ValidatorSample.Wrapper<int>" &&
+            diagnostic.MessageArgs[1] == "TestSerializer");
+    }
+
+    [Fact(DisplayName = "ValidateProtocolCoverage should report AKKASG029 when a protocol message forgets [AkkaSerializable]")]
+    public void ValidateProtocolCoverage_should_report_AKKASG029_for_unmarked_protocol_message()
+    {
+        const string source = """
+            #nullable enable
+            namespace ValidatorSample;
+
+            public interface IProtocol
+            {
+            }
+
+            public sealed record Unmarked(string Value) : IProtocol;
+            """;
+
+        var compilation = Compile(source);
+        var serializer = BuildSerializerInfo(ProtocolFullName(compilation));
+
+        var diagnostics = AkkaSerializerGenerator.ValidateProtocolCoverage(serializer, compilation, CancellationToken.None);
+
+        diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Key == AkkaSerializerGenerator.DiagnosticKey.ProtocolMessageNotSerializable &&
+            diagnostic.MessageArgs[0] == "ValidatorSample.Unmarked" &&
+            diagnostic.MessageArgs[1] == "ValidatorSample.IProtocol" &&
+            diagnostic.MessageArgs[2] == "TestSerializer");
+    }
+
+    [Fact(DisplayName = "EvaluateGate should report AKKASG032 and gate out a non-partial serializer before any message validation runs")]
+    public void EvaluateGate_should_report_AKKASG032_for_non_partial_serializer()
+    {
+        var serializer = BuildSerializerInfo(protocolTypeFullName: string.Empty, isPartial: false);
+
+        var gate = AkkaSerializerGenerator.EvaluateGate(
+            serializer,
+            ImmutableDictionary<int, string>.Empty,
+            ImmutableDictionary<string, string>.Empty,
+            ImmutableArray<AkkaSerializerGenerator.MessageInfo>.Empty);
+
+        gate.IsEmittable.Should().BeFalse();
+        gate.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Key == AkkaSerializerGenerator.DiagnosticKey.InvalidSerializerShape &&
+            diagnostic.MessageArgs[0] == "TestSerializer");
+    }
+
+    private static Compilation Compile(string source)
+    {
+        return GeneratorTestHarness.Run(source).OutputCompilation;
+    }
+
+    private static string ProtocolFullName(Compilation compilation)
+    {
+        var symbol = compilation.GetTypeByMetadataName(ProtocolMetadataName)
+            ?? throw new InvalidOperationException($"Could not resolve '{ProtocolMetadataName}' in the harness compilation.");
+        return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+    }
+
+    private static AkkaSerializerGenerator.MessageInfo ParseMessage(Compilation compilation, string metadataName)
+    {
+        var symbol = compilation.GetTypeByMetadataName(metadataName)
+            ?? throw new InvalidOperationException($"Could not resolve '{metadataName}' in the harness compilation.");
+        return AkkaSerializerGenerator.ParseMessageForTests(symbol, compilation)
+            ?? throw new InvalidOperationException($"'{metadataName}' was not recognized as [AkkaSerializable].");
+    }
+
+    private static AkkaSerializerGenerator.SerializerInfo BuildSerializerInfo(
+        string protocolTypeFullName,
+        bool protocolTypeIsInterface = true,
+        ImmutableArray<AkkaSerializerGenerator.ClosedGenericRegistrationInfo> closedGenericRegistrations = default,
+        ImmutableArray<AkkaSerializerGenerator.FormatterInfo> formatters = default,
+        bool isPartial = true,
+        bool isGeneric = false,
+        bool derivesFromAkkaSerializerBase = true)
+    {
+        return new AkkaSerializerGenerator.SerializerInfo(
+            ns: "ValidatorSample",
+            className: "TestSerializer",
+            fullyQualifiedName: "global::ValidatorSample.TestSerializer",
+            name: "test-serializer",
+            serializerId: 1,
+            protocolTypeFullName: protocolTypeFullName,
+            protocolTypeIsInterface: protocolTypeIsInterface,
+            declaredAccessibility: Accessibility.Public,
+            formatters: formatters.IsDefault ? ImmutableArray<AkkaSerializerGenerator.FormatterInfo>.Empty : formatters,
+            closedGenericRegistrations: closedGenericRegistrations.IsDefault ? ImmutableArray<AkkaSerializerGenerator.ClosedGenericRegistrationInfo>.Empty : closedGenericRegistrations,
+            isPartial: isPartial,
+            isGeneric: isGeneric,
+            derivesFromAkkaSerializerBase: derivesFromAkkaSerializerBase);
+    }
+}


### PR DESCRIPTION
## Summary

Part of #8384. Step S2 of the generator architecture pass. Stacked on #8521 (S1); this PR's base is that branch, and its diff is one commit. No behavior change: the set of diagnostics reported for any input is identical, emitted output is byte-identical, and `GoldenOutput/` and `WireSnapshots/` are untouched.

## What changes

- **Validation returns diagnostics instead of reporting them.** Every `Validate*` and `Report*` helper appends a value-equatable `DiagnosticSpec` to a builder. A `DiagnosticSpec` carries a `DiagnosticKey`, one enum member per descriptor field, and the message arguments. The key, not the public id, disambiguates the three ids that have two descriptor variants (AKKASG003 plain and polymorphic-hint; AKKASG007 and AKKASG015 same-assembly and cross-assembly). A private `DiagnosticRegistry` is the single place a key becomes a descriptor and a spec becomes a `Diagnostic`, still at `Location.None` until S6.
- **One gate ladder.** `EvaluateGate` returns whether a serializer is emittable plus its gate diagnostics. Both the emission callback and the protocol-coverage output call it; the silent duplicate ladder in `ReportProtocolCoverage` is deleted.
- **The emission callback is now: gate, resolve, validate, report, emit.** It emits only when no error-severity diagnostic was produced, which is exactly the rule the old `isValid` chain implemented; warnings and infos still allow emission.
- **Entry points for tests.** `Validate(SerializerInfo, ImmutableArray<MessageInfo>)` and `EvaluateGate(...)` run on models with no generator driver. `GeneratorValidatorSpec` adds nine facts that assert on keys and arguments, not message substrings, covering a valid pair, AKKASG005, 006, 012, 015, 023, 029, 032, and 034.

The pipeline wiring in `AkkaSerializerGenerator.cs` is untouched, and the four tracked stages are unchanged. `GeneratorIncrementalScenariosSpec` and `GeneratorIncrementalCachingSpec` pass with their original pins.

## Testing

`dotnet test src/core/Akka.Serialization.V2.Tests -c Release`: 287 passed (278 from S1 plus 9). Generator builds with warnings as errors. `Akka.Remote` builds.

## Benchmark

The numbers below were measured while other agents were running multi-node test loops on the same machine, so they are not comparable to S1's baseline yet. They will be re-measured on a quiet machine and posted as a comment before this PR is considered for merge. Nothing in this PR touches a cached pipeline input; the change is confined to the bodies of the two `RegisterSourceOutput` callbacks.

| Method | Mean | Allocated |
|---|---:|---:|
| Fresh driver, full corpus | 154.0 ms | 23.2 MB |
| Warm driver, one field renamed | 142.7 ms | 23.2 MB |
| Warm driver, comment edit | 72.8 ms | 7.8 MB |
| Warm driver, unrelated file edited | 66.2 ms | 7.8 MB |

## Stack

Base: `feature/serialization-v2-generator-harness` (#8521). When #8521 merges, this PR is rebased onto `dev` and retargeted.
