### PR TITLE
Treat object elements inside collections the same as an object field

### DIFF
--- a/openspec/changes/messagepack-sourcegen-validation/specs/messagepack-sourcegen/spec.md
+++ b/openspec/changes/messagepack-sourcegen-validation/specs/messagepack-sourcegen/spec.md
@@ -93,6 +93,10 @@ Generated serializers SHALL treat a field whose static type, after generic subst
 - **WHEN** a generic `[AkkaSerializable]` definition has a `[AkkaField]` property typed by its type parameter, and a registered closed construction substitutes `object` for that parameter
 - **THEN** the generator SHALL treat that field as a serializer boundary in the closed construction
 
+#### Scenario: Object elements inside a collection are boundaries
+- **WHEN** a supported collection's element type is `object` (an array, a list, a read-only or immutable collection, or a dictionary value -- a dictionary KEY typed `object` is rejected with AKKASG003 instead)
+- **THEN** the generator SHALL treat each element as its own serializer boundary, writing and reading it as an envelope payload the same way an `object`-typed field is
+
 #### Scenario: Union declaration on an object-typed field rejected
 - **WHEN** an `[AkkaField]` property typed `object` carries a field-level `[AkkaUnion]`
 - **THEN** the generator SHALL fail compilation with a diagnostic (AKKASG038), because an `object`-typed field is always a serializer boundary

--- a/openspec/changes/messagepack-sourcegen-validation/tasks.md
+++ b/openspec/changes/messagepack-sourcegen-validation/tasks.md
@@ -58,6 +58,7 @@
 - [x] 5.14 Support foreign-type formatters via [AkkaSerializerFormatter] escape hatch (AddressFormatter/ActorPathFormatter built-ins, byte-compatible with Artery control-message wire format)
 - [x] 5.15 Honor declared accessibility of serializer partial classes (internal serializers)
 - [x] 5.16 Remove `[AkkaEnvelopePayload]`; an `object`-typed field is the serializer boundary on its own, AKKASG035 retired, AKKASG038 added (design.md Decision 20) — PR #8518
+- [x] 5.17 Extend Decision 20 to collection elements: a `List<object>`/`object[]`/any other natively-supported collection whose element type is `object` (or `object?`) treats each element as its own envelope-payload boundary, nullable-aware the same way a field is (`MapCollectionElement`, `EmitWriteElement`/`EmitReadElement`/`EmitSizeElement` `FieldKind.EnvelopePayload` cases). A dictionary KEY typed `object` is rejected with AKKASG003 instead (unstable round-tripped identity for hash/equality lookups, plus a null key crashing `Dictionary<TKey,TValue>` at runtime); dictionary VALUES typed `object` are supported. `ObjectElementSpec.cs`
 
 ## 6. Integration Validation
 

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Emission.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Emission.cs
@@ -1454,7 +1454,7 @@ public sealed partial class AkkaSerializerGenerator
 
         return mapping.Kind switch
         {
-            FieldKind.String or FieldKind.ByteArray or FieldKind.ActorRef => true,
+            FieldKind.String or FieldKind.ByteArray or FieldKind.ActorRef or FieldKind.EnvelopePayload => true,
             FieldKind.Object => !mapping.IsValueType,
             _ => false
         };
@@ -1522,6 +1522,16 @@ public sealed partial class AkkaSerializerGenerator
             w.Line("else");
             using (w.Indented())
                 w.Raw("Write").Identifier(GetObjectMethodName(mapping)).Raw("(ref writer, ").Value(writeValue).Line(");");
+            return;
+        }
+
+        // Mirrors the field-level FieldKind.EnvelopePayload case in GenerateWriteFieldValue: no
+        // explicit null check is needed here (unlike FieldKind.Object above) because
+        // WriteEnvelopePayload(ref MessagePackWriter, object?) already writes nil for a null payload
+        // itself -- true regardless of whether this element's declared type is nullable.
+        if (mapping.Kind == FieldKind.EnvelopePayload)
+        {
+            w.Raw("WriteEnvelopePayload(ref writer, ").Value(value).Line(");");
             return;
         }
 
@@ -1783,6 +1793,31 @@ public sealed partial class AkkaSerializerGenerator
             return;
         }
 
