### PR TITLE
Cache one resolved model per serializer so one message edit regenerates one file (S3)

### DIFF
--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Emission.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Emission.cs
@@ -25,10 +25,11 @@ namespace Akka.Serialization.V2.Generators;
 /// which of those are top-level (dispatched directly by this serializer's Manifest/Serialize/
 /// Deserialize switches), and which are reachable from a top-level message (and therefore need
 /// generated Write/Read/SizeOf methods at all). Computed once per gate-passing serializer and shared
-/// between validation (<see cref="AkkaSerializerGenerator.Validate"/>) and emission
-/// (<see cref="AkkaSerializerGenerator.EmitSerializers"/>) so the two never see a different message
-/// table for the same input. Not a cached pipeline model -- like <see cref="SerializerGate"/>, it
-/// lives at namespace scope instead of nested under <see cref="AkkaSerializerGenerator"/>.
+/// between validation (<see cref="AkkaSerializerGenerator.Validate"/>) and the cached
+/// <see cref="AkkaSerializerGenerator.ResolvedSerializer"/> model (<see cref="AkkaSerializerGenerator.ResolveSerializer"/>)
+/// so the two never see a different message table for the same input. Not itself a cached pipeline
+/// model -- like <see cref="SerializerGate"/>, it lives at namespace scope instead of nested under
+/// <see cref="AkkaSerializerGenerator"/>.
 /// </summary>
 internal readonly struct ResolvedSerializerMessages
 {
@@ -49,7 +50,46 @@ internal readonly struct ResolvedSerializerMessages
 
 public sealed partial class AkkaSerializerGenerator
 {
-    private static void EmitSerializers(
+    /// <summary>
+    /// Every non-null message model, cast down from the raw collected array. Shared by
+    /// <see cref="ReportCrossSerializerDiagnostics"/>, <see cref="ReportProtocolCoverage"/>, and the
+    /// per-serializer <see cref="ResolveSerializer"/> step so the three never risk computing this
+    /// projection differently.
+    /// </summary>
+    private static ImmutableArray<MessageInfo> ComputeDeclaredMessages(ImmutableArray<MessageInfo?> messages)
+    {
+        return messages
+            .Where(message => message != null)
+            .Cast<MessageInfo>()
+            .ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Generic definitions are placeholders: never serialized, never top-level, never in the
+    /// message dictionary (their arity-less key could even collide with a same-named non-generic
+    /// type). They exist only for the AKKASG022/AKKASG037 checks.
+    /// </summary>
+    private static ImmutableArray<MessageInfo> ComputeGenericDefinitions(ImmutableArray<MessageInfo> declaredMessages)
+    {
+        return declaredMessages
+            .Where(message => message.IsGenericDefinition)
+            .ToImmutableArray();
+    }
+
+    /// <summary>
+    /// The cross-serializer diagnostics that cannot be attached to any one serializer's
+    /// <see cref="ResolvedSerializer"/> without either duplicating them (one copy per serializer) or
+    /// picking an arbitrary "owner" serializer to carry them: AKKASG013 (duplicate serializer id),
+    /// AKKASG031 (duplicate protocol binding), and AKKASG037 (Manifest ignored on a generic
+    /// definition, which is not even serializer-scoped). Registered as its own
+    /// <c>RegisterSourceOutput</c> over the collected serializers and messages, separate from
+    /// <see cref="ResolveSerializer"/>'s per-serializer output, so each of these is reported EXACTLY
+    /// ONCE regardless of how many serializers are declared -- the per-serializer output would
+    /// otherwise need to single out one serializer as the "owner" to avoid reporting a duplicate-id
+    /// pair once per serializer in the group. This mirrors the diagnostics-only shape
+    /// <see cref="ReportProtocolCoverage"/> already used for AKKASG029.
+    /// </summary>
+    private static void ReportCrossSerializerDiagnostics(
         SourceProductionContext context,
         ImmutableArray<SerializerInfo?> serializers,
         ImmutableArray<MessageInfo?> messages)
@@ -71,10 +111,7 @@ public sealed partial class AkkaSerializerGenerator
             context.ReportDiagnostic(Diagnostic.Create(DuplicateProtocolBinding, Location.None, ToDisplayName(duplicate.Key), duplicate.Value));
         }
 
-        var declaredMessages = messages
-            .Where(message => message != null)
-            .Cast<MessageInfo>()
-            .ToImmutableArray();
+        var declaredMessages = ComputeDeclaredMessages(messages);
 
         // Advisory only (AKKASG037): a Manifest on a generic [AkkaSerializable] DEFINITION is
         // silently ignored -- the definition is never serialized directly (see ExtractMessage),
@@ -84,52 +121,124 @@ public sealed partial class AkkaSerializerGenerator
         {
             context.ReportDiagnostic(Diagnostic.Create(ManifestIgnoredOnGenericDefinition, Location.None, ToDisplayName(definition.FullyQualifiedName), definition.Manifest));
         }
+    }
 
-        // Generic definitions are placeholders: never serialized, never top-level, never in
-        // the message dictionary (their arity-less key could even collide with a same-named
-        // non-generic type). They exist only for the AKKASG022/AKKASG037 checks.
-        var genericDefinitions = declaredMessages
-            .Where(message => message.IsGenericDefinition)
-            .ToImmutableArray();
+    /// <summary>
+    /// Resolves ONE serializer -- gate, message table, closed dispatch sets, union plan, and
+    /// validation diagnostics -- into the cached, value-equatable <see cref="ResolvedSerializer"/>
+    /// model. This is the per-serializer <c>Select</c> node of the pipeline
+    /// (<see cref="TrackingNames.ResolvedSerializers"/> in <see cref="Initialize"/>): its input is
+    /// this ONE serializer plus the FULL collected messages array (a message can only be judged
+    /// top-level/reachable/duplicate against every other message), so an edit to any message still
+    /// recomputes every serializer's resolve step -- but the resulting <see cref="ResolvedSerializer"/>
+    /// for a serializer that does not own the edited message compares EQUAL to its previous run,
+    /// which is what lets <see cref="EmitResolvedSerializer"/>'s <c>RegisterSourceOutput</c> skip
+    /// re-emitting that serializer's file. <paramref name="duplicateSerializerIds"/>,
+    /// <paramref name="duplicateProtocolBindings"/>, and <paramref name="genericDefinitions"/> are
+    /// precomputed by the caller from the same collected arrays every other serializer's resolve
+    /// step also sees, exactly as <see cref="ReportCrossSerializerDiagnostics"/> and
+    /// <see cref="ReportProtocolCoverage"/> independently recompute them from the same source --
+    /// see <see cref="EvaluateGate"/>'s doc comment.
+    /// </summary>
+    private static ResolvedSerializer ResolveSerializer(
+        SerializerInfo serializer,
+        ImmutableArray<MessageInfo> declaredMessages,
+        ImmutableDictionary<int, string> duplicateSerializerIds,
+        ImmutableDictionary<string, string> duplicateProtocolBindings,
+        ImmutableArray<MessageInfo> genericDefinitions)
+    {
+        var gate = EvaluateGate(serializer, duplicateSerializerIds, duplicateProtocolBindings, genericDefinitions);
+        if (!gate.IsEmittable)
+            return ResolvedSerializer.NotEmittable(serializer, gate.Diagnostics);
 
-        foreach (var serializer in serializers)
-        {
-            if (serializer == null)
-                continue;
+        var resolved = ResolveSerializerMessages(serializer, declaredMessages);
+        var validationDiagnostics = ImmutableArray.CreateBuilder<DiagnosticSpec>();
+        ValidateResolved(serializer, resolved, validationDiagnostics);
 
-            // One gate ladder, shared with ReportProtocolCoverage below: is this serializer's own
-            // declaration usable as a codegen target at all? See EvaluateGate's doc comment in
-            // AkkaSerializerGenerator.Validation.cs.
-            var gate = EvaluateGate(serializer, duplicateSerializerIds, duplicateProtocolBindings, genericDefinitions);
-            foreach (var gateDiagnostic in gate.Diagnostics)
-                context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(gateDiagnostic));
+        var topLevelMessages = BuildClosedSet(resolved.TopLevelMessages);
+        var usedFormatters = CollectUsedFormatters(resolved.ReachableMessages);
 
-            if (!gate.IsEmittable)
-                continue;
+        // PlanUnionHelpers and ResolveClosedGenericRegistrations both look up against
+        // resolved.ResolvedMessagesByType -- the FULL, whole-compilation dictionary
+        // ResolveSerializerMessages builds from declaredMessages, exactly as validation already
+        // does (see ValidateResolved). That full dictionary must NOT become the model's OWN stored
+        // ResolvedMessagesByType, though: it carries every OTHER serializer's messages too, so a
+        // serializer that adopts none of them would still see this model change shape whenever any
+        // of them do -- exactly the cross-serializer poisoning ResolvedSerializer.Equals must avoid
+        // (see BuildResolvedMessageTable's doc comment).
+        var unionPlan = PlanUnionHelpers(resolved.ReachableMessages, resolved.ResolvedMessagesByType);
+        var resolvedClosedGenericRegistrations = ResolveClosedGenericRegistrations(serializer.ClosedGenericRegistrations, resolved.ResolvedMessagesByType);
+        var resolvedMessagesByType = BuildResolvedMessageTable(resolved.ReachableMessages);
 
-            var resolved = ResolveSerializerMessages(serializer, declaredMessages);
-            var validationDiagnostics = ImmutableArray.CreateBuilder<DiagnosticSpec>();
-            ValidateResolved(serializer, resolved, validationDiagnostics);
+        return ResolvedSerializer.Emittable(
+            serializer,
+            gate.Diagnostics,
+            resolvedMessagesByType,
+            topLevelMessages,
+            resolved.ReachableMessages,
+            resolvedClosedGenericRegistrations,
+            usedFormatters,
+            unionPlan,
+            validationDiagnostics.ToImmutable());
+    }
 
-            var reportable = validationDiagnostics.ToImmutable();
-            foreach (var diagnostic in reportable)
-                context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(diagnostic));
+    /// <summary>
+    /// The message table actually STORED on <see cref="ResolvedSerializer.ResolvedMessagesByType"/>:
+    /// only this serializer's own reachable messages, keyed by type name -- deliberately narrower
+    /// than the full, whole-compilation dictionary <see cref="ResolveSerializerMessages"/> builds
+    /// (and validation still uses, unchanged) internally. A serializer's cached
+    /// <see cref="ResolvedSerializer"/> must depend only on what actually shapes ITS OWN output; the
+    /// full dictionary includes every other serializer's messages too, so storing it verbatim would
+    /// make an untouched serializer's resolved model compare UNEQUAL whenever some unrelated
+    /// serializer's message changed -- defeating the per-serializer caching this stage exists for.
+    /// Every top-level message is already a member of <paramref name="reachableMessages"/> (see
+    /// <see cref="CollectReachableMessages"/>, which seeds its walk from the top-level set), so
+    /// nothing is lost by keying only off it.
+    /// </summary>
+    private static ImmutableDictionary<string, MessageInfo> BuildResolvedMessageTable(ImmutableArray<MessageInfo> reachableMessages)
+    {
+        var builder = ImmutableDictionary.CreateBuilder<string, MessageInfo>(StringComparer.Ordinal);
+        foreach (var message in reachableMessages)
+            builder[message.FullyQualifiedName] = message;
 
-            // Emission is suppressed by an ERROR-severity diagnostic only -- a Warning (e.g.
-            // AKKASG027) or Info (e.g. AKKASG025) still lets the serializer generate normally, exactly
-            // as the old isValid-returning Validate* chain already behaved (see ValidateResolved).
-            if (reportable.Any(diagnostic => DiagnosticRegistry.Resolve(diagnostic.Key).DefaultSeverity == DiagnosticSeverity.Error))
-                continue;
+        return builder.ToImmutable();
+    }
 
-            context.AddSource(serializer.ClassName + ".AkkaSerialization.g.cs", Generate(serializer, resolved.TopLevelMessages, resolved.ReachableMessages, resolved.ResolvedMessagesByType));
-        }
+    /// <summary>
+    /// Reports a resolved serializer's own diagnostics (gate, then validation -- the same order
+    /// <see cref="ResolveSerializer"/>'s predecessor, the single-output <c>EmitSerializers</c>, used
+    /// to report them in) and emits its generated source, PURELY over the resolved model -- no
+    /// <see cref="Compilation"/>, no other serializer's data. Registered directly on the
+    /// <see cref="TrackingNames.ResolvedSerializers"/> values provider in <see cref="Initialize"/>,
+    /// so the driver's own per-element caching (not any code here) is what makes an unrelated
+    /// serializer's <c>AddSource</c> call Cached instead of re-running: this callback simply never
+    /// executes for an element whose resolved model still compares equal to last time.
+    /// </summary>
+    private static void EmitResolvedSerializer(SourceProductionContext context, ResolvedSerializer resolved)
+    {
+        foreach (var gateDiagnostic in resolved.GateDiagnostics)
+            context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(gateDiagnostic));
+
+        if (!resolved.IsEmittable)
+            return;
+
+        foreach (var diagnostic in resolved.ValidationDiagnostics)
+            context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(diagnostic));
+
+        // Emission is suppressed by an ERROR-severity diagnostic only -- a Warning (e.g. AKKASG027)
+        // or Info (e.g. AKKASG025) still lets the serializer generate normally, exactly as the old
+        // isValid-returning Validate* chain already behaved (see ValidateResolved).
+        if (resolved.ValidationDiagnostics.Any(diagnostic => DiagnosticRegistry.Resolve(diagnostic.Key).DefaultSeverity == DiagnosticSeverity.Error))
+            return;
+
+        context.AddSource(resolved.Serializer.ClassName + ".AkkaSerialization.g.cs", Generate(resolved));
     }
 
     /// <summary>
     /// Resolves one serializer's message table -- formatter substitution, top-level selection,
     /// reachability -- into the shape both validation (<see cref="ValidateResolved"/>/<see cref="Validate"/>)
     /// and code generation (<see cref="Generate"/>) need. Extracted so the two never risk seeing a
-    /// different table for the same input: <see cref="EmitSerializers"/> computes it once per
+    /// different table for the same input: <see cref="ResolveSerializer"/> computes it once per
     /// gate-passing serializer and passes the SAME <see cref="ResolvedSerializerMessages"/> to both.
     /// </summary>
     private static ResolvedSerializerMessages ResolveSerializerMessages(SerializerInfo serializer, ImmutableArray<MessageInfo> declaredMessages)
@@ -190,9 +299,16 @@ public sealed partial class AkkaSerializerGenerator
         return builder.ToImmutable();
     }
 