+        if (mapping.Kind == FieldKind.EnvelopePayload)
+        {
+            // Mirrors the field-level FieldKind.EnvelopePayload case in GenerateReadFieldValue/
+            // GenerateReadField: a nullable element pre-checks nil itself and assigns null directly,
+            // never calling the generic ReadEnvelopePayload<TPayload> helper for a nil payload --
+            // "null is TPayload" always fails the runtime pattern match (even for TPayload == object),
+            // so routing a nullable element's nil through the generic helper would throw instead of
+            // producing null. A non-nullable element skips the pre-check and calls the helper
+            // directly; if the wire unexpectedly holds nil there, the same "not assignable" exception
+            // is exactly the desired failure for a slot that promised never to be null.
+            if (mapping.IsNullable)
+            {
+                w.Line("if (reader.TryReadNil())");
+                using (w.Indented())
+                    w.Local(resultVar).Line(" = null;");
+                w.Line("else");
+                using (w.Indented())
+                    w.Local(resultVar).Raw(" = ReadEnvelopePayload<").Type(TypeName.Global(mapping.DeclaredTypeName)).Line(">(ref reader);");
+                return;
+            }
+
+            w.Local(resultVar).Raw(" = ReadEnvelopePayload<").Type(TypeName.Global(mapping.DeclaredTypeName)).Line(">(ref reader);");
+            return;
+        }
+
         if (mapping.IsNullable && IsScalarValueKind(mapping.Kind))
         {
             w.Line("if (reader.TryReadNil())");
@@ -1907,6 +1942,23 @@ public sealed partial class AkkaSerializerGenerator
                 w.Value(value).Raw(" is null ? SizeOfNil() : SizeOf").Identifier(GetObjectMethodName(mapping)).Raw("(").Value(sizedValue).Raw(")");
             }
 