-    private static string Generate(SerializerInfo serializer, ImmutableArray<MessageInfo> topLevelMessages, ImmutableArray<MessageInfo> reachableMessages, ImmutableDictionary<string, MessageInfo> messagesByType)
+    /// <summary>
+    /// Renders one serializer's generated source PURELY from its <see cref="ResolvedSerializer"/> --
+    /// no <see cref="Compilation"/>, no other serializer's data, and (since <see cref="ResolvedSerializer.UsedFormatters"/>
+    /// and <see cref="ResolvedSerializer.UnionPlan"/> are already resolved) no re-derivation of
+    /// anything <see cref="ResolveSerializer"/> already computed once.
+    /// </summary>
+    private static string Generate(ResolvedSerializer resolved)
     {
-        var usedFormatters = CollectUsedFormatters(reachableMessages);
+        var serializer = resolved.Serializer;
+        var usedFormatters = resolved.UsedFormatters;
 
         var sb = new StringBuilder();
         var w = new CodeWriter(sb);
@@ -230,25 +346,77 @@ public sealed partial class AkkaSerializerGenerator
             w.Raw("public override int Identifier => ").Number(serializer.SerializerId).Line(";");
             w.BlankLine();
             GenerateRegistration(w, serializer);
-            GenerateManifest(w, topLevelMessages);
+            GenerateManifest(w, resolved.TopLevelMessages);
             GenerateSerialize(w);
-            GenerateSerializeDirect(w, topLevelMessages);
-            GenerateDeserialize(w, topLevelMessages);
-            GenerateSizeHint(w, topLevelMessages);
+            GenerateSerializeDirect(w, resolved.TopLevelMessages);
+            GenerateDeserialize(w, resolved.TopLevelMessages);
+            GenerateSizeHint(w, resolved.TopLevelMessages);
             GenerateCountingBufferWriter(w);
 
-            var unionHelpers = PlanUnionHelpers(reachableMessages);
-            foreach (var message in reachableMessages)
+            // The union plan was already resolved to (signature -> helper name) once, in
+            // ResolveSerializer; this dictionary is just that view, rebuilt here for the per-field
+            // Write/Read/SizeOf call sites below (GenerateSizeField et al.) that look a helper up by
+            // BuildUnionSignature(field) rather than iterating the plan.
+            var unionHelpers = resolved.UnionPlan.Helpers.ToImmutableDictionary(helper => helper.Signature, helper => helper.HelperName, StringComparer.Ordinal);
+            foreach (var message in resolved.ReachableMessages)
             {
                 GenerateSizeMessage(w, message, unionHelpers);
                 GenerateWriteMessage(w, message, unionHelpers);
                 GenerateReadMessage(w, message, unionHelpers);
             }
 
-            GenerateUnionHelpers(w, unionHelpers, messagesByType);
+            GenerateUnionHelpers(w, resolved.UnionPlan);
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Reduces an ordered <see cref="MessageInfo"/> array to a <see cref="ClosedSet"/> of (type name,
+    /// manifest, method name) triples -- everything <see cref="GenerateManifest"/>,
+    /// <see cref="GenerateSerializeDirect"/>, <see cref="GenerateDeserialize"/>, and
+    /// <see cref="GenerateSizeHint"/> need for top-level dispatch, and nothing more (in particular,
+    /// no <see cref="FieldInfo"/>, so the top-level set stays cheap to hold in the cached
+    /// <see cref="ResolvedSerializer"/> model). Preserves <paramref name="messages"/>'s exact order --
+    /// the same order the dispatch switches have always emitted in.
+    /// </summary>
+    private static ClosedSet BuildClosedSet(ImmutableArray<MessageInfo> messages)
+    {
+        var builder = ImmutableArray.CreateBuilder<ClosedSetMember>(messages.Length);
+        foreach (var message in messages)
+            builder.Add(new ClosedSetMember(message.FullyQualifiedName, message.Manifest, GetMessageMethodName(message)));
+
+        return new ClosedSet(builder.ToImmutable());
+    }
+
+    /// <summary>
+    /// Rewrites each closed-generic registration's <see cref="ClosedGenericRegistrationInfo.Message"/>
+    /// to the FORMATTER-RESOLVED version of that message from <paramref name="resolvedMessagesByType"/>
+    /// (see <see cref="ResolveMessages"/>) -- a registration's message, as extracted, predates
+    /// per-serializer formatter substitution, exactly like every other message
+    /// <see cref="ResolveSerializerMessages"/> folds in. An invalid registration
+    /// (<see cref="ClosedGenericRegistrationInfo.Message"/> is null, or its type never made it into
+    /// the resolved table) passes through unchanged -- AKKASG020 already gates that case in
+    /// <see cref="EvaluateGate"/>, so this never actually happens for an emittable serializer, but a
+    /// bare pass-through is simpler than asserting it here too.
+    /// </summary>
+    private static ImmutableArray<ClosedGenericRegistrationInfo> ResolveClosedGenericRegistrations(
+        ImmutableArray<ClosedGenericRegistrationInfo> registrations,
+        ImmutableDictionary<string, MessageInfo> resolvedMessagesByType)
+    {
+        if (registrations.IsDefaultOrEmpty)
+            return ImmutableArray<ClosedGenericRegistrationInfo>.Empty;
+
+        var builder = ImmutableArray.CreateBuilder<ClosedGenericRegistrationInfo>(registrations.Length);
+        foreach (var registration in registrations)
+        {
+            if (registration.Message != null && resolvedMessagesByType.TryGetValue(registration.Message.FullyQualifiedName, out var resolvedMessage))
+                builder.Add(new ClosedGenericRegistrationInfo(registration.TargetDisplayName, resolvedMessage));
+            else
+                builder.Add(registration);
+        }
+
+        return builder.ToImmutable();
     }
 
     private static ImmutableArray<FormatterInfo> CollectUsedFormatters(ImmutableArray<MessageInfo> reachableMessages)
@@ -308,7 +476,7 @@ public sealed partial class AkkaSerializerGenerator
         w.BlankLine();
     }
 
-    private static void GenerateManifest(CodeWriter w, ImmutableArray<MessageInfo> messages)
+    private static void GenerateManifest(CodeWriter w, ClosedSet messages)
     {
         w.Line("public override string Manifest(object obj)");
         using (w.Block())
@@ -316,8 +484,8 @@ public sealed partial class AkkaSerializerGenerator
             w.Line("return obj switch");
             using (w.ExpressionBlock())
             {
-                foreach (var message in messages)
-                    w.Type(TypeName.Global(message.FullyQualifiedName)).Raw(" => ").StringLiteral(message.Manifest).Line(",");
+                foreach (var message in messages.Members)
+                    w.Type(TypeName.Global(message.TypeFullName)).Raw(" => ").StringLiteral(message.Manifest).Line(",");
                 w.Line("_ => throw new global::System.ArgumentException($\"Unsupported generated serializer type: {obj.GetType()}\", nameof(obj))");
             }
         }
@@ -340,7 +508,7 @@ public sealed partial class AkkaSerializerGenerator
         w.BlankLine();
     }
 
-    private static void GenerateSerializeDirect(CodeWriter w, ImmutableArray<MessageInfo> messages)
+    private static void GenerateSerializeDirect(CodeWriter w, ClosedSet messages)
     {
         w.Line("private void SerializeMessagePack(object obj, ref global::MessagePack.MessagePackWriter writer)");
         using (w.Block())
@@ -348,11 +516,11 @@ public sealed partial class AkkaSerializerGenerator
             w.Line("switch (obj)");
             using (var sw = w.Switch())
             {
-                foreach (var message in messages)
+                foreach (var message in messages.Members)
                 {
-                    using (sw.CaseTypePattern(TypeName.Global(message.FullyQualifiedName), "message"))
+                    using (sw.CaseTypePattern(TypeName.Global(message.TypeFullName), "message"))
                     {
-                        w.Raw("Write").Identifier(GetMessageMethodName(message)).Line("(ref writer, message);");
+                        w.Raw("Write").Identifier(message.MethodName).Line("(ref writer, message);");
                         w.Line("break;");
                     }
                 }
@@ -365,7 +533,7 @@ public sealed partial class AkkaSerializerGenerator
         w.BlankLine();
     }
 
-    private static void GenerateDeserialize(CodeWriter w, ImmutableArray<MessageInfo> messages)
+    private static void GenerateDeserialize(CodeWriter w, ClosedSet messages)
     {
         w.Line("public override object Deserialize(ReadOnlySequence<byte> bytes, string manifest)");
         using (w.Block())
@@ -374,8 +542,8 @@ public sealed partial class AkkaSerializerGenerator
             w.Line("return manifest switch");
             using (w.ExpressionBlock())
             {
-                foreach (var message in messages)
-                    w.StringLiteral(message.Manifest).Raw(" => Read").Identifier(GetMessageMethodName(message)).Line("(ref reader),");
+                foreach (var message in messages.Members)
+                    w.StringLiteral(message.Manifest).Raw(" => Read").Identifier(message.MethodName).Line("(ref reader),");
                 w.Line("_ => throw new global::System.Runtime.Serialization.SerializationException($\"Unknown generated serializer manifest [{manifest}] for serializer [{GetType()}].\")");
             }
         }
@@ -383,7 +551,7 @@ public sealed partial class AkkaSerializerGenerator
         w.BlankLine();
     }
 
-    private static void GenerateSizeHint(CodeWriter w, ImmutableArray<MessageInfo> messages)
+    private static void GenerateSizeHint(CodeWriter w, ClosedSet messages)
     {
         w.Line("public override int SizeHint(object obj)");
         using (w.Block())
@@ -391,8 +559,8 @@ public sealed partial class AkkaSerializerGenerator
             w.Line("return obj switch");
             using (w.ExpressionBlock())
             {
-                foreach (var message in messages)
-                    w.Type(TypeName.Global(message.FullyQualifiedName)).Raw(" message => SizeOf").Identifier(GetMessageMethodName(message)).Line("(message),");
+                foreach (var message in messages.Members)
+                    w.Type(TypeName.Global(message.TypeFullName)).Raw(" message => SizeOf").Identifier(message.MethodName).Line("(message),");
                 w.Line("_ => global::Akka.Serialization.SerializerV2.UnknownSize");
             }
         }
@@ -436,7 +604,7 @@ public sealed partial class AkkaSerializerGenerator
         w.BlankLine();
     }
 
-    private static void GenerateSizeMessage(CodeWriter w, MessageInfo message, ImmutableDictionary<string, (string HelperName, FieldInfo Field)> unionHelpers)
+    private static void GenerateSizeMessage(CodeWriter w, MessageInfo message, ImmutableDictionary<string, string> unionHelpers)
     {
         w.Raw("private int SizeOf").Identifier(GetMessageMethodName(message))
             .Raw("(").Type(TypeName.Global(message.FullyQualifiedName)).Line(" message)");
@@ -456,7 +624,7 @@ public sealed partial class AkkaSerializerGenerator
         w.BlankLine();
     }
 
-    private static void GenerateSizeField(CodeWriter w, ImmutableDictionary<string, (string HelperName, FieldInfo Field)> unionHelpers, FieldInfo field, NameAlloc alloc)
+    private static void GenerateSizeField(CodeWriter w, ImmutableDictionary<string, string> unionHelpers, FieldInfo field, NameAlloc alloc)
     {
         var value = ValueExpr.GeneratorOwned("message").Member(field.Name);
         var localName = Local.ForField(field.Name).WithSuffix("Size");
@@ -533,7 +701,7 @@ public sealed partial class AkkaSerializerGenerator
         return true;
     }
 
-    private static void GenerateSizeExpression(CodeWriter w, ImmutableDictionary<string, (string HelperName, FieldInfo Field)> unionHelpers, FieldInfo field, ValueExpr value)
+    private static void GenerateSizeExpression(CodeWriter w, ImmutableDictionary<string, string> unionHelpers, FieldInfo field, ValueExpr value)
     {
         switch (field.Mapping.Kind)
         {
@@ -541,10 +709,10 @@ public sealed partial class AkkaSerializerGenerator
                 w.Raw("SizeOfEnvelopePayload(").Value(value).Raw(")");
                 break;
             case FieldKind.Union when field.IsNullable:
-                w.Value(value).Raw(" is null ? SizeOfNil() : SizeOf").Identifier(unionHelpers[BuildUnionSignature(field)].HelperName).Raw("(").Value(value).Raw(")");
+                w.Value(value).Raw(" is null ? SizeOfNil() : SizeOf").Identifier(unionHelpers[BuildUnionSignature(field)]).Raw("(").Value(value).Raw(")");
                 break;
             case FieldKind.Union:
-                w.Raw("SizeOf").Identifier(unionHelpers[BuildUnionSignature(field)].HelperName).Raw("(").Value(value).Raw(")");
+                w.Raw("SizeOf").Identifier(unionHelpers[BuildUnionSignature(field)]).Raw("(").Value(value).Raw(")");
                 break;
             case FieldKind.Object when IsNullableValueField(field):
                 w.Value(value).Raw(" is null ? SizeOfNil() : SizeOf").Identifier(GetObjectMethodName(field.Mapping)).Raw("(").Value(value).Raw(".Value)");
@@ -616,7 +784,7 @@ public sealed partial class AkkaSerializerGenerator
         }
     }
 
-    private static void GenerateWriteMessage(CodeWriter w, MessageInfo message, ImmutableDictionary<string, (string HelperName, FieldInfo Field)> unionHelpers)
+    private static void GenerateWriteMessage(CodeWriter w, MessageInfo message, ImmutableDictionary<string, string> unionHelpers)
     {
         w.Raw("private void Write").Identifier(GetMessageMethodName(message))
             .Raw("(ref global::MessagePack.MessagePackWriter writer, ").Type(TypeName.Global(message.FullyQualifiedName)).Line(" message)");
@@ -631,7 +799,7 @@ public sealed partial class AkkaSerializerGenerator
         w.BlankLine();
     }
 
-    private static void GenerateReadMessage(CodeWriter w, MessageInfo message, ImmutableDictionary<string, (string HelperName, FieldInfo Field)> unionHelpers)
+    private static void GenerateReadMessage(CodeWriter w, MessageInfo message, ImmutableDictionary<string, string> unionHelpers)
     {
         w.Raw("private ").Type(TypeName.Global(message.FullyQualifiedName)).Raw(" Read").Identifier(GetMessageMethodName(message))
             .Line("(ref global::MessagePack.MessagePackReader reader)");
@@ -777,12 +945,19 @@ public sealed partial class AkkaSerializerGenerator
     }
 
     /// <summary>
-    /// Plans one helper per distinct union signature across all reachable messages. Helpers are
-    /// named after the union's folded static type ("Union_IOrderEvent"); when several distinct
-    /// member sets share a static type (field-level overrides), later ones -- ordered by signature
-    /// for determinism -- get a numeric suffix.
+    /// Plans one helper per distinct union signature across all reachable messages, as a
+    /// <see cref="UnionPlan"/> whose <see cref="UnionPlan.Helpers"/> are ALREADY ordered by helper
+    /// name (the order <see cref="GenerateUnionHelpers"/> used to derive itself, via
+    /// <c>unionHelpers.Values.OrderBy(...)</c>, every time it ran) and whose member lists are
+    /// ALREADY resolved to <see cref="ClosedSet"/>s against <paramref name="messagesByType"/> --
+    /// baking both derivations in here, once, at resolve time keeps <see cref="ResolvedSerializer"/>
+    /// a pure function of its inputs and keeps <see cref="Generate"/> from having to re-touch
+    /// <paramref name="messagesByType"/> at all. Helpers are named after the union's folded static
+    /// type ("Union_IOrderEvent"); when several distinct member sets share a static type
+    /// (field-level overrides), later ones -- ordered by signature for determinism -- get a numeric
+    /// suffix.
     /// </summary>
-    private static ImmutableDictionary<string, (string HelperName, FieldInfo Field)> PlanUnionHelpers(ImmutableArray<MessageInfo> reachableMessages)
+    private static UnionPlan PlanUnionHelpers(ImmutableArray<MessageInfo> reachableMessages, ImmutableDictionary<string, MessageInfo> messagesByType)
     {
         var representatives = new Dictionary<string, FieldInfo>(StringComparer.Ordinal);
         foreach (var message in reachableMessages)
@@ -795,56 +970,72 @@ public sealed partial class AkkaSerializerGenerator
             }
         }
 
-        var builder = ImmutableDictionary.CreateBuilder<string, (string, FieldInfo)>(StringComparer.Ordinal);
+        var helpers = ImmutableArray.CreateBuilder<UnionHelperPlan>();
         foreach (var group in representatives.GroupBy(pair => FoldTypeName(pair.Value.TypeFullName), StringComparer.Ordinal))
         {
             var ordered = group.OrderBy(pair => pair.Key, StringComparer.Ordinal).ToList();
             for (var i = 0; i < ordered.Count; i++)
             {
                 var helperName = i == 0 ? "Union_" + group.Key : "Union_" + group.Key + "_" + (i + 1);
-                builder[ordered[i].Key] = (helperName, ordered[i].Value);
+                var field = ordered[i].Value;
+                helpers.Add(new UnionHelperPlan(ordered[i].Key, helperName, field.TypeFullName, BuildUnionMembers(field, messagesByType)));
             }
         }
 
-        return builder.ToImmutable();
+        // GenerateUnionHelpers used to derive this ordering itself, on every (re)generation, from
+        // the dictionary's Values; baking it in here means Generate() can iterate Helpers as-is.
+        var orderedHelpers = helpers.ToImmutable().Sort((a, b) => string.CompareOrdinal(a.HelperName, b.HelperName));
+        return new UnionPlan(orderedHelpers);
     }
 
-    private static void GenerateUnionHelpers(
-        CodeWriter w,
-        ImmutableDictionary<string, (string HelperName, FieldInfo Field)> unionHelpers,
-        ImmutableDictionary<string, MessageInfo> messagesByType)
+    /// <summary>
+    /// The declared members of one union field, filtered to the supported/known ones (mirrors the
+    /// old inline filter in <see cref="GenerateUnionHelpers"/>: <c>member.IsSupported &amp;&amp;
+    /// messagesByType.ContainsKey(...)</c>) and reduced to the (type name, manifest, method name)
+    /// triple every union write/read/size helper actually needs -- exactly a <see cref="ClosedSet"/>.
+    /// </summary>
+    private static ClosedSet BuildUnionMembers(FieldInfo field, ImmutableDictionary<string, MessageInfo> messagesByType)
     {
-        foreach (var plan in unionHelpers.Values.OrderBy(plan => plan.HelperName, StringComparer.Ordinal))
+        var builder = ImmutableArray.CreateBuilder<ClosedSetMember>();
+        foreach (var member in field.UnionMembers)
         {
-            var field = plan.Field;
-            var members = field.UnionMembers
-                .Where(member => member.IsSupported && messagesByType.ContainsKey(member.TypeFullName))
-                .Select(member => (Member: member, Message: messagesByType[member.TypeFullName]))
-                .ToImmutableArray();
+            if (!member.IsSupported || !messagesByType.TryGetValue(member.TypeFullName, out var memberMessage))
+                continue;
 
-            GenerateUnionWrite(w, field, plan.HelperName, members);
-            GenerateUnionRead(w, field, plan.HelperName, members);
-            GenerateUnionSize(w, field, plan.HelperName, members);
+            builder.Add(new ClosedSetMember(member.TypeFullName, memberMessage.Manifest, GetMessageMethodName(memberMessage)));
+        }
+
+        return new ClosedSet(builder.ToImmutable());
+    }
+
+    private static void GenerateUnionHelpers(CodeWriter w, UnionPlan unionPlan)
+    {
+        // Already ordered by helper name -- see PlanUnionHelpers.
+        foreach (var helper in unionPlan.Helpers)
+        {
+            GenerateUnionWrite(w, helper);
+            GenerateUnionRead(w, helper);
+            GenerateUnionSize(w, helper);
         }
     }
 
-    private static void GenerateUnionWrite(CodeWriter w, FieldInfo field, string helperName, ImmutableArray<(UnionMemberInfo Member, MessageInfo Message)> members)
+    private static void GenerateUnionWrite(CodeWriter w, UnionHelperPlan helper)
     {
-        w.Raw("private void Write").Identifier(helperName)
-            .Raw("(ref global::MessagePack.MessagePackWriter writer, ").Type(TypeName.Global(field.TypeFullName)).Line(" value)");
+        w.Raw("private void Write").Identifier(helper.HelperName)
+            .Raw("(ref global::MessagePack.MessagePackWriter writer, ").Type(TypeName.Global(helper.FieldTypeFullName)).Line(" value)");
         using (w.Block())
         {
             w.Line("var runtimeType = value.GetType();");
-            foreach (var (member, memberMessage) in members)
+            foreach (var member in helper.Members.Members)
             {
                 w.Raw("if (runtimeType == typeof(").Type(TypeName.Global(member.TypeFullName)).Line("))");
                 using (w.Block())
                 {
                     w.Line("writer.WriteMapHeader(2);");
                     w.Line("writer.Write(1);");
-                    w.Raw("writer.Write(").StringLiteral(memberMessage.Manifest).Line(");");
+                    w.Raw("writer.Write(").StringLiteral(member.Manifest).Line(");");
                     w.Line("writer.Write(2);");
-                    w.Raw("Write").Identifier(GetMessageMethodName(memberMessage)).Raw("(ref writer, (").Type(TypeName.Global(member.TypeFullName)).Line(")value);");
+                    w.Raw("Write").Identifier(member.MethodName).Raw("(ref writer, (").Type(TypeName.Global(member.TypeFullName)).Line(")value);");
                     w.Line("return;");
                 }
 
@@ -852,21 +1043,21 @@ public sealed partial class AkkaSerializerGenerator
             }
 
             w.Raw("throw new global::System.Runtime.Serialization.SerializationException($\"Type [{runtimeType}] is not a declared union member for union [")
-                .LiteralText(field.TypeFullName).Line("].\");");
+                .LiteralText(helper.FieldTypeFullName).Line("].\");");
         }
 
         w.BlankLine();
     }
 