+            w.Line(";");
+            w.Raw("if (").Local(elementSize).Line(" < 0)");
+            using (w.Indented())
+                w.Line("return global::Akka.Serialization.SerializerV2.UnknownSize;");
+            w.Local(sizeVar).Raw(" += ").Local(elementSize).Line(";");
+            return;
+        }
+
+        // Mirrors the field-level FieldKind.EnvelopePayload case in GenerateSizeExpression: no
+        // separate null branch is needed here (unlike FieldKind.Object above) because
+        // SizeOfEnvelopePayload(object?) already returns SizeOfNil() for a null payload itself, so a
+        // single call covers both a genuinely null element and a real payload -- whose own SizeHint
+        // may still be UnknownSize, hence the same "< 0" propagation guard as every other kind here.
+        if (mapping.Kind == FieldKind.EnvelopePayload)
+        {
+            var elementSize = alloc.Next("size");
+            w.Raw("var ").Local(elementSize).Raw(" = SizeOfEnvelopePayload(").Value(value).Raw(")");
             w.Line(";");
             w.Raw("if (").Local(elementSize).Line(" < 0)");
             using (w.Indented())

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Extraction.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Extraction.cs
@@ -862,7 +862,10 @@ public sealed partial class AkkaSerializerGenerator
     /// A collection whose element/key/value is itself unsupported collapses to
     /// <see cref="FieldKind.Unsupported"/> so AKKASG003 fires with the full field type -- except an
     /// enum element with an unsupported underlying type, which propagates as
-    /// <see cref="FieldKind.UnsupportedEnumUnderlyingType"/> so AKKASG014 fires naming the enum.
+    /// <see cref="FieldKind.UnsupportedEnumUnderlyingType"/> so AKKASG014 fires naming the enum. An
+    /// element/value typed <c>object</c> maps to <see cref="FieldKind.EnvelopePayload"/> instead (see
+    /// <see cref="MapCollectionElement"/>); a dictionary KEY typed <c>object</c> also collapses to
+    /// <see cref="FieldKind.Unsupported"/>.
     /// <c>byte[]</c> is never seen here (it is intercepted earlier as <see cref="FieldKind.ByteArray"/>).
     /// </summary>
     private static bool TryMapCollection(ITypeSymbol type, KnownTypes knownTypes, out TypeMapping mapping)
@@ -981,7 +984,7 @@ public sealed partial class AkkaSerializerGenerator
 
     private static TypeMapping MapKeyValueCollection(FieldKind kind, INamedTypeSymbol namedType, KnownTypes knownTypes)
     {
-        var key = MapCollectionElement(namedType.TypeArguments[0], knownTypes);
+        var key = MapCollectionElement(namedType.TypeArguments[0], knownTypes, isKeyPosition: true);
         var value = MapCollectionElement(namedType.TypeArguments[1], knownTypes);
         return TryCollapseBadElement(key, out var collapsedKey) ? collapsedKey
             : TryCollapseBadElement(value, out var collapsedValue) ? collapsedValue
@@ -1029,7 +1032,12 @@ public sealed partial class AkkaSerializerGenerator
             or SpecialType.System_Int32;
     }
 
-    private static TypeMapping MapCollectionElement(ITypeSymbol type, KnownTypes knownTypes)
+    /// <summary>
+    /// Maps a single collection element/key/value type. <paramref name="isKeyPosition"/> is true only
+    /// for a dictionary KEY (see <see cref="MapKeyValueCollection"/>); every other caller (an
+    /// array/list element, a set member, or a dictionary value) leaves it false.
+    /// </summary>
+    private static TypeMapping MapCollectionElement(ITypeSymbol type, KnownTypes knownTypes, bool isKeyPosition = false)
     {
         var declaredTypeName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
@@ -1037,6 +1045,26 @@ public sealed partial class AkkaSerializerGenerator
             return MapTypeCore(underlyingType, knownTypes).AsCollectionElement(declaredTypeName, isNullable: true);
 
         var isNullable = type.IsReferenceType && type.NullableAnnotation == NullableAnnotation.Annotated;
+
+        // An element/value whose static type is `object` (or `object?`) is always the
+        // envelope-payload boundary, mirroring the property-level rule in ExtractMessageCore -- the
+        // type alone carries that meaning, with no attribute involved, at every position a supported
+        // collection can hold it: an array/list element, a set member, or a dictionary value.
+        //
+        // A dictionary KEY typed `object` is rejected instead (AKKASG003, via the same Unsupported
+        // collapse every other bad element/key/value already uses -- see TryCollapseBadElement):
+        // Dictionary&lt;TKey,TValue&gt; throws on a null key at runtime, so a nullable `object?` key
+        // would crash the first time an envelope legitimately decodes to null; and even a non-null
+        // envelope payload has no stable identity across a round trip (ReadEnvelopePayload always
+        // materializes a brand-new instance on read), so hash/equality-based key lookups could never
+        // reliably rediscover a deserialized entry. Neither failure mode is worth the surface area.
+        if (type.SpecialType == SpecialType.System_Object)
+        {
+            return isKeyPosition
+                ? new TypeMapping(FieldKind.Unsupported)
+                : new TypeMapping(FieldKind.EnvelopePayload).AsCollectionElement(declaredTypeName, isNullable);
+        }
+
         return MapTypeCore(type, knownTypes).AsCollectionElement(declaredTypeName, isNullable);
     }
 

--- a/src/core/Akka.Serialization.V2.Tests/GeneratedMessagePackSerializerSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratedMessagePackSerializerSpec.cs
@@ -8,6 +8,7 @@
 #nullable enable
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Runtime.Serialization;
@@ -761,6 +762,29 @@ public sealed record AttributeOuterEnvelope(
 public sealed record AttributeInnerEnvelope(
     [property: AkkaField(1)] string EnvelopeId,
     [property: AkkaField(2)] object Payload) : IGeneratedTestProtocol;
+
+// ---- object elements inside a collection: each element is its own envelope-payload boundary,
+// the same frame a property typed `object` already gets (see ObjectElementSpec) ----
+
+[AkkaSerializable(Manifest = "object-list-v1")]
+public sealed record ObjectListMessage(
+    [property: AkkaField(1)] List<object> Items) : IGeneratedTestProtocol;
+
+[AkkaSerializable(Manifest = "object-array-v1")]
+public sealed record ObjectArrayMessage(
+    [property: AkkaField(1)] object[] Items) : IGeneratedTestProtocol;
+
+[AkkaSerializable(Manifest = "object-list-nullable-v1")]
+public sealed record ObjectListNullableMessage(
+    [property: AkkaField(1)] List<object?> Items) : IGeneratedTestProtocol;
+
+[AkkaSerializable(Manifest = "object-dict-values-v1")]
+public sealed record ObjectDictValuesMessage(
+    [property: AkkaField(1)] Dictionary<string, object> Values) : IGeneratedTestProtocol;
+
+[AkkaSerializable(Manifest = "object-immutable-list-v1")]
+public sealed record ObjectImmutableListMessage(
+    [property: AkkaField(1)] ImmutableList<object> Items) : IGeneratedTestProtocol;
 
 public sealed record CustomProtobufPayload(string PayloadId, int Value);
 

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorGoldenOutputSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorGoldenOutputSpec.cs
@@ -217,6 +217,13 @@ public sealed class GeneratorGoldenOutputSpec
             [property: AkkaField(2)] object Payload,
             [property: AkkaField(3)] object? MaybePayload) : IProtocol;
 
+        // ---- object element inside a collection: each element is its own envelope-payload
+        // boundary, the same frame a property typed `object` already gets above ----
+
+        [AkkaSerializable(Manifest = "envelope-list-v1")]
+        public sealed record EnvelopeListMessage(
+            [property: AkkaField(1)] List<object> Items) : IProtocol;
+
         // ---- hybrid reconstruction: case-insensitive ctor matching, a keyword-named ctor
         // parameter, and leftover properties assigned via object initializer ----
 

--- a/src/core/Akka.Serialization.V2.Tests/GoldenOutput/GoldenSerializer.AkkaSerialization.g.cs.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/GoldenOutput/GoldenSerializer.AkkaSerialization.g.cs.verified.txt
@@ -34,6 +34,7 @@ public sealed partial class GoldenSerializer
             global::GoldenSample.CollectionMessage => "collections-v1",
             global::GoldenSample.UnionMessage => "union-v1",
             global::GoldenSample.EnvelopeMessage => "envelope-v1",
+            global::GoldenSample.EnvelopeListMessage => "envelope-list-v1",
             global::GoldenSample.HybridMessage => "hybrid-v1",
             global::GoldenSample.NestedMessage => "nested-v1",
             global::GoldenSample.Ping => "ping-v1",
@@ -70,6 +71,9 @@ public sealed partial class GoldenSerializer
                 break;
             case global::GoldenSample.EnvelopeMessage message:
                 WriteEnvelopeMessage(ref writer, message);
+                break;
+            case global::GoldenSample.EnvelopeListMessage message:
+                WriteEnvelopeListMessage(ref writer, message);
                 break;
             case global::GoldenSample.HybridMessage message:
                 WriteHybridMessage(ref writer, message);
@@ -109,6 +113,7 @@ public sealed partial class GoldenSerializer
             "collections-v1" => ReadCollectionMessage(ref reader),
             "union-v1" => ReadUnionMessage(ref reader),
             "envelope-v1" => ReadEnvelopeMessage(ref reader),
+            "envelope-list-v1" => ReadEnvelopeListMessage(ref reader),
             "hybrid-v1" => ReadHybridMessage(ref reader),
             "nested-v1" => ReadNestedMessage(ref reader),
             "ping-v1" => ReadPing(ref reader),
@@ -129,6 +134,7 @@ public sealed partial class GoldenSerializer
             global::GoldenSample.CollectionMessage message => SizeOfCollectionMessage(message),
             global::GoldenSample.UnionMessage message => SizeOfUnionMessage(message),
             global::GoldenSample.EnvelopeMessage message => SizeOfEnvelopeMessage(message),
+            global::GoldenSample.EnvelopeListMessage message => SizeOfEnvelopeListMessage(message),
             global::GoldenSample.HybridMessage message => SizeOfHybridMessage(message),
             global::GoldenSample.NestedMessage message => SizeOfNestedMessage(message),
             global::GoldenSample.Ping message => SizeOfPing(message),
@@ -1875,6 +1881,91 @@ public sealed partial class GoldenSerializer
         if (!__hasPayload || payload is null)
             throw new global::System.Runtime.Serialization.SerializationException("Missing required field [Payload] with index [2] while deserializing [global::GoldenSample.EnvelopeMessage].");
         return new global::GoldenSample.EnvelopeMessage(CorrelationId: correlationId!, Payload: payload!, MaybePayload: maybePayload);
+    }
+
+    private int SizeOfEnvelopeListMessage(global::GoldenSample.EnvelopeListMessage message)
+    {
+        checked
+        {
+            var size = SizeOfMapHeader(1);
+            size += SizeOfInt32(1);
+            int __size0;
+            if (message.Items is null)
+            {
+                __size0 = SizeOfNil();
+            }
+            else
+            {
+                __size0 = SizeOfArrayHeader(message.Items.Count);
+                foreach (var __item1 in message.Items)
+                {
+                    var __size2 = SizeOfEnvelopePayload(__item1);
+                    if (__size2 < 0)
+                        return global::Akka.Serialization.SerializerV2.UnknownSize;
+                    __size0 += __size2;
+                }
+            }
+            size += __size0;
+            return size;
+        }
+    }
+
+    private void WriteEnvelopeListMessage(ref global::MessagePack.MessagePackWriter writer, global::GoldenSample.EnvelopeListMessage message)
+    {
+        writer.WriteMapHeader(1);
+        writer.Write(1);
+        if (message.Items is null)
+        {
+            writer.WriteNil();
+        }
+        else
+        {
+            writer.WriteArrayHeader(message.Items.Count);
+            foreach (var __item0 in message.Items)
+            {
+                WriteEnvelopePayload(ref writer, __item0);
+            }
+        }
+    }
+
+    private global::GoldenSample.EnvelopeListMessage ReadEnvelopeListMessage(ref global::MessagePack.MessagePackReader reader)
+    {
+        var __fieldCount = reader.ReadMapHeader();
+        global::System.Collections.Generic.List<object>? items = default;
+        var __hasItems = false;
+        for (var __entryIndex = 0; __entryIndex < __fieldCount; __entryIndex++)
+        {
+            var __fieldId = reader.ReadInt32();
+            switch (__fieldId)
+            {
+                case 1:
+                    if (reader.TryReadNil())
+                    {
+                        items = null;
+                    }
+                    else
+                    {
+                        var __len0 = reader.ReadArrayHeader();
+                        var __col1 = new global::System.Collections.Generic.List<object>(__len0);
+                        for (var __i2 = 0; __i2 < __len0; __i2++)
+                        {
+                            object? __item3;
+                            __item3 = ReadEnvelopePayload<object>(ref reader);
+                            __col1.Add(__item3!);
+                        }
+                        items = __col1;
+                    }
+                    __hasItems = true;
+                    break;
+                default:
+                    reader.Skip();
+                    break;
+            }
+        }
+
+        if (!__hasItems || items is null)
+            throw new global::System.Runtime.Serialization.SerializationException("Missing required field [Items] with index [1] while deserializing [global::GoldenSample.EnvelopeListMessage].");
+        return new global::GoldenSample.EnvelopeListMessage(Items: items!);
     }
 
     private int SizeOfHybridMessage(global::GoldenSample.HybridMessage message)