-    private static void GenerateUnionRead(CodeWriter w, FieldInfo field, string helperName, ImmutableArray<(UnionMemberInfo Member, MessageInfo Message)> members)
+    private static void GenerateUnionRead(CodeWriter w, UnionHelperPlan helper)
     {
-        w.Raw("private ").Type(TypeName.Global(field.TypeFullName)).Raw(" Read").Identifier(helperName)
+        w.Raw("private ").Type(TypeName.Global(helper.FieldTypeFullName)).Raw(" Read").Identifier(helper.HelperName)
             .Line("(ref global::MessagePack.MessagePackReader reader)");
         using (w.Block())
         {
             w.Line("var fieldCount = reader.ReadMapHeader();");
             w.Line("string? manifest = null;");
-            w.Type(TypeName.Global(field.TypeFullName)).Line("? result = default;");
+            w.Type(TypeName.Global(helper.FieldTypeFullName)).Line("? result = default;");
             w.Line("var hasPayload = false;");
             w.Line("for (var entryIndex = 0; entryIndex < fieldCount; entryIndex++)");
             using (w.Block())
@@ -886,11 +1077,11 @@ public sealed partial class AkkaSerializerGenerator
                         w.Line("switch (manifest)");
                         using (var manifestSwitch = w.Switch())
                         {
-                            foreach (var (_, memberMessage) in members)
+                            foreach (var member in helper.Members.Members)
                             {
-                                using (manifestSwitch.CaseStringLiteral(memberMessage.Manifest))
+                                using (manifestSwitch.CaseStringLiteral(member.Manifest))
                                 {
-                                    w.Raw("result = Read").Identifier(GetMessageMethodName(memberMessage)).Line("(ref reader);");
+                                    w.Raw("result = Read").Identifier(member.MethodName).Line("(ref reader);");
                                     w.Line("break;");
                                 }
                             }
@@ -898,13 +1089,13 @@ public sealed partial class AkkaSerializerGenerator
                             using (manifestSwitch.CaseNull())
                             {
                                 w.Raw("throw new global::System.Runtime.Serialization.SerializationException(\"Union manifest must precede the payload for union [")
-                                    .LiteralText(field.TypeFullName).Line("].\");");
+                                    .LiteralText(helper.FieldTypeFullName).Line("].\");");
                             }
 
                             using (manifestSwitch.Default())
                             {
                                 w.Raw("throw new global::System.Runtime.Serialization.SerializationException($\"Unknown union manifest [{manifest}] for union [")
-                                    .LiteralText(field.TypeFullName).Line("].\");");
+                                    .LiteralText(helper.FieldTypeFullName).Line("].\");");
                             }
                         }
 
@@ -926,7 +1117,7 @@ public sealed partial class AkkaSerializerGenerator
             using (w.Indented())
             {
                 w.Raw("throw new global::System.Runtime.Serialization.SerializationException(\"Missing union payload for union [")
-                    .LiteralText(field.TypeFullName).Line("].\");");
+                    .LiteralText(helper.FieldTypeFullName).Line("].\");");
             }
 
             w.Line("return result;");
@@ -935,23 +1126,23 @@ public sealed partial class AkkaSerializerGenerator
         w.BlankLine();
     }
 
-    private static void GenerateUnionSize(CodeWriter w, FieldInfo field, string helperName, ImmutableArray<(UnionMemberInfo Member, MessageInfo Message)> members)
+    private static void GenerateUnionSize(CodeWriter w, UnionHelperPlan helper)
     {
-        w.Raw("private int SizeOf").Identifier(helperName)
-            .Raw("(").Type(TypeName.Global(field.TypeFullName)).Line(" value)");
+        w.Raw("private int SizeOf").Identifier(helper.HelperName)
+            .Raw("(").Type(TypeName.Global(helper.FieldTypeFullName)).Line(" value)");
         using (w.Block())
         {
             w.Line("var runtimeType = value.GetType();");
-            foreach (var (member, memberMessage) in members)
+            foreach (var member in helper.Members.Members)
             {
                 w.Raw("if (runtimeType == typeof(").Type(TypeName.Global(member.TypeFullName)).Line("))");
                 using (w.Block())
                 {
-                    w.Raw("var payloadSize = SizeOf").Identifier(GetMessageMethodName(memberMessage)).Raw("((").Type(TypeName.Global(member.TypeFullName)).Line(")value);");
+                    w.Raw("var payloadSize = SizeOf").Identifier(member.MethodName).Raw("((").Type(TypeName.Global(member.TypeFullName)).Line(")value);");
                     w.Line("if (payloadSize < 0)");
                     using (w.Indented())
                         w.Line("return global::Akka.Serialization.SerializerV2.UnknownSize;");
-                    w.Raw("return checked(SizeOfMapHeader(2) + SizeOfInt32(1) + SizeOfString(").StringLiteral(memberMessage.Manifest)
+                    w.Raw("return checked(SizeOfMapHeader(2) + SizeOfInt32(1) + SizeOfString(").StringLiteral(member.Manifest)
                         .Line(") + SizeOfInt32(2) + payloadSize);");
                 }
 
@@ -964,7 +1155,7 @@ public sealed partial class AkkaSerializerGenerator
         w.BlankLine();
     }
 
-    private static void GenerateWriteField(CodeWriter w, ImmutableDictionary<string, (string HelperName, FieldInfo Field)> unionHelpers, FieldInfo field, NameAlloc alloc)
+    private static void GenerateWriteField(CodeWriter w, ImmutableDictionary<string, string> unionHelpers, FieldInfo field, NameAlloc alloc)
     {
         var value = ValueExpr.GeneratorOwned("message").Member(field.Name);
         w.Raw("writer.Write(").Number(field.Index).Line(");");
@@ -982,7 +1173,7 @@ public sealed partial class AkkaSerializerGenerator
         GenerateWriteFieldValue(w, unionHelpers, field, value, alloc);
     }
 
-    private static void GenerateWriteFieldValue(CodeWriter w, ImmutableDictionary<string, (string HelperName, FieldInfo Field)> unionHelpers, FieldInfo field, ValueExpr value, NameAlloc alloc)
+    private static void GenerateWriteFieldValue(CodeWriter w, ImmutableDictionary<string, string> unionHelpers, FieldInfo field, ValueExpr value, NameAlloc alloc)
     {
         if (IsCollectionKind(field.Mapping.Kind))
         {
@@ -1066,17 +1257,17 @@ public sealed partial class AkkaSerializerGenerator
                         w.Line("writer.WriteNil();");
                     w.Line("else");
                     using (w.Indented())
-                        w.Raw("Write").Identifier(unionHelpers[BuildUnionSignature(field)].HelperName).Raw("(ref writer, ").Value(value).Line(");");
+                        w.Raw("Write").Identifier(unionHelpers[BuildUnionSignature(field)]).Raw("(ref writer, ").Value(value).Line(");");
                 }
                 else
                 {
-                    w.Raw("Write").Identifier(unionHelpers[BuildUnionSignature(field)].HelperName).Raw("(ref writer, ").Value(value).Line(");");
+                    w.Raw("Write").Identifier(unionHelpers[BuildUnionSignature(field)]).Raw("(ref writer, ").Value(value).Line(");");
                 }
                 break;
         }
     }
 
-    private static void GenerateReadField(CodeWriter w, ImmutableDictionary<string, (string HelperName, FieldInfo Field)> unionHelpers, FieldInfo field, NameAlloc alloc)
+    private static void GenerateReadField(CodeWriter w, ImmutableDictionary<string, string> unionHelpers, FieldInfo field, NameAlloc alloc)
     {
         var target = Local.ForField(field.Name);
 
@@ -1120,7 +1311,7 @@ public sealed partial class AkkaSerializerGenerator
         GenerateReadFieldValue(w, unionHelpers, field, target, alloc);
     }
 
-    private static void GenerateReadFieldValue(CodeWriter w, ImmutableDictionary<string, (string HelperName, FieldInfo Field)> unionHelpers, FieldInfo field, Local target, NameAlloc alloc)
+    private static void GenerateReadFieldValue(CodeWriter w, ImmutableDictionary<string, string> unionHelpers, FieldInfo field, Local target, NameAlloc alloc)
     {
         if (IsCollectionKind(field.Mapping.Kind))
         {
@@ -1177,7 +1368,7 @@ public sealed partial class AkkaSerializerGenerator
                 w.Local(target).Raw(" = ").Identifier(GetFormatterFieldName(field.Formatter!)).Line(".Read(ref reader);");
                 break;
             case FieldKind.Union:
-                w.Local(target).Raw(" = Read").Identifier(unionHelpers[BuildUnionSignature(field)].HelperName).Line("(ref reader);");
+                w.Local(target).Raw(" = Read").Identifier(unionHelpers[BuildUnionSignature(field)]).Line("(ref reader);");
                 break;
         }
     }

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Extraction.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Extraction.cs
@@ -49,8 +49,32 @@ public sealed partial class AkkaSerializerGenerator
         // rejected with CS0579 ("Duplicate 'AkkaSerializer<>' attribute") even though IA and IB
         // differ, so at most one [AkkaSerializer<T>] ever reaches this method. No AKKASG030 is
         // needed for this case.
-        var attribute = context.Attributes[0];
-        var compilation = context.SemanticModel.Compilation;
+        return ExtractSerializerCore(symbol, context.Attributes[0], context.SemanticModel.Compilation);
+    }
+
+    /// <summary>
+    /// Test-only entry point: extracts a <see cref="SerializerInfo"/> straight from a symbol and its
+    /// <see cref="Compilation"/>, with no <see cref="GeneratorAttributeSyntaxContext"/> syntax hook
+    /// to drive it -- the serializer-side counterpart of <see cref="ParseMessageForTests"/>. Finds
+    /// the <c>[AkkaSerializer&lt;TProtocol&gt;]</c> attribute directly off the symbol (the only
+    /// thing <see cref="GeneratorAttributeSyntaxContext.Attributes"/> would otherwise supply) and
+    /// delegates everything else to the same, unmodified <see cref="ExtractSerializerCore"/> routine
+    /// the real pipeline uses -- so a snapshot built from this reflects REAL extraction, not a
+    /// hand-typed approximation of it (see GeneratorResolvedSerializerSnapshotSpec.cs).
+    /// </summary>
+    internal static SerializerInfo? ExtractSerializerForTests(INamedTypeSymbol symbol, Compilation compilation)
+    {
+        var serializerAttributeType = compilation.GetTypeByMetadataName(SerializerAttributeFullName);
+        var attribute = symbol.GetAttributes()
+            .FirstOrDefault(attr => attr.AttributeClass != null && SymbolEqualityComparer.Default.Equals(attr.AttributeClass.OriginalDefinition, serializerAttributeType));
+        if (attribute == null)
+            return null;
+
+        return ExtractSerializerCore(symbol, attribute, compilation);
+    }
+
+    private static SerializerInfo ExtractSerializerCore(INamedTypeSymbol symbol, AttributeData attribute, Compilation compilation)
+    {
         string? name = null;
         var serializerId = 0;
 

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Models.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Models.cs
@@ -62,6 +62,54 @@ public sealed partial class AkkaSerializerGenerator
 
             return hash;
         }
+
+        /// <summary>
+        /// Value equality for an <see cref="ImmutableDictionary{TKey,TValue}"/>-shaped cached model
+        /// member (<see cref="ResolvedSerializer.ResolvedMessagesByType"/>): same key set, same value
+        /// (by <see cref="IEquatable{T}"/>/<see cref="EqualityComparer{T}.Default"/>) for every key.
+        /// <see cref="ImmutableDictionary{TKey,TValue}"/> has no such built-in equality of its own (its
+        /// default <c>Equals</c> is reference equality on the underlying node), so every dictionary-typed
+        /// model member must be compared through this helper instead of a bare <c>==</c>/<c>Equals</c>.
+        /// </summary>
+        public static bool DictionaryEquals<TValue>(ImmutableDictionary<string, TValue> left, ImmutableDictionary<string, TValue> right)
+        {
+            if (ReferenceEquals(left, right))
+                return true;
+
+            if (left.Count != right.Count)
+                return false;
+
+            foreach (var pair in left)
+            {
+                if (!right.TryGetValue(pair.Key, out var otherValue) || !EqualityComparer<TValue>.Default.Equals(pair.Value, otherValue))
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Order-independent hash companion to <see cref="DictionaryEquals{TValue}"/>: entries are
+        /// combined with an order-insensitive operator (addition) so two dictionaries holding the same
+        /// key/value pairs in a different enumeration order still hash equal, honoring the
+        /// Equals/GetHashCode contract <see cref="DictionaryEquals{TValue}"/> establishes.
+        /// </summary>
+        public static int CombineDictionary<TValue>(int hash, ImmutableDictionary<string, TValue> dictionary)
+        {
+            hash = Combine(hash, dictionary.Count);
+
+            var entriesHash = 0;
+            foreach (var pair in dictionary)
+            {
+                var entryHash = Combine(Combine(Seed, pair.Key), pair.Value == null ? 0 : EqualityComparer<TValue>.Default.GetHashCode(pair.Value));
+                unchecked
+                {
+                    entriesHash += entryHash;
+                }
+            }
+
+            return Combine(hash, entriesHash);
+        }
     }
 
     internal sealed class SerializerInfo : IEquatable<SerializerInfo>
@@ -937,6 +985,345 @@ public sealed partial class AkkaSerializerGenerator
             var hash = ValueEquality.Seed;
             hash = ValueEquality.Combine(hash, (int)Key);
             hash = ValueEquality.Combine(hash, MessageArgs);
+            return hash;
+        }
+    }
+
+    /// <summary>
+    /// One member of a <see cref="ClosedSet"/>: everything a top-level dispatch switch or a union
+    /// write/read/size helper needs to name and call into ONE message's generated methods --
+    /// nothing else. Reduced from a full <see cref="MessageInfo"/> (which also carries every field,
+    /// irrelevant to dispatch) so a <see cref="ClosedSet"/> stays cheap to hold inside a cached
+    /// <see cref="ResolvedSerializer"/>. <see cref="MethodName"/> is the same
+    /// <see cref="GetMessageMethodName"/> result the corresponding <c>Write&lt;name&gt;</c>/
+    /// <c>Read&lt;name&gt;</c>/<c>SizeOf&lt;name&gt;</c> methods use, computed once so every dispatch
+    /// site (top-level or union) agrees on it without recomputing <see cref="FoldTypeName"/>.
+    /// </summary>
+    internal sealed class ClosedSetMember : IEquatable<ClosedSetMember>
+    {
+        public ClosedSetMember(string typeFullName, string manifest, string methodName)
+        {
+            TypeFullName = typeFullName;
+            Manifest = manifest;
+            MethodName = methodName;
+        }
+
+        public string TypeFullName { get; }
+        public string Manifest { get; }
+        public string MethodName { get; }
+
+        public bool Equals(ClosedSetMember? other)
+        {
+            if (ReferenceEquals(this, other))
+                return true;
+
+            if (other is null)
+                return false;
+
+            return string.Equals(TypeFullName, other.TypeFullName, StringComparison.Ordinal)
+                && string.Equals(Manifest, other.Manifest, StringComparison.Ordinal)
+                && string.Equals(MethodName, other.MethodName, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as ClosedSetMember);
+
+        public override int GetHashCode()
+        {
+            var hash = ValueEquality.Seed;
+            hash = ValueEquality.Combine(hash, TypeFullName);
+            hash = ValueEquality.Combine(hash, Manifest);
+            hash = ValueEquality.Combine(hash, MethodName);
+            return hash;
+        }
+    }
+
+    /// <summary>
+    /// An ORDERED, closed set of <see cref="ClosedSetMember"/>s -- today, a serializer's top-level
+    /// dispatch set (<see cref="ResolvedSerializer.TopLevelMessages"/>) and one union field's
+    /// declared member set (<see cref="UnionHelperPlan.Members"/>). Order is significant and
+    /// preserved exactly as the pipeline has always produced it (declaration order for top-level
+    /// messages, [AkkaUnion] declaration order for union members) -- emitted switch/dispatch text is
+    /// ordered the same way, so re-ordering here would change emitted output. This is Decision 18's
+    /// single representation for "a closed, explicitly-enumerated set of message types": later work
+    /// on registration expansion is expected to build its own <see cref="ClosedSet"/>s the same way.
+    /// </summary>
+    internal sealed class ClosedSet : IEquatable<ClosedSet>
+    {
+        public static readonly ClosedSet Empty = new(ImmutableArray<ClosedSetMember>.Empty);
+
+        public ClosedSet(ImmutableArray<ClosedSetMember> members)
+        {
+            Members = members;
+        }
+
+        public ImmutableArray<ClosedSetMember> Members { get; }
+
+        public bool Equals(ClosedSet? other)
+        {
+            if (ReferenceEquals(this, other))
+                return true;
+
+            if (other is null)
+                return false;
+
+            return ValueEquality.SequenceEquals(Members, other.Members);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as ClosedSet);
+
+        public override int GetHashCode()
+        {
+            var hash = ValueEquality.Seed;
+            hash = ValueEquality.Combine(hash, Members);
+            return hash;
+        }
+    }
+
+    /// <summary>
+    /// One planned union dispatch helper (a Write/Read/SizeOf trio): its dedup identity
+    /// (<see cref="Signature"/>, from <see cref="BuildUnionSignature"/>), its generated method-name
+    /// suffix (<see cref="HelperName"/>), the union field's static type
+    /// (<see cref="FieldTypeFullName"/> -- the helper trio's shared parameter/return type), and its
+    /// declared member set already resolved to a <see cref="ClosedSet"/> (see
+    /// <see cref="PlanUnionHelpers"/>) so generation never needs to re-consult the message dictionary.
+    /// </summary>
+    internal sealed class UnionHelperPlan : IEquatable<UnionHelperPlan>
+    {
+        public UnionHelperPlan(string signature, string helperName, string fieldTypeFullName, ClosedSet members)
+        {
+            Signature = signature;
+            HelperName = helperName;
+            FieldTypeFullName = fieldTypeFullName;
+            Members = members;
+        }
+
+        /// <summary>The union's dedup identity: static type plus ordered member set. See <see cref="BuildUnionSignature"/>.</summary>
+        public string Signature { get; }
+
+        public string HelperName { get; }
+        public string FieldTypeFullName { get; }
+        public ClosedSet Members { get; }
+
+        public bool Equals(UnionHelperPlan? other)
+        {
+            if (ReferenceEquals(this, other))
+                return true;
+
+            if (other is null)
+                return false;
+
+            return string.Equals(Signature, other.Signature, StringComparison.Ordinal)
+                && string.Equals(HelperName, other.HelperName, StringComparison.Ordinal)
+                && string.Equals(FieldTypeFullName, other.FieldTypeFullName, StringComparison.Ordinal)
+                && Members.Equals(other.Members);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as UnionHelperPlan);
+
+        public override int GetHashCode()
+        {
+            var hash = ValueEquality.Seed;
+            hash = ValueEquality.Combine(hash, Signature);
+            hash = ValueEquality.Combine(hash, HelperName);
+            hash = ValueEquality.Combine(hash, FieldTypeFullName);
+            hash = ValueEquality.Combine(hash, Members.GetHashCode());
+            return hash;
+        }
+    }
+
+    /// <summary>
+    /// One serializer's full union dispatch plan: every distinct union helper it needs to generate,
+    /// ALREADY ordered by <see cref="UnionHelperPlan.HelperName"/> (the order
+    /// <see cref="GenerateUnionHelpers"/> emits them in) -- replaces the pipeline's former
+    /// string-keyed <c>ImmutableDictionary&lt;string, (string HelperName, FieldInfo Field)&gt;</c>,
+    /// which was neither a named model nor cheaply value-equatable (a <see cref="FieldInfo"/> per
+    /// entry pulled in every field of some arbitrary representative message).
+    /// </summary>
+    internal sealed class UnionPlan : IEquatable<UnionPlan>
+    {
+        public static readonly UnionPlan Empty = new(ImmutableArray<UnionHelperPlan>.Empty);
+
+        public UnionPlan(ImmutableArray<UnionHelperPlan> helpers)
+        {
+            Helpers = helpers;
+        }
+
+        /// <summary>Ordered by <see cref="UnionHelperPlan.HelperName"/>. See <see cref="PlanUnionHelpers"/>.</summary>
+        public ImmutableArray<UnionHelperPlan> Helpers { get; }
+
+        public bool Equals(UnionPlan? other)
+        {
+            if (ReferenceEquals(this, other))
+                return true;
+
+            if (other is null)
+                return false;
+
+            return ValueEquality.SequenceEquals(Helpers, other.Helpers);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as UnionPlan);
+
+        public override int GetHashCode()
+        {
+            var hash = ValueEquality.Seed;
+            hash = ValueEquality.Combine(hash, Helpers);
+            return hash;
+        }
+    }
+
+    /// <summary>
+    /// One serializer, fully resolved: the cached, value-equatable output of
+    /// <see cref="ResolveSerializer"/>, and the pipeline's terminal per-serializer model --
+    /// <see cref="EmitResolvedSerializer"/> reports its diagnostics and emits its source, PURELY from
+    /// this type, with no further symbol/<see cref="Compilation"/> access. Two resolves over equal
+    /// inputs produce an EQUAL <see cref="ResolvedSerializer"/> (see <see cref="GeneratorResolveSpec"/>),
+    /// which is exactly what lets an unrelated serializer's <c>RegisterSourceOutput</c> report
+    /// <see cref="Microsoft.CodeAnalysis.IncrementalStepRunReason.Cached"/> instead of re-emitting
+    /// when only ANOTHER serializer's message changed.
+    /// </summary>
+    /// <remarks>
+    /// When <see cref="IsEmittable"/> is false (the serializer's own declaration failed
+    /// <see cref="EvaluateGate"/>), every field below <see cref="GateDiagnostics"/> is empty/default:
+    /// a serializer that never clears the gate has no message table to resolve in the first place --
+    /// see <see cref="NotEmittable"/>.
+    /// </remarks>
+    internal sealed class ResolvedSerializer : IEquatable<ResolvedSerializer>
+    {
+        public ResolvedSerializer(
+            SerializerInfo serializer,
+            bool isEmittable,
+            ImmutableArray<DiagnosticSpec> gateDiagnostics,
+            ImmutableDictionary<string, MessageInfo> resolvedMessagesByType,
+            ClosedSet topLevelMessages,
+            ImmutableArray<MessageInfo> reachableMessages,
+            ImmutableArray<ClosedGenericRegistrationInfo> resolvedClosedGenericRegistrations,
+            ImmutableArray<FormatterInfo> usedFormatters,
+            UnionPlan unionPlan,
+            ImmutableArray<DiagnosticSpec> validationDiagnostics)
+        {
+            Serializer = serializer;
+            IsEmittable = isEmittable;
+            GateDiagnostics = gateDiagnostics;
+            ResolvedMessagesByType = resolvedMessagesByType;
+            TopLevelMessages = topLevelMessages;
+            ReachableMessages = reachableMessages;
+            ResolvedClosedGenericRegistrations = resolvedClosedGenericRegistrations;
+            UsedFormatters = usedFormatters;
+            UnionPlan = unionPlan;
+            ValidationDiagnostics = validationDiagnostics;
+        }
+
+        /// <summary>The serializer declaration this model resolves. Never null, even when <see cref="IsEmittable"/> is false.</summary>
+        public SerializerInfo Serializer { get; }
+
+        /// <summary>The result of <see cref="EvaluateGate"/>: whether this serializer's own declaration is usable as a codegen target at all.</summary>
+        public bool IsEmittable { get; }
+
+        /// <summary>Diagnostics from <see cref="EvaluateGate"/>. Reported unconditionally (gate diagnostics fire whether or not the gate itself passes).</summary>
+        public ImmutableArray<DiagnosticSpec> GateDiagnostics { get; }
+
+        /// <summary>Every message this serializer knows about, with formatters resolved. Empty when <see cref="IsEmittable"/> is false.</summary>
+        public ImmutableDictionary<string, MessageInfo> ResolvedMessagesByType { get; }
+
+        /// <summary>This serializer's top-level dispatch set (Manifest/Serialize/Deserialize/SizeHint switches), in declaration order.</summary>
+        public ClosedSet TopLevelMessages { get; }
+
+        /// <summary>Every message reachable from a top-level message -- the ones that need generated Write/Read/SizeOf methods.</summary>
+        public ImmutableArray<MessageInfo> ReachableMessages { get; }
+
+        /// <summary>
+        /// This serializer's <c>[AkkaSerializable&lt;T&gt;]</c> registrations, with each registration's
+        /// <see cref="ClosedGenericRegistrationInfo.Message"/> resolved to its formatter-substituted
+        /// form from <see cref="ResolvedMessagesByType"/> (see <see cref="ResolveClosedGenericRegistrations"/>).
+        /// </summary>
+        public ImmutableArray<ClosedGenericRegistrationInfo> ResolvedClosedGenericRegistrations { get; }
+
+        /// <summary>The distinct hand-written formatters actually used by <see cref="ReachableMessages"/>, sorted for deterministic field/constructor emission. See <see cref="CollectUsedFormatters"/>.</summary>
+        public ImmutableArray<FormatterInfo> UsedFormatters { get; }
+
+        /// <summary>This serializer's union dispatch helpers. See <see cref="PlanUnionHelpers"/>.</summary>
+        public UnionPlan UnionPlan { get; }
+
+        /// <summary>Diagnostics from validating <see cref="ReachableMessages"/>/<see cref="TopLevelMessages"/>. Empty when <see cref="IsEmittable"/> is false (there is nothing to validate).</summary>
+        public ImmutableArray<DiagnosticSpec> ValidationDiagnostics { get; }
+
+        /// <summary>A serializer whose own declaration failed <see cref="EvaluateGate"/>: nothing past the gate was ever computed.</summary>
+        public static ResolvedSerializer NotEmittable(SerializerInfo serializer, ImmutableArray<DiagnosticSpec> gateDiagnostics)
+        {
+            return new ResolvedSerializer(
+                serializer,
+                isEmittable: false,
+                gateDiagnostics: gateDiagnostics,
+                resolvedMessagesByType: ImmutableDictionary<string, MessageInfo>.Empty,
+                topLevelMessages: ClosedSet.Empty,
+                reachableMessages: ImmutableArray<MessageInfo>.Empty,
+                resolvedClosedGenericRegistrations: ImmutableArray<ClosedGenericRegistrationInfo>.Empty,
+                usedFormatters: ImmutableArray<FormatterInfo>.Empty,
+                unionPlan: UnionPlan.Empty,
+                validationDiagnostics: ImmutableArray<DiagnosticSpec>.Empty);
+        }
+
+        /// <summary>A serializer that cleared <see cref="EvaluateGate"/>, with its fully resolved message table and dispatch plans.</summary>
+        public static ResolvedSerializer Emittable(
+            SerializerInfo serializer,
+            ImmutableArray<DiagnosticSpec> gateDiagnostics,
+            ImmutableDictionary<string, MessageInfo> resolvedMessagesByType,
+            ClosedSet topLevelMessages,
+            ImmutableArray<MessageInfo> reachableMessages,
+            ImmutableArray<ClosedGenericRegistrationInfo> resolvedClosedGenericRegistrations,
+            ImmutableArray<FormatterInfo> usedFormatters,
+            UnionPlan unionPlan,
+            ImmutableArray<DiagnosticSpec> validationDiagnostics)
+        {
+            return new ResolvedSerializer(
+                serializer,
+                isEmittable: true,
+                gateDiagnostics,
+                resolvedMessagesByType,
+                topLevelMessages,
+                reachableMessages,
+                resolvedClosedGenericRegistrations,
+                usedFormatters,
+                unionPlan,
+                validationDiagnostics);
+        }
+
+        public bool Equals(ResolvedSerializer? other)
+        {
+            if (ReferenceEquals(this, other))
+                return true;
+
+            if (other is null)
+                return false;
+
+            return IsEmittable == other.IsEmittable
+                && Serializer.Equals(other.Serializer)
+                && TopLevelMessages.Equals(other.TopLevelMessages)
+                && UnionPlan.Equals(other.UnionPlan)
+                && ValueEquality.SequenceEquals(GateDiagnostics, other.GateDiagnostics)
+                && ValueEquality.SequenceEquals(ReachableMessages, other.ReachableMessages)
+                && ValueEquality.SequenceEquals(ResolvedClosedGenericRegistrations, other.ResolvedClosedGenericRegistrations)
+                && ValueEquality.SequenceEquals(UsedFormatters, other.UsedFormatters)
+                && ValueEquality.SequenceEquals(ValidationDiagnostics, other.ValidationDiagnostics)
+                && ValueEquality.DictionaryEquals(ResolvedMessagesByType, other.ResolvedMessagesByType);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as ResolvedSerializer);
+
+        public override int GetHashCode()
+        {
+            var hash = ValueEquality.Seed;
+            hash = ValueEquality.Combine(hash, IsEmittable);
+            hash = ValueEquality.Combine(hash, Serializer.GetHashCode());
+            hash = ValueEquality.Combine(hash, TopLevelMessages.GetHashCode());
+            hash = ValueEquality.Combine(hash, UnionPlan.GetHashCode());
+            hash = ValueEquality.Combine(hash, GateDiagnostics);
+            hash = ValueEquality.Combine(hash, ReachableMessages);
+            hash = ValueEquality.Combine(hash, ResolvedClosedGenericRegistrations);
+            hash = ValueEquality.Combine(hash, UsedFormatters);
+            hash = ValueEquality.Combine(hash, ValidationDiagnostics);
+            hash = ValueEquality.CombineDictionary(hash, ResolvedMessagesByType);
             return hash;
         }
     }

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Validation.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Validation.cs
@@ -48,38 +48,23 @@ public sealed partial class AkkaSerializerGenerator
     /// <summary>
     /// Diagnostics-only output for AKKASG029 (see the comment in <see cref="Initialize"/>). To
     /// preserve the old terminal stage's semantics, a serializer only reaches the coverage scan
-    /// after it passes the same gate <see cref="EmitSerializers"/> runs (see <see cref="EvaluateGate"/>)
-    /// -- evaluated here SILENTLY (its <see cref="SerializerGate.Diagnostics"/> are discarded): the
-    /// emission output above is the one that reports them, and reporting them twice would duplicate
-    /// every pre-coverage diagnostic.
+    /// when it is emittable -- consuming <see cref="ResolvedSerializer.IsEmittable"/> directly
+    /// instead of re-evaluating <see cref="EvaluateGate"/> from the raw collected arrays, now that
+    /// the gate has already been decided once, per serializer, by <see cref="ResolveSerializer"/>.
+    /// <see cref="ResolvedSerializer.GateDiagnostics"/> are NOT reported here (they are reported
+    /// once, by <see cref="EmitResolvedSerializer"/>); reporting them again here would duplicate
+    /// every pre-coverage diagnostic. This output still combines the live <see cref="Compilation"/>
+    /// (AKKASG029's whole-compilation scan genuinely needs it), so it re-runs on every edit exactly
+    /// as before -- only the GATE check underneath it got cheaper.
     /// </summary>
-    private static void ReportProtocolCoverage(
-        SourceProductionContext context,
-        ImmutableArray<SerializerInfo?> serializers,
-        ImmutableArray<MessageInfo?> messages,
-        Compilation compilation)
+    private static void ReportProtocolCoverage(SourceProductionContext context, ResolvedSerializer resolved, Compilation compilation)
     {
-        var duplicateSerializerIds = ComputeDuplicateSerializerIds(serializers);
-        var duplicateProtocolBindings = ComputeDuplicateProtocolBindings(serializers);
-        var genericDefinitions = messages
-            .Where(message => message != null)
-            .Cast<MessageInfo>()
-            .Where(message => message.IsGenericDefinition)
-            .ToImmutableArray();
+        if (!resolved.IsEmittable)
+            return;
 
-        foreach (var serializer in serializers)
-        {
-            if (serializer == null)
-                continue;
-
-            var gate = EvaluateGate(serializer, duplicateSerializerIds, duplicateProtocolBindings, genericDefinitions);
-            if (!gate.IsEmittable)
-                continue;
-
-            var protocolCoverageDiagnostics = ValidateProtocolCoverage(serializer, compilation, context.CancellationToken);
-            foreach (var diagnostic in protocolCoverageDiagnostics)
-                context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(diagnostic));
-        }
+        var protocolCoverageDiagnostics = ValidateProtocolCoverage(resolved.Serializer, compilation, context.CancellationToken);
+        foreach (var diagnostic in protocolCoverageDiagnostics)
+            context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(diagnostic));
     }
 
     private static ImmutableDictionary<int, string> ComputeDuplicateSerializerIds(ImmutableArray<SerializerInfo?> serializers)