--- a/src/core/Akka.Serialization.V2.Tests/MessageModelSnapshots/GoldenCorpusMessageModels.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/MessageModelSnapshots/GoldenCorpusMessageModels.verified.txt
@@ -51,6 +51,19 @@ ConstructionPlan: valid=True
     Palette <- Palette
 
 ================================================================================
+Type: global::GoldenSample.EnvelopeListMessage
+SimpleName: EnvelopeListMessage
+Manifest: envelope-list-v1
+AllowEmpty: False
+IsGenericDefinition: False
+Protocols: global::GoldenSample.IProtocol, global::System.IEquatable<global::GoldenSample.EnvelopeListMessage>
+Fields:
+  [1] Items: kind=List, type=global::System.Collections.Generic.List<object> (nullable: False)
+ConstructionPlan: valid=True
+  Arguments:
+    Items <- Items
+
+================================================================================
 Type: global::GoldenSample.EnvelopeMessage
 SimpleName: EnvelopeMessage
 Manifest: envelope-v1

--- a/src/core/Akka.Serialization.V2.Tests/MessageModelSnapshots/GoldenCorpusResolvedSerializers.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/MessageModelSnapshots/GoldenCorpusResolvedSerializers.verified.txt
@@ -6,6 +6,7 @@ TopLevelMessages (closed set, declaration order):
   global::GoldenSample.CollectionMessage (manifest=collections-v1, method=CollectionMessage)
   global::GoldenSample.UnionMessage (manifest=union-v1, method=UnionMessage)
   global::GoldenSample.EnvelopeMessage (manifest=envelope-v1, method=EnvelopeMessage)