@@ -107,17 +92,19 @@ public sealed partial class AkkaSerializerGenerator
     /// <summary>
     /// The per-serializer gate every codegen target must clear before its message table is even
     /// looked at: is the declaration itself usable (name, id, uniqueness, shape, protocol type,
-    /// formatters, closed-generic registrations, generic-definition coverage)? Both
-    /// <see cref="EmitSerializers"/> (which reports <see cref="SerializerGate.Diagnostics"/>) and
-    /// <see cref="ReportProtocolCoverage"/> (which discards them, silently replicating the gate) call
-    /// this SAME method, so the two outputs can never disagree about which serializers are gated out.
-    /// Mirrors the old single-output stage's check order exactly: each step below short-circuits the
-    /// ones after it, but a single step (formatters, closed-generic registrations, generic
-    /// definitions) can itself append more than one diagnostic before failing.
-    /// <paramref name="duplicateSerializerIds"/> and <paramref name="duplicateProtocolBindings"/> are
-    /// precomputed by the caller (each output computes its own copy from the same input array) so a
-    /// serializer that is part of either duplicate group is gated out WITHOUT a diagnostic here --
-    /// that diagnostic was already reported once, in bulk, by the caller.
+    /// formatters, closed-generic registrations, generic-definition coverage)? Called exactly once
+    /// per serializer, by <see cref="ResolveSerializer"/>, whose <see cref="ResolvedSerializer"/>
+    /// result then feeds BOTH <see cref="EmitResolvedSerializer"/> (which reports
+    /// <see cref="ResolvedSerializer.GateDiagnostics"/>) and <see cref="ReportProtocolCoverage"/>
+    /// (which only reads <see cref="ResolvedSerializer.IsEmittable"/>) -- so the two outputs can
+    /// never disagree about which serializers are gated out, without either recomputing the gate
+    /// independently. Mirrors the old single-output stage's check order exactly: each step below
+    /// short-circuits the ones after it, but a single step (formatters, closed-generic
+    /// registrations, generic definitions) can itself append more than one diagnostic before
+    /// failing. <paramref name="duplicateSerializerIds"/> and <paramref name="duplicateProtocolBindings"/>
+    /// are precomputed by the caller (every caller computes its own copy from the same input array)
+    /// so a serializer that is part of either duplicate group is gated out WITHOUT a diagnostic here
+    /// -- that diagnostic is reported once, in bulk, by <see cref="ReportCrossSerializerDiagnostics"/>.
     /// </summary>
     internal static SerializerGate EvaluateGate(
         SerializerInfo serializer,
@@ -183,10 +170,28 @@ public sealed partial class AkkaSerializerGenerator
     }
 
     /// <summary>
-    /// Shared by <see cref="Validate"/> and <see cref="EmitSerializers"/> so both run the exact same
-    /// validation over the exact same <see cref="ResolvedSerializerMessages"/> -- emission calls this
-    /// with a table it also reuses for code generation; <see cref="Validate"/> computes one just for
-    /// the call. <see cref="ValidateClosedGenericProtocolCoverage"/> runs only when
+    /// Test-only entry point for <see cref="ResolveSerializer"/>, with no duplicate-id/duplicate-
+    /// protocol-binding group and no generic-definition list to hand-build: a scenario driving this
+    /// directly (see GeneratorResolveSpec.cs) has exactly the one serializer under test in scope, so
+    /// those three cross-serializer inputs are trivially empty/derived from <paramref name="messages"/>
+    /// itself -- mirroring how <see cref="Validate"/> is <see cref="ResolveSerializer"/>'s
+    /// single-serializer counterpart for validation alone.
+    /// </summary>
+    internal static ResolvedSerializer ResolveSerializerForTests(SerializerInfo serializer, ImmutableArray<MessageInfo> messages)
+    {
+        return ResolveSerializer(
+            serializer,
+            messages,
+            ImmutableDictionary<int, string>.Empty,
+            ImmutableDictionary<string, string>.Empty,
+            ComputeGenericDefinitions(messages));
+    }
+
+    /// <summary>
+    /// Shared by <see cref="Validate"/> and <see cref="ResolveSerializer"/> so both run the exact same
+    /// validation over the exact same <see cref="ResolvedSerializerMessages"/> -- <see cref="ResolveSerializer"/>
+    /// calls this with a table it also reuses for code generation; <see cref="Validate"/> computes one
+    /// just for the call. <see cref="ValidateClosedGenericProtocolCoverage"/> runs only when
     /// <see cref="ValidateMessages"/> found no error, mirroring the old stage's short-circuit exactly
     /// (a message-level error already means nothing will be emitted, so the AKKASG034 coverage scan
     /// over a table already known to be broken is skipped, exactly as before).

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.cs
@@ -32,8 +32,9 @@ namespace Akka.Serialization.V2.Generators;
 //                                             reporting: ValidateMessages, ValidateUnionField,
 //                                             ValidateClosedGenericProtocolCoverage,
 //                                             CollectReachableMessages, the Report* helpers.
-//   AkkaSerializerGenerator.Emission.cs    - source emission: EmitSerializers, Generate*, union
-//                                             helper planning, naming/folding, collision handling.
+//   AkkaSerializerGenerator.Emission.cs    - the per-serializer resolve stage (ResolveSerializer)
+//                                             and source emission: EmitResolvedSerializer, Generate*,
+//                                             union helper planning, naming/folding, collision handling.
 //   AkkaSerializerGenerator.Models.cs      - the model records (SerializerInfo, MessageInfo,
 //                                             FieldInfo, TypeMapping, UnionMemberInfo, ...).
 [Generator]
@@ -52,8 +53,19 @@ public sealed partial class AkkaSerializerGenerator : IIncrementalGenerator
         public const string ExtractedMessages = nameof(ExtractedMessages);
         public const string CollectedMessages = nameof(CollectedMessages);
 