+  global::GoldenSample.EnvelopeListMessage (manifest=envelope-list-v1, method=EnvelopeListMessage)
   global::GoldenSample.HybridMessage (manifest=hybrid-v1, method=HybridMessage)
   global::GoldenSample.NestedMessage (manifest=nested-v1, method=NestedMessage)
   global::GoldenSample.Ping (manifest=ping-v1, method=Ping)
@@ -14,11 +15,12 @@ TopLevelMessages (closed set, declaration order):
   global::GoldenSample.Wrapper<int> (manifest=wrapper-int-v1, method=WrapperInt)
   global::GoldenSample.Wrapper<global::GoldenSample.GeoPoint> (manifest=wrapper-geo-v1, method=WrapperGeoPoint)
   global::GoldenSample.Wrapper<global::GoldenSample.Pair<int, string>> (manifest=wrapper-pair-v1, method=WrapperPairIntString)
-ReachableMessages (18, reachability-walk order):
+ReachableMessages (19, reachability-walk order):
   global::GoldenSample.ScalarMessage
   global::GoldenSample.CollectionMessage
   global::GoldenSample.UnionMessage
   global::GoldenSample.EnvelopeMessage
+  global::GoldenSample.EnvelopeListMessage
   global::GoldenSample.HybridMessage
   global::GoldenSample.NestedMessage
   global::GoldenSample.Ping
@@ -35,6 +37,7 @@ ReachableMessages (18, reachability-walk order):
   global::GoldenSample.Pair<int, string>
 ResolvedMessagesByType keys (sorted):
   global::GoldenSample.CollectionMessage
+  global::GoldenSample.EnvelopeListMessage
   global::GoldenSample.EnvelopeMessage
   global::GoldenSample.EscapedManifestMessage
   global::GoldenSample.GeoPoint

--- a/src/core/Akka.Serialization.V2.Tests/ObjectElementSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/ObjectElementSpec.cs
@@ -1,0 +1,231 @@
+//-----------------------------------------------------------------------
+// <copyright file="ObjectElementSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using Akka.Serialization.V2.Tests.Harness;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// Decision 20 (a property typed <c>object</c> is always the envelope-payload boundary) extended to
+/// collection elements: a <c>List&lt;object&gt;</c>, <c>object[]</c>, or any other natively-supported
+/// collection whose element type is <c>object</c> (or <c>object?</c>) treats each element as its own
+/// envelope-payload boundary -- the same frame a property typed <c>object</c> already gets. Fixture
+/// message types (<see cref="ObjectListMessage"/>, <see cref="ObjectArrayMessage"/>,
+/// <see cref="ObjectListNullableMessage"/>, <see cref="ObjectDictValuesMessage"/>,
+/// <see cref="ObjectImmutableListMessage"/>) live alongside the rest of the shared
+/// <see cref="IGeneratedTestProtocol"/> fixture in GeneratedMessagePackSerializerSpec.cs.
+/// </summary>
+public sealed class ObjectElementSpec : IAsyncLifetime
+{
+    private ActorSystem _system = null!;
+    private GeneratedTestSerializer _serializer = null!;
+
+    public ValueTask InitializeAsync()
+    {
+        // A real ActorSystem, not a bare `new GeneratedTestSerializer(...)`, because each object
+        // element's WriteEnvelopePayload/ReadEnvelopePayload/SizeOfEnvelopePayload call resolves its
+        // OWN serializer through `system.Serialization.FindSerializerFor` -- exercising that lookup
+        // (rather than bypassing it) is the point of these tests. Binds IGeneratedTestProtocol to
+        // GeneratedTestSerializer (so a RequiredMessage/AttributeInnerEnvelope element round-trips
+        // through the SAME generated serializer as the outer message) and CustomProtobufPayload to a
+        // non-SerializerV2 serializer (so an element's SizeHint can be deliberately un-sizable).
+        var setup = ActorSystemSetup.Create(SerializationSetup.Create(extendedSystem =>
+        {
+            var generated = GeneratedTestSerializer.CreateRegistration().CreateDetails(extendedSystem);
+            var custom = SerializerDetails.Create(
+                "custom-protobuf",
+                new CustomProtobufPayloadSerializer(extendedSystem),
+                ImmutableHashSet.Create<Type>(typeof(CustomProtobufPayload)));
+            return ImmutableHashSet.Create(generated, custom);
+        }));
+        _system = ActorSystem.Create("object-element-spec", setup);
+        _serializer = new GeneratedTestSerializer((ExtendedActorSystem)_system);
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _system.Terminate();
+    }
+
+    private TMessage RoundTrip<TMessage>(TMessage message)
+        where TMessage : class, IGeneratedTestProtocol
+    {
+        var bytes = _serializer.ToBinary(message);
+        var manifest = _serializer.Manifest(message);
+        return _serializer.FromBinary(bytes, manifest).Should().BeOfType<TMessage>().Subject;
+    }
+
+    [Fact(DisplayName = "List<object> round-trips a mix of a message from the same serializer, a plain string, and a boxed int")]
+    public void Should_round_trip_List_of_object_with_mixed_payload_types()
+    {
+        var message = new ObjectListMessage(new List<object>
+        {
+            new RequiredMessage("order-1", 42),
+            "plain-string",
+            7
+        });
+
+        var result = RoundTrip(message);
+
+        result.Items.Should().HaveCount(3);
+        result.Items[0].Should().Be(new RequiredMessage("order-1", 42));
+        result.Items[1].Should().Be("plain-string");
+        result.Items[2].Should().Be(7);
+    }
+
+    [Fact(DisplayName = "object[] round-trips a mix of a message from the same serializer, a plain string, and a boxed int")]
+    public void Should_round_trip_object_array_with_mixed_payload_types()
+    {
+        var message = new ObjectArrayMessage(new object[]
+        {
+            new RequiredMessage("order-2", 5),
+            "another-string",
+            99
+        });
+
+        var result = RoundTrip(message);
+
+        result.Items.Should().HaveCount(3);
+        result.Items[0].Should().Be(new RequiredMessage("order-2", 5));
+        result.Items[1].Should().Be("another-string");
+        result.Items[2].Should().Be(99);
+    }
+
+    [Fact(DisplayName = "List<object?> round-trips a null element alongside real payloads")]
+    public void Should_round_trip_nullable_object_element_with_null()
+    {
+        var message = new ObjectListNullableMessage(new List<object?>
+        {
+            new RequiredMessage("order-3", 1),
+            null,
+            "text"
+        });
+
+        var result = RoundTrip(message);
+
+        result.Items.Should().HaveCount(3);
+        result.Items[0].Should().Be(new RequiredMessage("order-3", 1));
+        result.Items[1].Should().BeNull();
+        result.Items[2].Should().Be("text");
+    }
+
+    [Fact(DisplayName = "Dictionary<string, object> values round-trip as envelope payloads")]
+    public void Should_round_trip_dictionary_values_as_envelope_payloads()
+    {
+        var message = new ObjectDictValuesMessage(new Dictionary<string, object>
+        {
+            ["a"] = new RequiredMessage("order-4", 3),
+            ["b"] = "value-b",
+            ["c"] = 123
+        });
+
+        var result = RoundTrip(message);
+
+        result.Values.Should().HaveCount(3);
+        result.Values["a"].Should().Be(new RequiredMessage("order-4", 3));
+        result.Values["b"].Should().Be("value-b");
+        result.Values["c"].Should().Be(123);
+    }
+
+    [Fact(DisplayName = "ImmutableList<object> round-trips a mix of payload types")]
+    public void Should_round_trip_immutable_list_of_object()
+    {
+        var message = new ObjectImmutableListMessage(ImmutableList.Create<object>(
+            new RequiredMessage("order-5", 9),
+            "immutable-text",
+            17));
+
+        var result = RoundTrip(message);
+
+        result.Items.Should().HaveCount(3);
+        result.Items[0].Should().Be(new RequiredMessage("order-5", 9));
+        result.Items[1].Should().Be("immutable-text");
+        result.Items[2].Should().Be(17);
+    }
+
+    [Fact(DisplayName = "SizeHint returns UnknownSize when a List<object> element's own serializer cannot size it")]
+    public void SizeHint_should_return_UnknownSize_when_element_serializer_cannot_size()
+    {
+        // CustomProtobufPayloadSerializer is a SerializerWithStringManifest, not a SerializerV2, so
+        // SizeOfEnvelopePayload gives up on it (UnknownSize) exactly as it would for a hand-written,
+        // non-generated serializer anywhere else in this codebase -- the propagation guard added to
+        // EmitSizeElement's FieldKind.EnvelopePayload case must bubble that all the way out.
+        var message = new ObjectListMessage(new List<object>
+        {
+            "sizable-string",
+            new CustomProtobufPayload("payload-1", 17)
+        });
+
+        _serializer.SizeHint(message).Should().Be(SerializerV2.UnknownSize);
+    }
+
+    [Fact(DisplayName = "An object element holding a self-nesting envelope chain still respects the envelope depth guard")]
+    public void List_of_object_element_should_respect_envelope_depth_guard()
+    {
+        // Comfortably past AkkaSerializer's internal MaxEnvelopePayloadDepth (100) -- see
+        // EnvelopeDepthGuardSpec, whose field-level version of this same scenario this mirrors. A
+        // collection element's WriteEnvelopePayload call enters/exits the SAME [ThreadStatic] depth
+        // counter as a field's, so nesting the chain one level deeper -- inside a List<object>
+        // element instead of directly in a property -- must trip the identical guard.
+        object payload = new RequiredMessage("leaf", 1);
+        for (var i = 0; i < 250; i++)
+            payload = new AttributeInnerEnvelope($"lvl-{i}", payload);
+
+        var message = new ObjectListMessage(new List<object> { payload });
+
+        Action serialize = () => _serializer.ToBinary(message);
+
+        serialize.Should().Throw<SerializationException>().WithMessage("*maximum depth*");
+    }
+
+    [Fact(DisplayName = "Generator should reject a Dictionary<object, string> key with AKKASG003")]
+    public void Generator_should_reject_object_typed_dictionary_key()
+    {
+        // A dictionary KEY typed `object` is rejected rather than treated as an envelope-payload
+        // boundary: Dictionary<TKey,TValue> throws on a null key at runtime (a nullable `object?` key
+        // would crash the moment an envelope legitimately decodes to null), and ReadEnvelopePayload
+        // always hands back a brand-new instance on read, so a round-tripped key has no stable
+        // identity for hash/equality-based lookups to rediscover. See MapCollectionElement's remarks.
+        const string source = """
+            #nullable enable
+            using System.Collections.Generic;
+            using Akka.Actor;
+            using Akka.Serialization.V2;
+
+            namespace ObjectKeySample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializer<IProtocol>("sample", 121101)]
+            public sealed partial class SampleSerializer : AkkaSerializer
+            {
+                public static partial SerializerRegistration CreateRegistration();
+            }
+
+            [AkkaSerializable(Manifest = "bad-key-v1")]
+            public sealed record BadKeyMessage([property: AkkaField(1)] Dictionary<object, string> Values) : IProtocol;
+            """;
+
+        var diagnostics = GeneratorTestHarness.Run(source).AllDiagnostics;
+
+        diagnostics.Should().Contain(diagnostic => diagnostic.Id == "AKKASG003" && diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+}

--- a/src/core/Akka.Serialization.V2.Tests/WireFormatSnapshotSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/WireFormatSnapshotSpec.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Actor.Setup;
 using VerifyXunit;
 using Xunit;
 
@@ -93,6 +94,10 @@ public sealed class WireFormatSnapshotSpec : IAsyncLifetime
         // Object-typed envelope payload: fixed inner serializer id + manifest + bytes.
         "envelope-payload-fixed-inner-serializer",
 
+        // Object elements inside a collection: each element is its own envelope-payload boundary,
+        // same as an object-typed property above -- fixture from ObjectElementSpec.
+        "envelope-list-element-string-and-message",
+
         // AllowEmpty fieldless message: the smallest possible wire shape (a bare 1-byte map header).
         "fieldless-message-allow-empty",
     };
@@ -107,7 +112,14 @@ public sealed class WireFormatSnapshotSpec : IAsyncLifetime
 
     public ValueTask InitializeAsync()
     {
-        _system = ActorSystem.Create("wire-format-snapshot-spec");
+        // Bind IGeneratedTestProtocol to GeneratedTestSerializer via the generator's own registration
+        // (rather than a bare, unregistered ActorSystem) so that the "envelope-list-element..." case's
+        // List<object> element -- a RequiredMessage, an IGeneratedTestProtocol type -- resolves through
+        // system.Serialization.FindSerializerFor to the SAME generated serializer instead of the
+        // system's default fallback. Every other case in this corpus is unaffected: none of them route
+        // an IGeneratedTestProtocol-typed value through FindSerializerFor.
+        var setup = ActorSystemSetup.Create(GeneratedTestSerializer.CreateRegistration().CreateSetup());
+        _system = ActorSystem.Create("wire-format-snapshot-spec", setup);
         var extendedSystem = (ExtendedActorSystem)_system;
         _generatedSerializer = new GeneratedTestSerializer(extendedSystem);
         _collectionSerializer = new CollectionTestSerializer(extendedSystem);
@@ -270,6 +282,14 @@ public sealed class WireFormatSnapshotSpec : IAsyncLifetime
                 CustomProtobufPayloadSerializer.IdentifierValue,
                 CustomProtobufPayloadSerializer.ManifestName,
                 Encoding.UTF8.GetBytes("fake-protobuf|payload-1|17")))),