+        /// <summary>
+        /// The per-serializer <see cref="ResolvedSerializer"/> stage: a <c>Select</c> over each
+        /// serializer PLUS the full collected messages array (see <see cref="ResolveSerializer"/>).
+        /// An edit to any message recomputes every serializer's step here -- that dependency cannot
+        /// be avoided, since a message's top-level/reachable status depends on every other message
+        /// too -- but the RESULT for a serializer untouched by the edit compares equal to its
+        /// previous run, which is what lets code emission (registered directly on this stage) skip
+        /// re-emitting that one serializer's file.
+        /// </summary>
+        public const string ResolvedSerializers = nameof(ResolvedSerializers);
+
         public static ImmutableArray<string> All { get; } = ImmutableArray.Create(
-            ExtractedSerializers, CollectedSerializers, ExtractedMessages, CollectedMessages);
+            ExtractedSerializers, CollectedSerializers, ExtractedMessages, CollectedMessages, ResolvedSerializers);
     }
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -78,18 +90,64 @@ public sealed partial class AkkaSerializerGenerator : IIncrementalGenerator
             .Collect()
             .WithTrackingName(TrackingNames.CollectedMessages);
 
-        // Code emission consumes ONLY the collected, value-equatable, symbol-free models -- never
-        // the Compilation. An edit anywhere that does not change an extracted model therefore
-        // reuses the cached emission output instead of regenerating every serializer per keystroke.
+        // The per-serializer resolve stage: each serializer plus ALL collected messages (a message's
+        // top-level/reachable status can only be judged against the full set) resolves, via
+        // ResolveSerializer, to ONE cached, value-equatable ResolvedSerializer. SelectMany splits the
+        // single (serializers, messages) combined value back out into one independently-cached
+        // element per serializer -- the driver diffs each element against its previous run by VALUE
+        // (ResolvedSerializer.Equals), so a serializer whose resolved model is unaffected by an
+        // edit reports Unchanged here even though the whole stage recomputed. See ResolveSerializer's
+        // doc comment for why this dependency shape is unavoidable, and the RegisterSourceOutput
+        // below for why an Unchanged/Cached element here is what makes that serializer's own emitted
+        // file Cached, not just this stage.
+        var resolvedSerializers = serializers
+            .Combine(messages)
+            .SelectMany(static (pair, cancellationToken) =>
+            {
+                var (allSerializers, allMessages) = pair;
+                var duplicateSerializerIds = ComputeDuplicateSerializerIds(allSerializers);
+                var duplicateProtocolBindings = ComputeDuplicateProtocolBindings(allSerializers);
+                var declaredMessages = ComputeDeclaredMessages(allMessages);
+                var genericDefinitions = ComputeGenericDefinitions(declaredMessages);
+
+                var builder = ImmutableArray.CreateBuilder<ResolvedSerializer>();
+                foreach (var serializer in allSerializers)
+                {
+                    if (serializer == null)
+                        continue;
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    builder.Add(ResolveSerializer(serializer, declaredMessages, duplicateSerializerIds, duplicateProtocolBindings, genericDefinitions));
+                }
+
+                return builder.ToImmutable();
+            })
+            .WithTrackingName(TrackingNames.ResolvedSerializers);
+
+        // Code emission consumes ONLY the cached, value-equatable, symbol-free ResolvedSerializer
+        // model -- never the Compilation, and never another serializer's data. Registered on the
+        // VALUES provider (one independent output per serializer) rather than a Collect()'d array,
+        // so editing a message owned by one serializer re-emits only that serializer's file: the
+        // driver skips this callback entirely for any OTHER serializer whose resolved model still
+        // compares equal to last run.
+        context.RegisterSourceOutput(resolvedSerializers, static (ctx, resolved) => EmitResolvedSerializer(ctx, resolved));
+
+        // The cross-serializer diagnostics (AKKASG013 duplicate ids, AKKASG031 duplicate protocol
+        // bindings, AKKASG037 manifest ignored on a generic definition) cannot be attached to any
+        // one serializer's ResolvedSerializer without either duplicating them or picking an
+        // arbitrary "owner" -- see ReportCrossSerializerDiagnostics's doc comment. Reported exactly
+        // once each, from a small diagnostics-only output over the same two collected arrays.
         context.RegisterSourceOutput(
             serializers.Combine(messages),
-            static (ctx, pair) => EmitSerializers(ctx, pair.Left, pair.Right));
+            static (ctx, pair) => ReportCrossSerializerDiagnostics(ctx, pair.Left, pair.Right));
 
         // AKKASG029's whole-compilation protocol-coverage scan (ValidateProtocolCoverage) is the
         // one check that genuinely needs the Compilation ("does any source-declared type implement
         // this protocol interface without [AkkaSerializable]?"), so it lives in this SEPARATE,
         // diagnostics-only output: the Compilation input changes on every edit, but only this cheap
-        // re-scan pays for that -- code emission above stays cached.
+        // re-scan pays for that -- code emission above stays cached. It combines the cached
+        // ResolvedSerializer (for its gate) with the live Compilation (for the scan itself), so a
+        // serializer's own gate is decided once, by ResolveSerializer, and never recomputed here.
         //
         // Design decision: coverage errors no longer gate emission (the old terminal stage skipped
         // AddSource for a serializer whose coverage check failed). This is the standard split for
@@ -99,7 +157,7 @@ public sealed partial class AkkaSerializerGenerator : IIncrementalGenerator
         // while the user fixes the gap) and lets the emission stage surface OTHER diagnostics that
         // the old early-return used to hide until the coverage error was fixed.
         context.RegisterSourceOutput(
-            serializers.Combine(messages).Combine(context.CompilationProvider),
-            static (ctx, tuple) => ReportProtocolCoverage(ctx, tuple.Left.Left, tuple.Left.Right, tuple.Right));
+            resolvedSerializers.Combine(context.CompilationProvider),
+            static (ctx, pair) => ReportProtocolCoverage(ctx, pair.Left, pair.Right));
     }
 }

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorIncrementalCachingSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorIncrementalCachingSpec.cs
@@ -146,7 +146,12 @@ public sealed class GeneratorIncrementalCachingSpec
         // ...and, stronger, every named pipeline stage must have been served from cache
         // (Cached: not re-run; Unchanged: re-run but produced an equal value). Any other reason
         // means a model stopped comparing equal across compilations -- a symbol or other
-        // non-equatable state leaked into a cached model.
+        // non-equatable state leaked into a cached model. This loop over TrackingNames.All already
+        // covers ResolvedSerializers (the per-serializer resolve stage added in the S3 architecture
+        // pass) automatically -- see the dedicated assertion below for what "reused" means for THAT
+        // stage specifically: its cached ResolvedSerializer model must exercise every cached shape
+        // this fixture declares (formatter, closed generic registration, union, collections, plain
+        // scalar fields -- see SerializerSource's doc comment) without any of them defeating equality.
         var trackedSteps = secondRun.Results.Single().TrackedSteps;
         foreach (var trackingName in AkkaSerializerGenerator.TrackingNames.All)
         {
@@ -160,6 +165,16 @@ public sealed class GeneratorIncrementalCachingSpec
                 }
             }
         }
+
+        // ResolvedSerializers specifically: exactly one resolved model (SampleSerializer, the
+        // fixture's only [AkkaSerializer]), and it must be marked emittable -- a false-Cached read
+        // that silently skipped over a broken/non-emittable model would defeat the point of this
+        // guard.
+        var resolvedSerializerReasons = trackedSteps[AkkaSerializerGenerator.TrackingNames.ResolvedSerializers]
+            .SelectMany(step => step.Outputs)
+            .ToList();
+        resolvedSerializerReasons.Should().HaveCount(1);
+        ((AkkaSerializerGenerator.ResolvedSerializer)resolvedSerializerReasons[0].Value).IsEmittable.Should().BeTrue();
     }
 
     [Fact(DisplayName = "Generator should emit source alongside an AKKASG029 coverage error")]

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorIncrementalScenariosSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorIncrementalScenariosSpec.cs
@@ -107,16 +107,20 @@ public sealed class GeneratorIncrementalScenariosSpec
     [Fact(DisplayName = "Tracked pipeline stages should match TrackingNames.All exactly (a new stage must update this spec)")]
     public void TrackingNames_should_match_expected_stage_count()
     {
-        // Pins today's stage count. Adding a fifth (or removing one) named pipeline stage is a
+        // Pins today's stage count. Adding a sixth (or removing one) named pipeline stage is a
         // deliberate architectural change -- this assertion makes it fail loudly here instead of
-        // only surfacing as a silent gap in the scenarios below.
-        AkkaSerializerGenerator.TrackingNames.All.Should().HaveCount(4);
+        // only surfacing as a silent gap in the scenarios below. ResolvedSerializers (the
+        // per-serializer resolve stage from the S3 architecture pass) is the fifth: it was ADDED
+        // downstream of the four stages above, which is why scenarios (a)/(c)/(d)/(e) below still
+        // pin the exact same reasons for those four as before.
+        AkkaSerializerGenerator.TrackingNames.All.Should().HaveCount(5);
         AkkaSerializerGenerator.TrackingNames.All.Should().BeEquivalentTo(new[]
         {
             AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
             AkkaSerializerGenerator.TrackingNames.CollectedSerializers,
             AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
-            AkkaSerializerGenerator.TrackingNames.CollectedMessages
+            AkkaSerializerGenerator.TrackingNames.CollectedMessages,
+            AkkaSerializerGenerator.TrackingNames.ResolvedSerializers
         });
     }
 
@@ -152,12 +156,18 @@ public sealed class GeneratorIncrementalScenariosSpec
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
 
+        // ResolvedSerializers' own input (serializers.Combine(messages)) is unchanged (both
+        // component values are the SAME cached references as before), so the SelectMany transform
+        // is skipped entirely for both serializers -- Cached, not merely Unchanged.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
+
         // TARGET: none -- this IS the caching discipline PR 1 pins as the baseline; PRs 2, 3, 5, 6
         // must not regress it. No hint name's text should change.
         ChangedHintNames(result).Should().BeEmpty();
     }
 
-    [Fact(DisplayName = "Scenario (b): renaming one message's field re-emits every serializer's output, byte-identically except the affected one")]
+    [Fact(DisplayName = "Scenario (b): renaming one message's field re-emits only the serializer that owns it")]
     public void Scenario_b_message_field_renamed()
     {
         var result = GeneratorTestHarness.RunIncremental(FixtureSource, FixtureWithAlphaTwoFieldRenamed);
@@ -176,12 +186,24 @@ public sealed class GeneratorIncrementalScenariosSpec
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Modified);
 
-        // TARGET: only AlphaSerializer's generated file should change once emission is split
-        // per-serializer (PR 3/5). Today EmitSerializers is ONE RegisterSourceOutput over the whole
-        // (serializers, messages) pair, so it re-executes and re-emits BOTH generated files on any
-        // message edit -- but BetaSerializer's re-emitted text is nonetheless byte-identical to
-        // before (it does not depend on AlphaTwo), so it is correctly excluded from the CHANGED set
-        // computed here (text-equality, not "did this hint name get touched by AddSource again").
+        // THE SCENARIO FLIP (S3): CollectedMessages changing forces the ResolvedSerializers
+        // SelectMany transform to rerun for EVERY serializer (its input, serializers.Combine(messages),
+        // changed) -- but AlphaSerializer is declared first and BetaSerializer second, and only
+        // AlphaSerializer's resolve actually OWNS AlphaTwo, so only ITS resulting ResolvedSerializer
+        // differs (Modified). BetaSerializer's resolved model, though recomputed, compares EQUAL to
+        // its previous run (Unchanged) -- ResolvedSerializer.ResolvedMessagesByType is deliberately
+        // scoped to each serializer's OWN reachable messages (see BuildResolvedMessageTable), so it
+        // is never poisoned by an unrelated serializer's message.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
+            IncrementalStepRunReason.Modified, IncrementalStepRunReason.Unchanged);
+
+        // Because RegisterSourceOutput is now registered directly on the ResolvedSerializers values
+        // provider (one independent output per serializer, not one output over the whole collected
+        // pair), BetaSerializer's Unchanged resolved model means its AddSource callback is never
+        // re-invoked at all (Cached) -- unlike the pre-S3 architecture, where EmitSerializers's
+        // single RegisterSourceOutput re-executed for BOTH serializers on any message edit and
+        // merely happened to re-emit byte-identical text for Beta. Only AlphaSerializer's generated
+        // file changes here.
         ChangedHintNames(result).Should().BeEquivalentTo(new[] { "AlphaSerializer.AkkaSerialization.g.cs" });
     }
 
@@ -202,6 +224,11 @@ public sealed class GeneratorIncrementalScenariosSpec
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
+
+        // Same as scenario (a): ResolvedSerializers' input is unchanged, so both serializers' resolve
+        // steps are skipped entirely (Cached).
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
 
         // TARGET: unchanged from today -- a comment-only edit re-emitting nothing is already the
         // desired behavior; no migration PR needs to touch this.
@@ -225,18 +252,24 @@ public sealed class GeneratorIncrementalScenariosSpec
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
+
+        // Same as scenario (a): ResolvedSerializers' input is unchanged, so both serializers' resolve
+        // steps are skipped entirely (Cached).
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
         ChangedHintNames(result).Should().BeEmpty();
 
         // TARGET: the coverage scan (AKKASG029, ReportProtocolCoverage) is registered on
-        // serializers.Combine(messages).Combine(context.CompilationProvider) with NO tracking
-        // name -- it is not gated by the same equality contract as the four named stages above, and
+        // resolvedSerializers.Combine(context.CompilationProvider) with NO tracking name of its
+        // own -- it is not gated by the same equality contract as the five named stages above, and
         // is not observable through GetRunResult().Results[0].TrackedSteps at all. OBSERVED today:
         // it produces the SAME (empty) diagnostics both before and after this trivial edit -- the
         // fixture is coverage-clean -- which is the externally-visible half of "it still re-runs
         // every time": the CompilationProvider input this output depends on changes identity on
         // every edit, so the scan re-executes on this one too, it just has nothing new to report.
-        // PR 5/6 (moving coverage scanning onto the cached message/serializer models instead of the
-        // raw Compilation) is expected to make this scan cacheable too.
+        // As of S3, this scan's per-serializer GATE check is read straight off the cached
+        // ResolvedSerializer instead of being recomputed -- only the whole-compilation scan itself
+        // still re-runs every time, which is unavoidable (it genuinely needs the live Compilation).
         result.Before.CompileDiagnostics.Where(d => d.Id == "AKKASG029").Should().BeEmpty();
         result.After.CompileDiagnostics.Where(d => d.Id == "AKKASG029").Should().BeEmpty();
         result.Before.RunResult.Diagnostics.Where(d => d.Id == "AKKASG029").Should().BeEmpty();