+
+        // --------------------------------------------------------------------------------------
+        // Object elements inside a collection: each List<object> element is its own envelope-payload
+        // boundary, framed exactly like the object-typed property above -- fixture from
+        // ObjectElementSpec. A plain string then a message from the SAME generated serializer.
+        // --------------------------------------------------------------------------------------
+        "envelope-list-element-string-and-message" => Case(_generatedSerializer, new ObjectListMessage(
+            new List<object> { "note", new RequiredMessage("order-1", 42) })),
 
         // --------------------------------------------------------------------------------------
         // AllowEmpty fieldless message -- fixture from FieldlessAndStructFieldSpec. The smallest

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/envelope-list-element-string-and-message.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/envelope-list-element-string-and-message.verified.txt
@@ -1,0 +1,10 @@
+﻿case: envelope-list-element-string-and-message
+message-type: ObjectListMessage
+manifest: object-list-v1
+serializer-id: 120101
+byte-count: 52
+
+0000  81 01 92 83 01 01 02 a0  03 c4 06 22 6e 6f 74 65  |..........."note|
+0010  22 83 01 ce 00 01 d5 25  02 ab 72 65 71 75 69 72  |"......%..requir|
+0020  65 64 2d 76 31 03 c4 0c  82 01 a7 6f 72 64 65 72  |ed-v1......order|
+0030  2d 31 02 2a                                       |-1.*|


### PR DESCRIPTION
> Stack, bottom to top: S1 #8525 -> S2 #8526 -> S3 #8527 -> object elements #8528 -> S4 #8530 -> S5 #8532 -> S6 #8533 -> F1 #8534 -> F2 #8536 -> F3 #8537 -> S7 #8538. Each PR is one commit on top of the one below it. This PR is the object-elements fix. It reopens #8523 with the same change; the S3 resolved-model snapshot gains the new golden message.

## What changes

A collection whose elements are `object` now works. Since #8518, a field typed `object` is a boundary: the generator wraps the value in an envelope that records which serializer and manifest to use, and unwraps it on read. This PR gives each element of `List<object>`, `object[]`, sets, immutable collections, and dictionary values the same envelope. A nullable element gets the same nil framing a nullable field gets. Every other element kind is byte for byte untouched.

Dictionary keys typed `object` stay rejected with AKKASG003, and the code says why: a null key crashes a dictionary at run time, and a round-tripped envelope is a fresh instance, so a key would have no stable identity for lookup.

## Why

The guide listed this as unsupported after #8520, and Decision 20 in the design record covered fields but not elements. All collection shapes funnel through one element-mapping routine, so the change is one case in three places.

## How it was checked

- Eight new tests round-trip a message, a string, and an int through `List<object>`, `object[]`, `Dictionary<string, object>`, and `ImmutableList<object>`; a nullable element holding null; `SizeHint` reporting unknown size when an element cannot be sized; the nesting-depth guard reached through an element; and the AKKASG003 case for `Dictionary<object, string>`.
- The golden corpus gains one message with a `List<object>` field. The diff is purely additive. The S1 model snapshot gains the same message.
- A new wire snapshot pins the bytes for a list holding a string and a message.
- 287 tests pass. Generator builds with warnings as errors. `Akka.Remote` builds.

## Design record

The source-generator spec gains the scenario "Object elements inside a collection are boundaries", and task 5.17.

## Follow-up

The guide's supported-types table still lists this as unsupported. A one-line docs change lands after this merges.