@@ -264,6 +297,11 @@ public sealed class GeneratorIncrementalScenariosSpec
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
+
+        // Same as scenario (a): ResolvedSerializers' input is unchanged, so both serializers' resolve
+        // steps are skipped entirely (Cached).
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
 
         // TARGET: unchanged from today -- an unused added reference re-emitting nothing is already
         // the desired behavior; no migration PR needs to touch this.

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorResolveSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorResolveSpec.cs
@@ -1,0 +1,297 @@
+//-----------------------------------------------------------------------
+// <copyright file="GeneratorResolveSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Akka.Serialization.V2.Generators;
+using Akka.Serialization.V2.Tests.Harness;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// Exercises <see cref="AkkaSerializerGenerator.ResolveSerializerForTests"/> -- the test-only entry
+/// point for <see cref="AkkaSerializerGenerator.ResolveSerializer"/>, the S3 architecture pass's
+/// per-serializer resolve stage -- directly on models, with no <see cref="SourceProductionContext"/>,
+/// driver, or generator run. Message models come from <see cref="AkkaSerializerGenerator.ParseMessageForTests"/>
+/// (same as <see cref="GeneratorValidatorSpec"/>); <see cref="AkkaSerializerGenerator.SerializerInfo"/>
+/// values are hand-built. Covers the shape of the resolved model itself (closed set order, top-level
+/// set, reachable set, union plan) and the equality property the whole S3 caching story depends on:
+/// two resolves over equal inputs are equal, and a change to a message an unrelated serializer does
+/// not own leaves that serializer's own resolved model unaffected.
+/// </summary>
+public sealed class GeneratorResolveSpec
+{
+    [Fact(DisplayName = "ResolveSerializer should build the top-level closed set in declaration order")]
+    public void ResolveSerializer_should_build_top_level_closed_set_in_declaration_order()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Serialization.V2;
+
+            namespace ResolveSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializable(Manifest = "third-v1")]
+            public sealed record Third([property: AkkaField(1)] string Value) : IProtocol;
+
+            [AkkaSerializable(Manifest = "first-v1")]
+            public sealed record First([property: AkkaField(1)] string Value) : IProtocol;
+
+            [AkkaSerializable(Manifest = "second-v1")]
+            public sealed record Second([property: AkkaField(1)] string Value) : IProtocol;
+            """;
+
+        var compilation = Compile(source);
+        var serializer = BuildSerializerInfo(ProtocolFullName(compilation));
+        var third = ParseMessage(compilation, "ResolveSample.Third");
+        var first = ParseMessage(compilation, "ResolveSample.First");
+        var second = ParseMessage(compilation, "ResolveSample.Second");
+
+        // Declared in the order Third, First, Second -- the closed set must preserve exactly that
+        // order (the same order the emitted Manifest/Serialize/Deserialize switches have always
+        // used), not alphabetical or manifest order.
+        var resolved = AkkaSerializerGenerator.ResolveSerializerForTests(serializer, ImmutableArray.Create(third, first, second));
+
+        resolved.IsEmittable.Should().BeTrue();
+        resolved.TopLevelMessages.Members.Select(m => m.TypeFullName).Should().ContainInOrder(
+            third.FullyQualifiedName, first.FullyQualifiedName, second.FullyQualifiedName);
+        resolved.TopLevelMessages.Members.Select(m => m.Manifest).Should().ContainInOrder("third-v1", "first-v1", "second-v1");
+        resolved.TopLevelMessages.Members.Select(m => m.MethodName).Should().ContainInOrder("Third", "First", "Second");
+    }
+
+    [Fact(DisplayName = "ResolveSerializer should compute the reachable set, including a nested message that is not itself top-level")]
+    public void ResolveSerializer_should_compute_reachable_set()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Serialization.V2;
+
+            namespace ResolveSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializable]
+            public sealed record Nested([property: AkkaField(1)] string Value);
+
+            [AkkaSerializable(Manifest = "outer-v1")]
+            public sealed record Outer([property: AkkaField(1)] Nested Inner) : IProtocol;
+            """;
+
+        var compilation = Compile(source);
+        var serializer = BuildSerializerInfo(ProtocolFullName(compilation));
+        var outer = ParseMessage(compilation, "ResolveSample.Outer");
+        var nested = ParseMessage(compilation, "ResolveSample.Nested");
+
+        var resolved = AkkaSerializerGenerator.ResolveSerializerForTests(serializer, ImmutableArray.Create(outer, nested));
+
+        // Nested is reachable (Outer's field references it) but is NOT top-level -- it does not
+        // implement IProtocol.
+        resolved.TopLevelMessages.Members.Select(m => m.TypeFullName).Should().Equal(outer.FullyQualifiedName);
+        resolved.ReachableMessages.Select(m => m.FullyQualifiedName).Should().BeEquivalentTo(new[] { outer.FullyQualifiedName, nested.FullyQualifiedName });
+        resolved.ResolvedMessagesByType.Keys.Should().BeEquivalentTo(new[] { outer.FullyQualifiedName, nested.FullyQualifiedName });
+    }
+
+    [Fact(DisplayName = "ResolveSerializer should plan one union helper with members in declared order")]
+    public void ResolveSerializer_should_plan_union_helper()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Serialization.V2;
+
+            namespace ResolveSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaUnion(typeof(MemberB), typeof(MemberA))]
+            public interface IEvent
+            {
+            }
+
+            [AkkaSerializable(Manifest = "member-b-v1")]
+            public sealed record MemberB([property: AkkaField(1)] string Value) : IEvent;
+
+            [AkkaSerializable(Manifest = "member-a-v1")]
+            public sealed record MemberA([property: AkkaField(1)] string Value) : IEvent;
+
+            [AkkaSerializable(Manifest = "outer-v1")]
+            public sealed record Outer([property: AkkaField(1)] IEvent Event) : IProtocol;
+            """;
+
+        var compilation = Compile(source);
+        var serializer = BuildSerializerInfo(ProtocolFullName(compilation));
+        var outer = ParseMessage(compilation, "ResolveSample.Outer");
+        var memberA = ParseMessage(compilation, "ResolveSample.MemberA");
+        var memberB = ParseMessage(compilation, "ResolveSample.MemberB");
+
+        var resolved = AkkaSerializerGenerator.ResolveSerializerForTests(serializer, ImmutableArray.Create(outer, memberA, memberB));
+
+        resolved.UnionPlan.Helpers.Should().HaveCount(1);
+        var helper = resolved.UnionPlan.Helpers[0];
+        helper.HelperName.Should().Be("Union_IEvent");
+        helper.FieldTypeFullName.Should().Be(outer.Fields.Single().TypeFullName);
+
+        // [AkkaUnion(typeof(MemberB), typeof(MemberA))] declares MemberB first -- the plan's member
+        // order must match the attribute's declaration order, not source-declaration or alphabetical
+        // order.
+        helper.Members.Members.Select(m => m.TypeFullName).Should().ContainInOrder(memberB.FullyQualifiedName, memberA.FullyQualifiedName);
+        helper.Members.Members.Select(m => m.Manifest).Should().ContainInOrder("member-b-v1", "member-a-v1");
+        helper.Members.Members.Select(m => m.MethodName).Should().ContainInOrder("MemberB", "MemberA");
+    }
+
+    [Fact(DisplayName = "Two resolves over equal inputs should be equal")]
+    public void ResolveSerializer_should_be_value_equatable_across_equal_inputs()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Serialization.V2;
+
+            namespace ResolveSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializable(Manifest = "outer-v1")]
+            public sealed record Outer([property: AkkaField(1)] string Value) : IProtocol;
+            """;
+
+        // Two SEPARATE compilations of the identical source: proves the resolved model's equality
+        // is genuinely structural (never relies on symbol/object identity surviving from one
+        // compilation into the next), exactly what the incremental pipeline needs across two
+        // generator runs.
+        var compilationOne = Compile(source);
+        var compilationTwo = Compile(source);
+        var serializer = BuildSerializerInfo(ProtocolFullName(compilationOne));
+
+        var resolvedOne = AkkaSerializerGenerator.ResolveSerializerForTests(serializer, ImmutableArray.Create(ParseMessage(compilationOne, "ResolveSample.Outer")));
+        var resolvedTwo = AkkaSerializerGenerator.ResolveSerializerForTests(serializer, ImmutableArray.Create(ParseMessage(compilationTwo, "ResolveSample.Outer")));
+
+        resolvedOne.Equals(resolvedTwo).Should().BeTrue();
+        resolvedOne.GetHashCode().Should().Be(resolvedTwo.GetHashCode());
+    }
+
+    [Fact(DisplayName = "A change to an unrelated message's field should yield an equal resolved model for a serializer that does not own it")]
+    public void ResolveSerializer_should_be_unaffected_by_an_unowned_message_change()
+    {
+        const string sourceBefore = """
+            #nullable enable
+            using Akka.Serialization.V2;
+
+            namespace ResolveSample;
+
+            public interface IAlphaProtocol
+            {
+            }
+
+            public interface IBetaProtocol
+            {
+            }
+
+            [AkkaSerializable(Manifest = "alpha-v1")]
+            public sealed record AlphaMessage([property: AkkaField(1)] int Count) : IAlphaProtocol;
+
+            [AkkaSerializable(Manifest = "beta-v1")]
+            public sealed record BetaMessage([property: AkkaField(1)] string Label) : IBetaProtocol;
+            """;
+
+        // AlphaMessage's field renamed -- the edit scenario this resolve stage exists to isolate.
+        // BetaMessage is untouched.
+        const string sourceAfter = """
+            #nullable enable
+            using Akka.Serialization.V2;
+
+            namespace ResolveSample;
+
+            public interface IAlphaProtocol
+            {
+            }
+
+            public interface IBetaProtocol
+            {
+            }
+
+            [AkkaSerializable(Manifest = "alpha-v1")]
+            public sealed record AlphaMessage([property: AkkaField(1)] int Total) : IAlphaProtocol;
+
+            [AkkaSerializable(Manifest = "beta-v1")]
+            public sealed record BetaMessage([property: AkkaField(1)] string Label) : IBetaProtocol;
+            """;
+
+        var compilationBefore = Compile(sourceBefore);
+        var compilationAfter = Compile(sourceAfter);
+
+        var betaSerializer = BuildSerializerInfo(ProtocolFullName(compilationBefore, "ResolveSample.IBetaProtocol"), className: "BetaSerializer");
+
+        var messagesBefore = ImmutableArray.Create(
+            ParseMessage(compilationBefore, "ResolveSample.AlphaMessage"),
+            ParseMessage(compilationBefore, "ResolveSample.BetaMessage"));
+        var messagesAfter = ImmutableArray.Create(
+            ParseMessage(compilationAfter, "ResolveSample.AlphaMessage"),
+            ParseMessage(compilationAfter, "ResolveSample.BetaMessage"));
+
+        // Sanity check: AlphaMessage really did change between the two message arrays -- otherwise
+        // this test would trivially pass for the wrong reason.
+        messagesBefore[0].Should().NotBe(messagesAfter[0]);
+
+        var betaResolvedBefore = AkkaSerializerGenerator.ResolveSerializerForTests(betaSerializer, messagesBefore);
+        var betaResolvedAfter = AkkaSerializerGenerator.ResolveSerializerForTests(betaSerializer, messagesAfter);
+
+        betaResolvedBefore.Equals(betaResolvedAfter).Should().BeTrue(
+            "BetaSerializer does not own AlphaMessage, so its resolved model must not change shape when AlphaMessage does");
+        betaResolvedBefore.GetHashCode().Should().Be(betaResolvedAfter.GetHashCode());
+    }
+
+    private static Compilation Compile(string source)
+    {
+        return GeneratorTestHarness.Run(source).OutputCompilation;
+    }
+
+    private static string ProtocolFullName(Compilation compilation, string metadataName = "ResolveSample.IProtocol")
+    {
+        var symbol = compilation.GetTypeByMetadataName(metadataName)
+            ?? throw new InvalidOperationException($"Could not resolve '{metadataName}' in the harness compilation.");
+        return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+    }
+
+    private static AkkaSerializerGenerator.MessageInfo ParseMessage(Compilation compilation, string metadataName)
+    {
+        var symbol = compilation.GetTypeByMetadataName(metadataName)
+            ?? throw new InvalidOperationException($"Could not resolve '{metadataName}' in the harness compilation.");
+        return AkkaSerializerGenerator.ParseMessageForTests(symbol, compilation)
+            ?? throw new InvalidOperationException($"'{metadataName}' was not recognized as [AkkaSerializable].");
+    }
+
+    private static AkkaSerializerGenerator.SerializerInfo BuildSerializerInfo(string protocolTypeFullName, string className = "TestSerializer")
+    {
+        return new AkkaSerializerGenerator.SerializerInfo(
+            ns: "ResolveSample",
+            className: className,
+            fullyQualifiedName: $"global::ResolveSample.{className}",
+            name: "test-serializer",
+            serializerId: 1,
+            protocolTypeFullName: protocolTypeFullName,
+            protocolTypeIsInterface: true,
+            declaredAccessibility: Accessibility.Public,
+            formatters: ImmutableArray<AkkaSerializerGenerator.FormatterInfo>.Empty,
+            closedGenericRegistrations: ImmutableArray<AkkaSerializerGenerator.ClosedGenericRegistrationInfo>.Empty,
+            isPartial: true,
+            isGeneric: false,
+            derivesFromAkkaSerializerBase: true);
+    }
+}

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorResolvedSerializerSnapshotSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorResolvedSerializerSnapshotSpec.cs
@@ -1,0 +1,177 @@
+//-----------------------------------------------------------------------
+// <copyright file="GeneratorResolvedSerializerSnapshotSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Serialization.V2.Generators;
+using Akka.Serialization.V2.Tests.Harness;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using VerifyXunit;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// Snapshot gate for the S3 architecture pass's per-serializer resolve stage
+/// (<see cref="AkkaSerializerGenerator.ResolveSerializer"/>) -- the counterpart of
+/// <see cref="GeneratorMessageModelSnapshotSpec"/> (which snapshots extraction) and
+/// <see cref="GeneratorGoldenOutputSpec"/> (which snapshots emitted text). Extracts every real
+/// <c>[AkkaSerializer]</c> and <c>[AkkaSerializable]</c> declaration in the exact same golden corpus
+/// (reused from <see cref="GeneratorGoldenOutputSpec.GoldenSource"/>/<see cref="GeneratorGoldenOutputSpec.GlobalNamespaceSource"/>,
+/// never a parallel copy) through the SAME test-only entry points
+/// (<see cref="AkkaSerializerGenerator.ExtractSerializerForTests"/>/<see cref="AkkaSerializerGenerator.ParseMessageForTests"/>)
+/// that wrap the pipeline's real, UNMODIFIED extraction routines, resolves each serializer with
+/// <see cref="AkkaSerializerGenerator.ResolveSerializerForTests"/>, and snapshots a stable,
+/// human-readable rendering of the RESOLVED model: gate result, top-level closed set, reachable set,
+/// resolved closed-generic registrations, used formatters, union plan, and validation diagnostics.
+/// This is a rendering of the MODEL, not the emitted code -- <see cref="GeneratorGoldenOutputSpec"/>
+/// already gates emitted text separately, and byte-identical output is a hard requirement this spec
+/// does not touch.
+/// </summary>
+public sealed class GeneratorResolvedSerializerSnapshotSpec
+{
+    private static readonly string[] SerializerNames = { "GoldenSerializer", "MiniSerializer", "RootSerializer" };
+
+    [Fact(DisplayName = "Resolved serializer models for the golden corpus should match their committed snapshot")]
+    public Task Resolved_serializers_should_match_committed_snapshot()
+    {
+        var result = GeneratorTestHarness.Run(new[]
+        {
+            new SourceFile("GoldenSample.cs", GeneratorGoldenOutputSpec.GoldenSource),
+            new SourceFile("GlobalSample.cs", GeneratorGoldenOutputSpec.GlobalNamespaceSource)
+        });
+
+        var compilation = result.OutputCompilation;
+        var serializableAttributeType = compilation.GetTypeByMetadataName(typeof(AkkaSerializableAttribute).FullName!)
+            ?? throw new InvalidOperationException($"Could not resolve {typeof(AkkaSerializableAttribute).FullName} in the harness compilation.");
+
+        var messageSymbols = new List<INamedTypeSymbol>();
+        var serializerSymbolsByName = new Dictionary<string, INamedTypeSymbol>(StringComparer.Ordinal);
+        foreach (var filePath in new[] { "GoldenSample.cs", "GlobalSample.cs" })
+        {
+            var tree = compilation.SyntaxTrees.Single(t => t.FilePath == filePath);
+            var model = compilation.GetSemanticModel(tree);
+            foreach (var typeDecl in tree.GetRoot().DescendantNodes().OfType<TypeDeclarationSyntax>())
+            {
+                if (model.GetDeclaredSymbol(typeDecl) is not INamedTypeSymbol symbol)
+                    continue;
+
+                if (symbol.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, serializableAttributeType)))
+                    messageSymbols.Add(symbol);
+
+                if (SerializerNames.Contains(symbol.Name, StringComparer.Ordinal))
+                    serializerSymbolsByName[symbol.Name] = symbol;
+            }
+        }
+
+        var messages = messageSymbols
+            .Select(symbol => AkkaSerializerGenerator.ParseMessageForTests(symbol, compilation))
+            .Where(message => message != null)
+            .Cast<AkkaSerializerGenerator.MessageInfo>()
+            .ToImmutableArray();
+
+        var document = string.Join(
+            Environment.NewLine + new string('=', 80) + Environment.NewLine,
+            SerializerNames
+                .Select(name => serializerSymbolsByName[name])
+                .Select(symbol =>
+                {
+                    var serializer = AkkaSerializerGenerator.ExtractSerializerForTests(symbol, compilation)
+                        ?? throw new InvalidOperationException($"'{symbol.Name}' was not recognized as [AkkaSerializer].");
+                    var resolved = AkkaSerializerGenerator.ResolveSerializerForTests(serializer, messages);
+                    return RenderResolvedSerializer(resolved);
+                }));
+
+        return Verifier.Verify(document)
+            .UseDirectory("MessageModelSnapshots")
+            .UseFileName("GoldenCorpusResolvedSerializers");
+    }
+
+    private static string RenderResolvedSerializer(AkkaSerializerGenerator.ResolvedSerializer resolved)
+    {
+        var sb = new StringBuilder();
+        var serializer = resolved.Serializer;
+
+        sb.AppendLine($"Serializer: {serializer.ClassName} (ns={serializer.Namespace}, name={serializer.Name}, id={serializer.SerializerId})");
+        sb.AppendLine($"Protocol: {(serializer.ProtocolTypeFullName.Length == 0 ? "(none)" : serializer.ProtocolTypeFullName)}");
+        sb.AppendLine($"IsEmittable: {resolved.IsEmittable}");
+
+        if (!resolved.GateDiagnostics.IsDefaultOrEmpty)
+        {
+            sb.AppendLine("GateDiagnostics:");
+            foreach (var diagnostic in resolved.GateDiagnostics)
+                sb.AppendLine($"  {RenderDiagnostic(diagnostic)}");
+        }
+
+        if (!resolved.IsEmittable)
+            return sb.ToString();
+
+        sb.AppendLine("TopLevelMessages (closed set, declaration order):");
+        if (resolved.TopLevelMessages.Members.IsDefaultOrEmpty)
+        {
+            sb.AppendLine("  (none)");
+        }
+        else
+        {
+            foreach (var member in resolved.TopLevelMessages.Members)
+                sb.AppendLine($"  {member.TypeFullName} (manifest={member.Manifest}, method={member.MethodName})");
+        }
+
+        sb.AppendLine($"ReachableMessages ({resolved.ReachableMessages.Length}, reachability-walk order):");
+        foreach (var message in resolved.ReachableMessages)
+            sb.AppendLine($"  {message.FullyQualifiedName}");
+
+        sb.AppendLine("ResolvedMessagesByType keys (sorted):");
+        foreach (var key in resolved.ResolvedMessagesByType.Keys.OrderBy(k => k, StringComparer.Ordinal))
+            sb.AppendLine($"  {key}");
+
+        if (!resolved.ResolvedClosedGenericRegistrations.IsDefaultOrEmpty)
+        {
+            sb.AppendLine("ResolvedClosedGenericRegistrations:");
+            foreach (var registration in resolved.ResolvedClosedGenericRegistrations)
+                sb.AppendLine($"  {registration.TargetDisplayName} -> {(registration.Message == null ? "(invalid)" : registration.Message.FullyQualifiedName)}");
+        }
+
+        if (!resolved.UsedFormatters.IsDefaultOrEmpty)
+        {
+            sb.AppendLine("UsedFormatters:");
+            foreach (var formatter in resolved.UsedFormatters)
+                sb.AppendLine($"  {formatter.TargetTypeFullName} -> {formatter.FormatterTypeFullName} (ctorKind={formatter.CtorKind})");
+        }
+
+        if (!resolved.UnionPlan.Helpers.IsDefaultOrEmpty)
+        {
+            sb.AppendLine("UnionPlan:");
+            foreach (var helper in resolved.UnionPlan.Helpers)
+            {
+                sb.AppendLine($"  {helper.HelperName} (fieldType={helper.FieldTypeFullName}, signature={helper.Signature}):");
+                foreach (var member in helper.Members.Members)
+                    sb.AppendLine($"    {member.TypeFullName} (manifest={member.Manifest}, method={member.MethodName})");
+            }
+        }
+
+        if (!resolved.ValidationDiagnostics.IsDefaultOrEmpty)
+        {
+            sb.AppendLine("ValidationDiagnostics:");
+            foreach (var diagnostic in resolved.ValidationDiagnostics)
+                sb.AppendLine($"  {RenderDiagnostic(diagnostic)}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string RenderDiagnostic(AkkaSerializerGenerator.DiagnosticSpec diagnostic)
+    {
+        return $"{diagnostic.Key}({string.Join(", ", diagnostic.MessageArgs)})";
+    }
+}

--- a/src/core/Akka.Serialization.V2.Tests/MessageModelSnapshots/GoldenCorpusResolvedSerializers.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/MessageModelSnapshots/GoldenCorpusResolvedSerializers.verified.txt
@@ -1,0 +1,91 @@
+﻿Serializer: GoldenSerializer (ns=GoldenSample, name=golden-sample, id=150101)
+Protocol: global::GoldenSample.IProtocol
+IsEmittable: True
+TopLevelMessages (closed set, declaration order):
+  global::GoldenSample.ScalarMessage (manifest=scalars-v1, method=ScalarMessage)
+  global::GoldenSample.CollectionMessage (manifest=collections-v1, method=CollectionMessage)
+  global::GoldenSample.UnionMessage (manifest=union-v1, method=UnionMessage)
+  global::GoldenSample.EnvelopeMessage (manifest=envelope-v1, method=EnvelopeMessage)
+  global::GoldenSample.HybridMessage (manifest=hybrid-v1, method=HybridMessage)
+  global::GoldenSample.NestedMessage (manifest=nested-v1, method=NestedMessage)
+  global::GoldenSample.Ping (manifest=ping-v1, method=Ping)
+  global::GoldenSample.StructMessage (manifest=struct-msg-v1, method=StructMessage)
+  global::GoldenSample.EscapedManifestMessage (manifest=esc-"quote"-\-v1, method=EscapedManifestMessage)
+  global::GoldenSample.Wrapper<int> (manifest=wrapper-int-v1, method=WrapperInt)
+  global::GoldenSample.Wrapper<global::GoldenSample.GeoPoint> (manifest=wrapper-geo-v1, method=WrapperGeoPoint)
+  global::GoldenSample.Wrapper<global::GoldenSample.Pair<int, string>> (manifest=wrapper-pair-v1, method=WrapperPairIntString)
+ReachableMessages (18, reachability-walk order):
+  global::GoldenSample.ScalarMessage
+  global::GoldenSample.CollectionMessage
+  global::GoldenSample.UnionMessage
+  global::GoldenSample.EnvelopeMessage
+  global::GoldenSample.HybridMessage
+  global::GoldenSample.NestedMessage
+  global::GoldenSample.Ping
+  global::GoldenSample.StructMessage
+  global::GoldenSample.EscapedManifestMessage
+  global::GoldenSample.Wrapper<int>
+  global::GoldenSample.Wrapper<global::GoldenSample.GeoPoint>
+  global::GoldenSample.Wrapper<global::GoldenSample.Pair<int, string>>
+  global::GoldenSample.Reading
+  global::GoldenSample.GeoPoint
+  global::GoldenSample.OrderPlaced
+  global::GoldenSample.OrderCancelled
+  global::GoldenSample.OrderExpired
+  global::GoldenSample.Pair<int, string>
+ResolvedMessagesByType keys (sorted):
+  global::GoldenSample.CollectionMessage
+  global::GoldenSample.EnvelopeMessage
+  global::GoldenSample.EscapedManifestMessage
+  global::GoldenSample.GeoPoint
+  global::GoldenSample.HybridMessage
+  global::GoldenSample.NestedMessage
+  global::GoldenSample.OrderCancelled
+  global::GoldenSample.OrderExpired
+  global::GoldenSample.OrderPlaced
+  global::GoldenSample.Pair<int, string>
+  global::GoldenSample.Ping
+  global::GoldenSample.Reading
+  global::GoldenSample.ScalarMessage
+  global::GoldenSample.StructMessage
+  global::GoldenSample.UnionMessage
+  global::GoldenSample.Wrapper<global::GoldenSample.GeoPoint>
+  global::GoldenSample.Wrapper<global::GoldenSample.Pair<int, string>>
+  global::GoldenSample.Wrapper<int>
+ResolvedClosedGenericRegistrations:
+  global::GoldenSample.Wrapper<int> -> global::GoldenSample.Wrapper<int>
+  global::GoldenSample.Wrapper<global::GoldenSample.GeoPoint> -> global::GoldenSample.Wrapper<global::GoldenSample.GeoPoint>
+  global::GoldenSample.Wrapper<global::GoldenSample.Pair<int, string>> -> global::GoldenSample.Wrapper<global::GoldenSample.Pair<int, string>>
+  global::GoldenSample.Pair<int, string> -> global::GoldenSample.Pair<int, string>
+UsedFormatters:
+  global::GoldenSample.Foreign -> global::GoldenSample.ForeignFormatter (ctorKind=Parameterless)
+  global::GoldenSample.Temperature -> global::GoldenSample.TemperatureFormatter (ctorKind=System)
+UnionPlan:
+  Union_IOrderEvent (fieldType=global::GoldenSample.IOrderEvent, signature=global::GoldenSample.IOrderEvent|global::GoldenSample.OrderPlaced):
+    global::GoldenSample.OrderPlaced (manifest=order-placed-v1, method=OrderPlaced)
+  Union_IOrderEvent_2 (fieldType=global::GoldenSample.IOrderEvent, signature=global::GoldenSample.IOrderEvent|global::GoldenSample.OrderPlaced|global::GoldenSample.OrderCancelled|global::GoldenSample.OrderExpired):
+    global::GoldenSample.OrderPlaced (manifest=order-placed-v1, method=OrderPlaced)
+    global::GoldenSample.OrderCancelled (manifest=order-cancelled-v1, method=OrderCancelled)
+    global::GoldenSample.OrderExpired (manifest=order-expired-v1, method=OrderExpired)
+
+================================================================================
+Serializer: MiniSerializer (ns=GoldenSample, name=golden-mini, id=150102)
+Protocol: global::GoldenSample.IMiniProtocol
+IsEmittable: True
+TopLevelMessages (closed set, declaration order):
+  global::GoldenSample.MiniMessage (manifest=mini-v1, method=MiniMessage)
+ReachableMessages (1, reachability-walk order):
+  global::GoldenSample.MiniMessage
+ResolvedMessagesByType keys (sorted):
+  global::GoldenSample.MiniMessage
+
+================================================================================
+Serializer: RootSerializer (ns=, name=golden-root, id=150103)
+Protocol: global::IRootProtocol
+IsEmittable: True
+TopLevelMessages (closed set, declaration order):
+  global::RootMessage (manifest=root-v1, method=RootMessage)
+ReachableMessages (1, reachability-walk order):
+  global::RootMessage
+ResolvedMessagesByType keys (sorted):
+  global::RootMessage


### PR DESCRIPTION
> Stack, bottom to top: S1 #8525 -> S2 #8526 -> S3 #8527 -> object elements #8528 -> S4 #8530 -> S5 #8532 -> S6 #8533 -> F1 #8534 -> F2 #8536 -> F3 #8537 -> S7 #8538. Each PR is one commit on top of the one below it. This PR is S3.

## What changes

Renaming a field in a message now regenerates one file, the serializer that owns that message. Before, it regenerated every serializer's file, and the unchanged ones matched byte for byte only by luck. Generated text is byte-identical. No golden, wire, or model snapshot changed. The diagnostic set is unchanged.

- **One cached model per serializer.** `ResolvedSerializer` holds everything emission needs: the gate result, the messages this serializer can reach, the top-level set as a `ClosedSet`, the closed-generic registrations after resolution, formatter overrides, a typed `UnionPlan` in place of a string-keyed dictionary, the derived method names, and the validation diagnostics. It compares by content.
- **Emission reads only that model.** No compilation, no symbols, no other serializer's data. Diagnostics that span serializers (AKKASG013, 031, 037) get their own small output and report once. The protocol-coverage output reads the gate result from the model instead of recomputing it.
- **One `ClosedSet` type** for the top-level dispatch set and the union sets. Decision 18 later expands over this object.

## Why

Roslyn reuses a step's output when its inputs compare equal. A model that holds only what one serializer needs stays equal when another serializer's message changes. A first version stored the whole message table in every serializer's model, and a probe test showed every model changing on every edit.

## Savings

Short run, 5 serializers x 100 messages, machine at moderate load.

| Scenario | S2 | S3 |
|---|---:|---:|
| Fresh driver, full corpus | 75.3 ms, 23.19 MB | 89.8 ms, 22.61 MB |
| One field renamed in one message | 75.8 ms, 23.17 MB | 69.4 ms, 13.15 MB |
| Comment edit inside a message | 60.2 ms, 7.82 MB | 59.1 ms, 7.79 MB |
| Unrelated file edited | 59.0 ms, 7.77 MB | 57.1 ms, 7.76 MB |

The rename row drops from the full-corpus figure to the no-change floor plus one serializer's emission. Wall clock carries noise at this load.

## How it was checked

Scenario b in the caching tests flips: the rename runs one serializer's emit step, and the other never runs. 293 tests pass (287 plus 6): resolve tests on models with no driver, and a Verify snapshot of each serializer's resolved model over the golden corpus. Generator builds with warnings as errors. `Akka.Remote` builds.

## Known follow-up

The protocol-coverage scan (AKKASG029) now runs once per serializer instead of once per compilation. Same output, more scanning when a project has several serializers. S5 moves it into one cached step.
