### PR TITLE
Use typed keys for every type lookup so same-named types cannot collide (S4)

### DIFF
--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Emission.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Emission.cs
@@ -36,7 +36,7 @@ internal readonly struct ResolvedSerializerMessages
     public ResolvedSerializerMessages(
         ImmutableArray<AkkaSerializerGenerator.MessageInfo> topLevelMessages,
         ImmutableArray<AkkaSerializerGenerator.MessageInfo> reachableMessages,
-        ImmutableDictionary<string, AkkaSerializerGenerator.MessageInfo> resolvedMessagesByType)
+        ImmutableDictionary<AkkaSerializerGenerator.TypeKey, AkkaSerializerGenerator.MessageInfo> resolvedMessagesByType)
     {
         TopLevelMessages = topLevelMessages;
         ReachableMessages = reachableMessages;
@@ -45,7 +45,7 @@ internal readonly struct ResolvedSerializerMessages
 
     public ImmutableArray<AkkaSerializerGenerator.MessageInfo> TopLevelMessages { get; }
     public ImmutableArray<AkkaSerializerGenerator.MessageInfo> ReachableMessages { get; }
-    public ImmutableDictionary<string, AkkaSerializerGenerator.MessageInfo> ResolvedMessagesByType { get; }
+    public ImmutableDictionary<AkkaSerializerGenerator.TypeKey, AkkaSerializerGenerator.MessageInfo> ResolvedMessagesByType { get; }
 }
 
 public sealed partial class AkkaSerializerGenerator
@@ -158,16 +158,18 @@ public sealed partial class AkkaSerializerGenerator
         var topLevelMessages = BuildClosedSet(resolved.TopLevelMessages);
         var usedFormatters = CollectUsedFormatters(resolved.ReachableMessages);
 
-        // PlanUnionHelpers and ResolveClosedGenericRegistrations both look up against
-        // resolved.ResolvedMessagesByType -- the FULL, whole-compilation dictionary
-        // ResolveSerializerMessages builds from declaredMessages, exactly as validation already
-        // does (see ValidateResolved). That full dictionary must NOT become the model's OWN stored
-        // ResolvedMessagesByType, though: it carries every OTHER serializer's messages too, so a
-        // serializer that adopts none of them would still see this model change shape whenever any
-        // of them do -- exactly the cross-serializer poisoning ResolvedSerializer.Equals must avoid
-        // (see BuildResolvedMessageTable's doc comment).
+        // PlanUnionHelpers looks up against resolved.ResolvedMessagesByType -- the FULL,
+        // whole-compilation table ResolveSerializerMessages builds from declaredMessages, exactly as
+        // validation already does (see ValidateResolved). That full table must NOT become the
+        // model's OWN stored ResolvedMessagesByType, though: it carries every OTHER serializer's
+        // messages too, so a serializer that adopts none of them would still see this model change
+        // shape whenever any of them do -- exactly the cross-serializer poisoning
+        // ResolvedSerializer.Equals must avoid (see BuildResolvedMessageTable's doc comment).
+        // ResolveClosedGenericSchemas is safe from that same poisoning by construction: it resolves
+        // ONLY this serializer's own ClosedGenericSchemas against its own Formatters, never touching
+        // declaredMessages at all.
         var unionPlan = PlanUnionHelpers(resolved.ReachableMessages, resolved.ResolvedMessagesByType);
-        var resolvedClosedGenericRegistrations = ResolveClosedGenericRegistrations(serializer.ClosedGenericRegistrations, resolved.ResolvedMessagesByType);
+        var resolvedClosedGenericSchemas = ResolveClosedGenericSchemas(serializer);
         var resolvedMessagesByType = BuildResolvedMessageTable(resolved.ReachableMessages);
 
         return ResolvedSerializer.Emittable(
@@ -176,7 +178,7 @@ public sealed partial class AkkaSerializerGenerator
             resolvedMessagesByType,
             topLevelMessages,
             resolved.ReachableMessages,
-            resolvedClosedGenericRegistrations,
+            resolvedClosedGenericSchemas,
             usedFormatters,
             unionPlan,
             validationDiagnostics.ToImmutable());
@@ -184,24 +186,42 @@ public sealed partial class AkkaSerializerGenerator
 
     /// <summary>
     /// The message table actually STORED on <see cref="ResolvedSerializer.ResolvedMessagesByType"/>:
-    /// only this serializer's own reachable messages, keyed by type name -- deliberately narrower
-    /// than the full, whole-compilation dictionary <see cref="ResolveSerializerMessages"/> builds
-    /// (and validation still uses, unchanged) internally. A serializer's cached
-    /// <see cref="ResolvedSerializer"/> must depend only on what actually shapes ITS OWN output; the
-    /// full dictionary includes every other serializer's messages too, so storing it verbatim would
-    /// make an untouched serializer's resolved model compare UNEQUAL whenever some unrelated
-    /// serializer's message changed -- defeating the per-serializer caching this stage exists for.
-    /// Every top-level message is already a member of <paramref name="reachableMessages"/> (see
-    /// <see cref="CollectReachableMessages"/>, which seeds its walk from the top-level set), so
-    /// nothing is lost by keying only off it.
+    /// only this serializer's own reachable messages, keyed by type -- deliberately narrower than the
+    /// full, whole-compilation dictionary <see cref="ResolveSerializerMessages"/> builds (and
+    /// validation still uses, unchanged) internally. A serializer's cached <see cref="ResolvedSerializer"/>
+    /// must depend only on what actually shapes ITS OWN output; the full dictionary includes every
+    /// other serializer's messages too, so storing it verbatim would make an untouched serializer's
+    /// resolved model compare UNEQUAL whenever some unrelated serializer's message changed --
+    /// defeating the per-serializer caching this stage exists for. Every top-level message is already
+    /// a member of <paramref name="reachableMessages"/> (see <see cref="CollectReachableMessages"/>,
+    /// which seeds its walk from the top-level set), so nothing is lost by keying only off it.
     /// </summary>
-    private static ImmutableDictionary<string, MessageInfo> BuildResolvedMessageTable(ImmutableArray<MessageInfo> reachableMessages)
+    private static ImmutableDictionary<TypeKey, MessageInfo> BuildResolvedMessageTable(ImmutableArray<MessageInfo> reachableMessages)
     {
-        var builder = ImmutableDictionary.CreateBuilder<string, MessageInfo>(StringComparer.Ordinal);
+        var builder = ImmutableDictionary.CreateBuilder<TypeKey, MessageInfo>();
         foreach (var message in reachableMessages)
-            builder[message.FullyQualifiedName] = message;
+            builder[message.Key] = message;
 
         return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Resolves this serializer's OWN closed-generic registrations -- <see cref="SerializerInfo.ClosedGenericSchemas"/>
+    /// -- to their formatter-substituted form, keyed by <see cref="TypeKey"/>: the "one schema table"
+    /// for this serializer's registrations. Deliberately self-scoped, exactly like
+    /// <see cref="BuildResolvedMessageTable"/>'s narrowing: it depends only on THIS serializer's own
+    /// <see cref="SerializerInfo.ClosedGenericSchemas"/> and <see cref="SerializerInfo.Formatters"/>,
+    /// reusing the SAME per-key-independent <see cref="ResolveMessages"/> transform every other
+    /// message goes through -- never the whole-compilation <c>declaredMessages</c> array -- so an
+    /// edit to an unrelated message can never change this table.
+    /// </summary>
+    private static ImmutableDictionary<TypeKey, MessageInfo> ResolveClosedGenericSchemas(SerializerInfo serializer)
+    {
+        if (serializer.ClosedGenericSchemas.IsDefaultOrEmpty)
+            return ImmutableDictionary<TypeKey, MessageInfo>.Empty;
+
+        var schemasByKey = serializer.ClosedGenericSchemas.ToImmutableDictionary(message => message.Key);
+        return ResolveMessages(schemasByKey, serializer.Formatters);
     }
 
     /// <summary>
@@ -245,33 +265,31 @@ public sealed partial class AkkaSerializerGenerator
     {
         var allMessages = declaredMessages
             .Where(message => !message.IsGenericDefinition)
-            .Concat(serializer.ClosedGenericRegistrations
-                .Where(registration => registration.Message != null)
-                .Select(registration => registration.Message!))
+            .Concat(serializer.ClosedGenericSchemas)
             .ToImmutableArray();
-        var allMessagesByType = allMessages.ToImmutableDictionary(message => message.FullyQualifiedName);
+        var allMessagesByType = allMessages.ToImmutableDictionary(message => message.Key);
         var resolvedMessagesByType = ResolveMessages(allMessagesByType, serializer.Formatters);
         var topLevelMessages = allMessages
             .Where(message => serializer.ProtocolTypeFullName.Length > 0 && message.Protocols.Contains(serializer.ProtocolTypeFullName))
-            .Select(message => resolvedMessagesByType[message.FullyQualifiedName])
+            .Select(message => resolvedMessagesByType[message.Key])
             .ToImmutableArray();
         var reachableMessages = CollectReachableMessages(topLevelMessages, resolvedMessagesByType);
 
         return new ResolvedSerializerMessages(topLevelMessages, reachableMessages, resolvedMessagesByType);
     }
 
-    private static ImmutableDictionary<string, MessageInfo> ResolveMessages(
-        ImmutableDictionary<string, MessageInfo> allMessagesByType,
+    private static ImmutableDictionary<TypeKey, MessageInfo> ResolveMessages(
+        ImmutableDictionary<TypeKey, MessageInfo> allMessagesByType,
         ImmutableArray<FormatterInfo> formatters)
     {
         if (formatters.IsDefaultOrEmpty)
             return allMessagesByType;
 
-        var formattersByTarget = new Dictionary<string, FormatterInfo>(StringComparer.Ordinal);
+        var formattersByTarget = new Dictionary<TypeKey, FormatterInfo>();
         foreach (var formatter in formatters)
-            formattersByTarget[formatter.TargetTypeFullName] = formatter;
+            formattersByTarget[formatter.TargetTypeKey] = formatter;
 
-        var builder = ImmutableDictionary.CreateBuilder<string, MessageInfo>();
+        var builder = ImmutableDictionary.CreateBuilder<TypeKey, MessageInfo>();
         foreach (var pair in allMessagesByType)
         {
             var message = pair.Value;
@@ -282,9 +300,9 @@ public sealed partial class AkkaSerializerGenerator
             {
                 if (field.Mapping.Kind != FieldKind.EnvelopePayload &&
                     field.Mapping.TypeFullName.Length > 0 &&
-                    formattersByTarget.TryGetValue(field.Mapping.TypeFullName, out var formatter))
+                    formattersByTarget.TryGetValue(field.Mapping.Key, out var formatter))
                 {
-                    resolvedFields.Add(field.WithFormatter(new TypeMapping(FieldKind.Formatted, field.Mapping.TypeFullName), formatter));
+                    resolvedFields.Add(field.WithFormatter(new TypeMapping(FieldKind.Formatted, field.Mapping.Key), formatter));
                     changed = true;
                 }
                 else
@@ -384,39 +402,9 @@ public sealed partial class AkkaSerializerGenerator
     {
         var builder = ImmutableArray.CreateBuilder<ClosedSetMember>(messages.Length);
         foreach (var message in messages)
-            builder.Add(new ClosedSetMember(message.FullyQualifiedName, message.Manifest, GetMessageMethodName(message)));
+            builder.Add(new ClosedSetMember(message.Key, message.Manifest, GetMessageMethodName(message)));
 
         return new ClosedSet(builder.ToImmutable());
-    }
-
-    /// <summary>
-    /// Rewrites each closed-generic registration's <see cref="ClosedGenericRegistrationInfo.Message"/>
-    /// to the FORMATTER-RESOLVED version of that message from <paramref name="resolvedMessagesByType"/>
-    /// (see <see cref="ResolveMessages"/>) -- a registration's message, as extracted, predates
-    /// per-serializer formatter substitution, exactly like every other message
-    /// <see cref="ResolveSerializerMessages"/> folds in. An invalid registration
-    /// (<see cref="ClosedGenericRegistrationInfo.Message"/> is null, or its type never made it into
-    /// the resolved table) passes through unchanged -- AKKASG020 already gates that case in
-    /// <see cref="EvaluateGate"/>, so this never actually happens for an emittable serializer, but a
-    /// bare pass-through is simpler than asserting it here too.
-    /// </summary>
-    private static ImmutableArray<ClosedGenericRegistrationInfo> ResolveClosedGenericRegistrations(
-        ImmutableArray<ClosedGenericRegistrationInfo> registrations,
-        ImmutableDictionary<string, MessageInfo> resolvedMessagesByType)
-    {
-        if (registrations.IsDefaultOrEmpty)
-            return ImmutableArray<ClosedGenericRegistrationInfo>.Empty;
-
-        var builder = ImmutableArray.CreateBuilder<ClosedGenericRegistrationInfo>(registrations.Length);
-        foreach (var registration in registrations)
-        {
-            if (registration.Message != null && resolvedMessagesByType.TryGetValue(registration.Message.FullyQualifiedName, out var resolvedMessage))
-                builder.Add(new ClosedGenericRegistrationInfo(registration.TargetDisplayName, resolvedMessage));
-            else
-                builder.Add(registration);
-        }
-
-        return builder.ToImmutable();
     }
 
     private static ImmutableArray<FormatterInfo> CollectUsedFormatters(ImmutableArray<MessageInfo> reachableMessages)
@@ -957,7 +945,7 @@ public sealed partial class AkkaSerializerGenerator
     /// (field-level overrides), later ones -- ordered by signature for determinism -- get a numeric
     /// suffix.
     /// </summary>
-    private static UnionPlan PlanUnionHelpers(ImmutableArray<MessageInfo> reachableMessages, ImmutableDictionary<string, MessageInfo> messagesByType)
+    private static UnionPlan PlanUnionHelpers(ImmutableArray<MessageInfo> reachableMessages, ImmutableDictionary<TypeKey, MessageInfo> messagesByType)
     {
         var representatives = new Dictionary<string, FieldInfo>(StringComparer.Ordinal);
         foreach (var message in reachableMessages)
@@ -994,15 +982,15 @@ public sealed partial class AkkaSerializerGenerator
     /// messagesByType.ContainsKey(...)</c>) and reduced to the (type name, manifest, method name)
     /// triple every union write/read/size helper actually needs -- exactly a <see cref="ClosedSet"/>.
     /// </summary>
-    private static ClosedSet BuildUnionMembers(FieldInfo field, ImmutableDictionary<string, MessageInfo> messagesByType)
+    private static ClosedSet BuildUnionMembers(FieldInfo field, ImmutableDictionary<TypeKey, MessageInfo> messagesByType)
     {
         var builder = ImmutableArray.CreateBuilder<ClosedSetMember>();
         foreach (var member in field.UnionMembers)
         {
-            if (!member.IsSupported || !messagesByType.TryGetValue(member.TypeFullName, out var memberMessage))
+            if (!member.IsSupported || !messagesByType.TryGetValue(member.Key, out var memberMessage))
                 continue;
 
-            builder.Add(new ClosedSetMember(member.TypeFullName, memberMessage.Manifest, GetMessageMethodName(memberMessage)));
+            builder.Add(new ClosedSetMember(member.Key, memberMessage.Manifest, GetMessageMethodName(memberMessage)));
         }
 
         return new ClosedSet(builder.ToImmutable());

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Extraction.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Extraction.cs
@@ -91,17 +91,17 @@ public sealed partial class AkkaSerializerGenerator
         }
 
         // The protocol type symbol is consumed HERE and only here: everything the pipeline needs
-        // downstream is its fully-qualified name (dispatch/grouping keys) and whether it is an
-        // interface (AKKASG033). Retaining the INamedTypeSymbol in the cached model would defeat
-        // incremental caching outright -- symbols never compare equal across compilations.
+        // downstream is its key (dispatch/grouping) and whether it is an interface (AKKASG033).
+        // Retaining the INamedTypeSymbol in the cached model would defeat incremental caching
+        // outright -- symbols never compare equal across compilations.
         var protocolType = attribute.AttributeClass?.TypeArguments.FirstOrDefault() as INamedTypeSymbol;
-        var protocolTypeFullName = protocolType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? string.Empty;
+        var protocolTypeKey = protocolType != null ? TypeKey.FromSymbol(protocolType) : default;
         var protocolTypeIsInterface = protocolType?.TypeKind == TypeKind.Interface;
 
         var formatterAttributeType = compilation.GetTypeByMetadataName(FormatterAttributeFullName);
         var extendedActorSystemType = compilation.GetTypeByMetadataName(ExtendedActorSystemFullName);
         var formatters = ExtractFormatters(symbol, formatterAttributeType, extendedActorSystemType);
-        var closedGenericRegistrations = ExtractClosedGenericRegistrations(symbol, compilation);
+        var (closedGenericRegistrations, closedGenericSchemas) = ExtractClosedGenericRegistrations(symbol, compilation);
 
         return new SerializerInfo(
             GetNamespace(symbol),
@@ -109,11 +109,12 @@ public sealed partial class AkkaSerializerGenerator
             GetFullyQualifiedTypeName(symbol),
             name ?? string.Empty,
             serializerId,
-            protocolTypeFullName,
+            protocolTypeKey,
             protocolTypeIsInterface,
             symbol.DeclaredAccessibility,
             formatters,
             closedGenericRegistrations,
+            closedGenericSchemas,
             IsPartial(symbol),
             symbol.IsGenericType,
             DerivesFromAkkaSerializerBase(symbol, compilation));
@@ -162,26 +163,31 @@ public sealed partial class AkkaSerializerGenerator
     }
 
     /// <summary>
-    /// Extracts <c>[AkkaSerializable&lt;T&gt;]</c> registrations from the serializer class. A
-    /// valid target is a CLOSED generic construction (no unbound generics, no type parameters
-    /// anywhere in its arguments) whose definition is annotated <c>[AkkaSerializable]</c>; its
-    /// <see cref="MessageInfo"/> is built from the constructed symbol, so all field types arrive
-    /// already substituted. Invalid targets are recorded with a null message so AKKASG020 fires.
+    /// Extracts <c>[AkkaSerializable&lt;T&gt;]</c> registrations from the serializer class, as light
+    /// specs (see <see cref="ClosedGenericRegistrationInfo"/>) plus the full schema for every VALID
+    /// target (see <see cref="SerializerInfo.ClosedGenericSchemas"/>). A valid target is a CLOSED
+    /// generic construction (no unbound generics, no type parameters anywhere in its arguments) whose
+    /// definition is annotated <c>[AkkaSerializable]</c>; its schema is built from the constructed
+    /// symbol through the SAME <see cref="ExtractMessageCore"/> routine every other schema goes
+    /// through, so all field types arrive already substituted. An invalid target gets a registration
+    /// with no matching schema entry, so AKKASG020 fires instead of the registration silently
+    /// vanishing.
     /// </summary>
-    private static ImmutableArray<ClosedGenericRegistrationInfo> ExtractClosedGenericRegistrations(INamedTypeSymbol symbol, Compilation compilation)
+    private static (ImmutableArray<ClosedGenericRegistrationInfo> Registrations, ImmutableArray<MessageInfo> Schemas) ExtractClosedGenericRegistrations(INamedTypeSymbol symbol, Compilation compilation)
     {
         var genericSerializableAttribute = compilation.GetTypeByMetadataName(GenericSerializableAttributeFullName);
         if (genericSerializableAttribute == null)
-            return ImmutableArray<ClosedGenericRegistrationInfo>.Empty;
+            return (ImmutableArray<ClosedGenericRegistrationInfo>.Empty, ImmutableArray<MessageInfo>.Empty);
 
         var attributes = symbol.GetAttributes()
             .Where(attr => attr.AttributeClass is { IsGenericType: true } ac && SymbolEqualityComparer.Default.Equals(ac.OriginalDefinition, genericSerializableAttribute))
             .ToImmutableArray();
         if (attributes.IsEmpty)
-            return ImmutableArray<ClosedGenericRegistrationInfo>.Empty;
+            return (ImmutableArray<ClosedGenericRegistrationInfo>.Empty, ImmutableArray<MessageInfo>.Empty);
 
         var knownTypes = KnownTypes.From(compilation);
-        var builder = ImmutableArray.CreateBuilder<ClosedGenericRegistrationInfo>(attributes.Length);
+        var registrationsBuilder = ImmutableArray.CreateBuilder<ClosedGenericRegistrationInfo>(attributes.Length);
+        var schemasBuilder = ImmutableArray.CreateBuilder<MessageInfo>();
         foreach (var attribute in attributes)
         {
             var manifest = string.Empty;
@@ -200,8 +206,8 @@ public sealed partial class AkkaSerializerGenerator
 
             if (!isValidTarget)
             {
-                var displayName = attribute.AttributeClass!.TypeArguments[0].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-                builder.Add(new ClosedGenericRegistrationInfo(displayName, message: null));
+                var targetKey = TypeKey.FromSymbol(attribute.AttributeClass!.TypeArguments[0]);
+                registrationsBuilder.Add(new ClosedGenericRegistrationInfo(targetKey, manifest: string.Empty, allowEmpty: false));
                 continue;
             }
 
@@ -210,18 +216,20 @@ public sealed partial class AkkaSerializerGenerator
             // registration attribute.
             var allowEmpty = serializableAttribute!.NamedArguments
                 .Any(argument => argument.Key == "AllowEmpty" && argument.Value.Value is true);
+            var targetTypeKey = TypeKey.FromSymbol(target!);
             var message = ExtractMessageCore(
                 target!,
-                GetMessageDictionaryKey(target!),
+                targetTypeKey,
                 manifest,
                 allowEmpty,
                 knownTypes,
                 compilation,
                 definitionFullName: GetFullyQualifiedTypeName(target!.OriginalDefinition));
-            builder.Add(new ClosedGenericRegistrationInfo(message.FullyQualifiedName, message));
+            registrationsBuilder.Add(new ClosedGenericRegistrationInfo(targetTypeKey, manifest, allowEmpty));
+            schemasBuilder.Add(message);
         }
 
-        return builder.ToImmutable();
+        return (registrationsBuilder.ToImmutable(), schemasBuilder.ToImmutable());
     }
 
     /// <summary>
@@ -284,9 +292,7 @@ public sealed partial class AkkaSerializerGenerator
             // Both remain recorded with IsTargetSupported = false so AKKASG011 fires.
             var targetNamedType = targetTypeSymbol as INamedTypeSymbol;
             var isTargetSupported = targetNamedType is { IsGenericType: false };
-            var targetTypeFullName = isTargetSupported
-                ? GetFullyQualifiedTypeName(targetNamedType!)
-                : targetTypeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            var targetTypeKey = TypeKey.FromSymbol(targetTypeSymbol);
 
             var formatterNamedType = formatterTypeSymbol as INamedTypeSymbol;
             var formatterTypeFullName = formatterNamedType != null
@@ -307,7 +313,7 @@ public sealed partial class AkkaSerializerGenerator
                 : FormatterCtorKind.None;
 
             builder.Add(new FormatterInfo(
-                targetTypeFullName,
+                targetTypeKey,
                 targetTypeSymbol.IsValueType,
                 formatterTypeFullName,
                 isAbstract,
@@ -370,7 +376,7 @@ public sealed partial class AkkaSerializerGenerator
         {
             return new MessageInfo(
                 symbol.Name,
-                GetFullyQualifiedTypeName(symbol),
+                BuildGenericDefinitionKey(symbol),
                 manifest,
                 ImmutableArray<FieldInfo>.Empty,
                 GetProtocolNames(symbol),
@@ -381,7 +387,28 @@ public sealed partial class AkkaSerializerGenerator
                 constructionPlan: ConstructionPlan.Empty);
         }
 
-        return ExtractMessageCore(symbol, GetFullyQualifiedTypeName(symbol), manifest, allowEmpty, knownTypes, compilation, definitionFullName: string.Empty);
+        return ExtractMessageCore(symbol, TypeKey.FromSymbol(symbol), manifest, allowEmpty, knownTypes, compilation, definitionFullName: string.Empty);
+    }
+
+    /// <summary>
+    /// The key for a generic <c>[AkkaSerializable]</c> DEFINITION placeholder (e.g. <c>Wrapper&lt;T&gt;</c>
+    /// itself, as opposed to one of its registered closed constructions). This placeholder is never
+    /// stored in any message dictionary (<see cref="ResolveSerializerMessages"/> excludes every
+    /// <see cref="MessageInfo.IsGenericDefinition"/> entry), so its <see cref="TypeKey.MetadataName"/>/
+    /// <see cref="TypeKey.TypeArguments"/> are never actually looked up against -- what DOES matter is
+    /// that its <see cref="TypeKey.DisplayName"/> keeps rendering the same ARITY-LESS text
+    /// <see cref="GetFullyQualifiedTypeName"/> has always produced for it (e.g. "Wrapper", never
+    /// "Wrapper&lt;T&gt;"), since <see cref="MessageInfo.FullyQualifiedName"/> is compared against
+    /// <see cref="MessageInfo.DefinitionFullName"/> (AKKASG022's registration-coverage check) and
+    /// rendered directly into AKKASG037's message text -- both of which predate this key entirely.
+    /// A plain <see cref="TypeKey.FromSymbol"/> would instead render the type-parameter list (e.g.
+    /// "Wrapper&lt;T&gt;"), since <c>ToDisplayString</c> shows a generic type DEFINITION's own type
+    /// parameters.
+    /// </summary>
+    private static TypeKey BuildGenericDefinitionKey(INamedTypeSymbol symbol)
+    {
+        var key = TypeKey.FromSymbol(symbol);
+        return new TypeKey(key.MetadataName, key.TypeArguments, GetFullyQualifiedTypeName(symbol));
     }
 
     /// <summary>
@@ -418,7 +445,7 @@ public sealed partial class AkkaSerializerGenerator
         {
             return new MessageInfo(
                 type.Name,
-                GetFullyQualifiedTypeName(type),
+                BuildGenericDefinitionKey(type),
                 manifest,
                 ImmutableArray<FieldInfo>.Empty,
                 GetProtocolNames(type),
@@ -429,7 +456,7 @@ public sealed partial class AkkaSerializerGenerator
                 constructionPlan: ConstructionPlan.Empty);
         }
 
-        return ExtractMessageCore(type, GetFullyQualifiedTypeName(type), manifest, allowEmpty, knownTypes, compilation, definitionFullName: string.Empty);
+        return ExtractMessageCore(type, TypeKey.FromSymbol(type), manifest, allowEmpty, knownTypes, compilation, definitionFullName: string.Empty);
     }
 
     /// <summary>
@@ -442,7 +469,7 @@ public sealed partial class AkkaSerializerGenerator
     /// </summary>
     private static MessageInfo ExtractMessageCore(
         INamedTypeSymbol symbol,
-        string fullyQualifiedName,
+        TypeKey key,
         string manifest,
         bool allowEmpty,
         KnownTypes knownTypes,
@@ -506,7 +533,7 @@ public sealed partial class AkkaSerializerGenerator
 
         return new MessageInfo(
             symbol.Name,
-            fullyQualifiedName,
+            key,
             manifest,
             fields.OrderBy(f => f.Index).ToImmutableArray(),
             GetProtocolNames(symbol),
@@ -725,12 +752,13 @@ public sealed partial class AkkaSerializerGenerator
                 var displayName = argument.Value is ITypeSymbol typeSymbol
                     ? typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
                     : "<null>";
-                builder.Add(new UnionMemberInfo(displayName, isValueType: false, isAssignable: false, isSupported: false, isSealed: false, isAbstract: false));
+                var fallbackKey = new TypeKey(displayName, ImmutableArray<TypeKey>.Empty, displayName);
+                builder.Add(new UnionMemberInfo(fallbackKey, isValueType: false, isAssignable: false, isSupported: false, isSealed: false, isAbstract: false));
                 continue;
             }
 
             builder.Add(new UnionMemberInfo(
-                GetMessageDictionaryKey(memberType),
+                TypeKey.FromSymbol(memberType),
                 memberType.IsValueType,
                 compilation.HasImplicitConversion(memberType, member.Type),
                 isSupported: true,
@@ -742,33 +770,20 @@ public sealed partial class AkkaSerializerGenerator
         return builder.ToImmutable();
     }
 
-    /// <summary>
-    /// The key a type is looked up under in the serializer's message dictionary. Non-generic types
-    /// use the arity-less <see cref="GetFullyQualifiedTypeName"/> (the existing key for every
-    /// <c>[AkkaSerializable]</c> message); closed generic constructions use the full,
-    /// fully-qualified display string (e.g. <c>Ns.Wrapper&lt;Ns.Foo&gt;</c>) so distinct
-    /// constructions stay distinct.
-    /// </summary>
-    private static string GetMessageDictionaryKey(INamedTypeSymbol type)
-    {
-        return type.IsGenericType
-            ? type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
-            : GetFullyQualifiedTypeName(type);
-    }
-
     private static TypeMapping MapType(ITypeSymbol type, KnownTypes knownTypes)
     {
         if (TryGetNullableValueType(type, out var underlyingType))
             return MapType(underlyingType, knownTypes);
 
-        // Only attach the fallback underlying-type name for NON-GENERIC named types:
-        // GetFullyQualifiedTypeName is arity-less, so stamping it onto a generic field type
-        // (e.g. Result<int>) would let it match a formatter registered for a same-named
-        // non-generic type (Result) and emit ill-typed code. Generic field types keep an empty
-        // mapping name, can never match a formatter, and still fail with AKKASG003.
+        // Only attach the fallback underlying-type key for NON-GENERIC named types: stamping a key
+        // onto a generic field type (e.g. Result<int>) would let it match a formatter registered for
+        // a same-named non-generic type (Result) and emit ill-typed code -- TypeKey's metadata name
+        // carries the arity suffix, so this guard still matters even though the key is no longer a
+        // bare arity-less string. Generic field types keep a default (empty) key, can never match a
+        // formatter, and still fail with AKKASG003.
         var mapping = MapTypeCore(type, knownTypes);
         if (mapping.TypeFullName.Length == 0 && type is INamedTypeSymbol { IsGenericType: false } namedType)
-            return mapping.WithTypeFullName(GetFullyQualifiedTypeName(namedType));
+            return mapping.WithKey(TypeKey.FromSymbol(namedType));
 
         return mapping;
     }
@@ -785,11 +800,11 @@ public sealed partial class AkkaSerializerGenerator
             {
                 return new TypeMapping(
                     FieldKind.UnsupportedEnumUnderlyingType,
-                    GetFullyQualifiedTypeName(enumType),
+                    TypeKey.FromSymbol(enumType),
                     enumUnderlyingTypeName: underlyingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
             }
 
-            return new TypeMapping(FieldKind.Enum, GetFullyQualifiedTypeName(enumType));
+            return new TypeMapping(FieldKind.Enum, TypeKey.FromSymbol(enumType));
         }
 
         if (type is IArrayTypeSymbol { ElementType.SpecialType: SpecialType.System_Byte })
@@ -797,13 +812,14 @@ public sealed partial class AkkaSerializerGenerator
 
         // OriginalDefinition covers both shapes: for a non-generic type it is the type itself; for a
         // closed generic construction (Wrapper<Foo>) the [AkkaSerializable] attribute lives on the
-        // definition. The mapping name is arity-aware (GetMessageDictionaryKey) so a closed
-        // construction resolves to its registered [AkkaSerializable<T>] message -- or, if
-        // unregistered, fails AKKASG023 instead of silently dropping its type arguments.
+        // definition. The mapping key is TypeKey.FromSymbol, whose metadata name plus type arguments
+        // are arity-aware and construction-aware, so a closed construction resolves to its registered
+        // [AkkaSerializable<T>] message -- or, if unregistered, fails AKKASG023 instead of silently
+        // dropping its type arguments.
         if (type is INamedTypeSymbol namedType && namedType.OriginalDefinition.GetAttributes().Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, knownTypes.SerializableAttribute)))
             return new TypeMapping(
                 FieldKind.Object,
-                GetMessageDictionaryKey(namedType),
+                TypeKey.FromSymbol(namedType),
                 namedType.IsValueType,
                 foreignAssemblyName: GetForeignAssemblyName(namedType, knownTypes),
                 isGenericConstruction: namedType.IsGenericType);
@@ -830,7 +846,7 @@ public sealed partial class AkkaSerializerGenerator
             return collectionMapping;
 
         if (type is INamedTypeSymbol { IsGenericType: false, TypeKind: TypeKind.Class or TypeKind.Struct } missingNestedType)
-            return new TypeMapping(FieldKind.MissingSerializableDefinition, GetFullyQualifiedTypeName(missingNestedType), foreignAssemblyName: GetForeignAssemblyName(missingNestedType, knownTypes));
+            return new TypeMapping(FieldKind.MissingSerializableDefinition, TypeKey.FromSymbol(missingNestedType), foreignAssemblyName: GetForeignAssemblyName(missingNestedType, knownTypes));
 
         // AKKASG003 on an interface, an abstract class, or a type parameter is usually a forgotten
         // [AkkaUnion] declaration, or a field that should simply be typed `object`, rather than a
@@ -1003,7 +1019,7 @@ public sealed partial class AkkaSerializerGenerator
         {
             collapsed = new TypeMapping(
                 FieldKind.UnsupportedEnumUnderlyingType,
-                element.TypeFullName,
+                element.Key,
                 enumUnderlyingTypeName: element.EnumUnderlyingTypeName);
             return true;
         }
@@ -1109,6 +1125,15 @@ public sealed partial class AkkaSerializerGenerator
 
     private static string GetFullyQualifiedTypeName(INamedTypeSymbol symbol)
     {
+        // Fast path: a non-nested type -- by far the common case -- needs no containing-type walk
+        // (or Stack allocation) at all; the general path below produces the identical string for
+        // this shape too, just at needless extra cost.
+        if (symbol.ContainingType == null)
+        {
+            var ns0 = GetNamespace(symbol);
+            return ns0.Length == 0 ? "global::" + symbol.Name : "global::" + ns0 + "." + symbol.Name;
+        }
+
         var parts = new Stack<string>();
         ISymbol? current = symbol;
         while (current is INamedTypeSymbol named)
@@ -1123,8 +1148,15 @@ public sealed partial class AkkaSerializerGenerator
 
     private static string GetNamespace(INamedTypeSymbol symbol)
     {
-        var parts = new Stack<string>();
         var ns = symbol.ContainingNamespace;
+        if (ns == null || ns.IsGlobalNamespace)
+            return string.Empty;
+
+        // Fast path: a single-segment namespace -- by far the common case -- needs no Stack/Join.
+        if (ns.ContainingNamespace == null || ns.ContainingNamespace.IsGlobalNamespace)
+            return ns.Name;
+
+        var parts = new Stack<string>();
         while (ns != null && !ns.IsGlobalNamespace)
         {
             parts.Push(ns.Name);

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Models.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Models.cs
@@ -70,8 +70,11 @@ public sealed partial class AkkaSerializerGenerator
         /// <see cref="ImmutableDictionary{TKey,TValue}"/> has no such built-in equality of its own (its
         /// default <c>Equals</c> is reference equality on the underlying node), so every dictionary-typed
         /// model member must be compared through this helper instead of a bare <c>==</c>/<c>Equals</c>.
+        /// Generic over the key type (<c>string</c> or <see cref="TypeKey"/>) so the same helper serves
+        /// every dictionary-shaped model member regardless of key kind.
         /// </summary>
-        public static bool DictionaryEquals<TValue>(ImmutableDictionary<string, TValue> left, ImmutableDictionary<string, TValue> right)
+        public static bool DictionaryEquals<TKey, TValue>(ImmutableDictionary<TKey, TValue> left, ImmutableDictionary<TKey, TValue> right)
+            where TKey : notnull
         {
             if (ReferenceEquals(left, right))
                 return true;
@@ -89,19 +92,20 @@ public sealed partial class AkkaSerializerGenerator
         }
 
         /// <summary>
-        /// Order-independent hash companion to <see cref="DictionaryEquals{TValue}"/>: entries are
+        /// Order-independent hash companion to <see cref="DictionaryEquals{TKey,TValue}"/>: entries are
         /// combined with an order-insensitive operator (addition) so two dictionaries holding the same
         /// key/value pairs in a different enumeration order still hash equal, honoring the
-        /// Equals/GetHashCode contract <see cref="DictionaryEquals{TValue}"/> establishes.
+        /// Equals/GetHashCode contract <see cref="DictionaryEquals{TKey,TValue}"/> establishes.
         /// </summary>
-        public static int CombineDictionary<TValue>(int hash, ImmutableDictionary<string, TValue> dictionary)
+        public static int CombineDictionary<TKey, TValue>(int hash, ImmutableDictionary<TKey, TValue> dictionary)
+            where TKey : notnull
         {
             hash = Combine(hash, dictionary.Count);
 
             var entriesHash = 0;
             foreach (var pair in dictionary)
             {
-                var entryHash = Combine(Combine(Seed, pair.Key), pair.Value == null ? 0 : EqualityComparer<TValue>.Default.GetHashCode(pair.Value));
+                var entryHash = Combine(Combine(Seed, EqualityComparer<TKey>.Default.GetHashCode(pair.Key)), pair.Value == null ? 0 : EqualityComparer<TValue>.Default.GetHashCode(pair.Value));
                 unchecked
                 {
                     entriesHash += entryHash;
@@ -109,6 +113,147 @@ public sealed partial class AkkaSerializerGenerator
             }
 
             return Combine(hash, entriesHash);
+        }
+    }
+
+    /// <summary>
+    /// A type's identity for every dictionary key and equality check in the pipeline, replacing the
+    /// former scheme of keying off a type's own fully-qualified DISPLAY name (a plain <c>string</c>).
+    /// <see cref="MetadataName"/> is built from exactly what <see cref="INamedTypeSymbol"/> exposes
+    /// through its own <see cref="ISymbol.MetadataName"/> (the CLR metadata name, arity suffix
+    /// included -- e.g. <c>Wrapper`1</c>) walked up its <see cref="INamedTypeSymbol.ContainingType"/>
+    /// chain joined by <c>+</c> (matching real CLR nested-type metadata names), then its containing
+    /// namespace joined by <c>.</c>. Two types whose DISPLAY STRING happens to render identically --
+    /// a nested type <c>A.Outer+Inner</c> and an unrelated namespace-qualified type <c>A.Outer.Inner</c>
+    /// both render as <c>"A.Outer.Inner"</c> -- no longer collide as a dictionary key: their
+    /// <see cref="MetadataName"/>s differ ("A.Outer+Inner" vs "A.Outer.Inner"). <see cref="TypeArguments"/>
+    /// carries the same key, recursively, for each of a generic construction's own type arguments, so
+    /// <c>Wrapper&lt;int&gt;</c> and <c>Wrapper&lt;string&gt;</c> never collide even though they share
+    /// one <see cref="MetadataName"/>.
+    /// <see cref="DisplayName"/> is carried verbatim -- the EXACT string the generator has always
+    /// rendered for this type -- so emitted text and diagnostics do not move, but it plays NO part in
+    /// <see cref="Equals(TypeKey)"/>/<see cref="GetHashCode"/>: two keys with the same metadata
+    /// identity are equal regardless of what (if anything) their <see cref="DisplayName"/> carries.
+    /// That is what lets a purely comparison-scoped key skip building a display string entirely (see
+    /// <see cref="FromSymbol"/>'s <c>includeDisplayName</c> parameter, used by the AKKASG029 protocol
+    /// coverage scan to avoid formatting every interface of every candidate type just to test it
+    /// against the serializer's own protocol type).
+    /// </summary>
+    internal readonly struct TypeKey : IEquatable<TypeKey>
+    {
+        public TypeKey(string metadataName, ImmutableArray<TypeKey> typeArguments, string displayName)
+        {
+            MetadataName = metadataName;
+            TypeArguments = typeArguments.IsDefault ? ImmutableArray<TypeKey>.Empty : typeArguments;
+            DisplayName = displayName;
+        }
+
+        /// <summary>The CLR metadata name (arity suffix included), containing types joined by '+', containing namespace joined by '.'.</summary>
+        public string MetadataName { get; }
+
+        /// <summary>Value-equal child keys for a generic construction's own type arguments; empty for a non-generic type.</summary>
+        public ImmutableArray<TypeKey> TypeArguments { get; }
+
+        /// <summary>The exact fully-qualified display string the generator has always rendered for this type. Carried verbatim; never compared.</summary>
+        public string DisplayName { get; }
+
+        /// <summary>The compact, collision-checked (AKKASG024) generated-member-name folding of <see cref="DisplayName"/>. See <see cref="FoldTypeName"/>.</summary>
+        public string Fold() => FoldTypeName(DisplayName ?? string.Empty);
+
+        public override string ToString() => DisplayName ?? string.Empty;
+
+        // Equality is METADATA-based only: MetadataName plus TypeArguments. DisplayName is carried for
+        // rendering, never compared -- see the type's own doc comment for why that split is what
+        // closes the nested-vs-dotted collision and lets a display-free comparison key exist at all.
+        public bool Equals(TypeKey other)
+        {
+            return string.Equals(MetadataName, other.MetadataName, StringComparison.Ordinal)
+                && ValueEquality.SequenceEquals(TypeArguments, other.TypeArguments);
+        }
+
+        public override bool Equals(object? obj) => obj is TypeKey other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            var hash = ValueEquality.Seed;
+            hash = ValueEquality.Combine(hash, MetadataName);
+            hash = ValueEquality.Combine(hash, TypeArguments);
+            return hash;
+        }
+
+        /// <summary>
+        /// Builds a key from a live symbol -- the only place a <see cref="TypeKey"/> is ever produced,
+        /// since extraction is the only phase with symbols. <paramref name="includeDisplayName"/> is
+        /// false only for a transient, single-compilation-pass comparison that never crosses an
+        /// incremental boundary and never needs a display string of its own: the AKKASG029 protocol
+        /// coverage scan builds a throwaway key per candidate interface purely to test it against the
+        /// serializer's own protocol key, and skipping <see cref="ISymbol.ToDisplayString(SymbolDisplayFormat)"/>
+        /// there is exactly the saving that replaces the old "format every interface of every type" scan.
+        /// </summary>
+        public static TypeKey FromSymbol(ITypeSymbol type, bool includeDisplayName = true)
+        {
+            if (type is INamedTypeSymbol named)
+            {
+                var metadataName = BuildMetadataName(named);
+
+                if (!named.IsGenericType)
+                {
+                    // Non-generic (the overwhelming common case): GetFullyQualifiedTypeName's own
+                    // dot-joined, arity-less text is IDENTICAL to ToDisplayString(FullyQualifiedFormat)
+                    // for any non-generic type, nested or not -- both are "global::" plus the
+                    // namespace plus each containing type's simple name, dot-joined; a generic type's
+                    // OWN type-parameter list is the only thing ToDisplayString would add that this
+                    // does not produce, and this branch never runs for one. Reusing it here avoids
+                    // paying for a second, independent Roslyn symbol-display pass just to populate
+                    // DisplayName, on top of the walk BuildMetadataName already did.
+                    var displayName = includeDisplayName ? GetFullyQualifiedTypeName(named) : string.Empty;
+                    return new TypeKey(metadataName, ImmutableArray<TypeKey>.Empty, displayName);
+                }
+
+                var genericDisplayName = includeDisplayName ? named.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) : string.Empty;
+                var typeArguments = BuildTypeArguments(named, includeDisplayName);
+                return new TypeKey(metadataName, typeArguments, genericDisplayName);
+            }
+
+            // A type argument that is not itself a named type (array, pointer, type parameter,
+            // dynamic, ...) has no CLR metadata name of its own to key on; its identity degrades to
+            // its display string, exactly as it already did before this type existed -- these shapes
+            // were never distinguishable from their own display string in the first place.
+            var fallbackName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return new TypeKey(fallbackName, ImmutableArray<TypeKey>.Empty, includeDisplayName ? fallbackName : string.Empty);
+        }
+
+        private static ImmutableArray<TypeKey> BuildTypeArguments(INamedTypeSymbol symbol, bool includeDisplayName)
+        {
+            var builder = ImmutableArray.CreateBuilder<TypeKey>(symbol.TypeArguments.Length);
+            foreach (var argument in symbol.TypeArguments)
+                builder.Add(FromSymbol(argument, includeDisplayName));
+
+            return builder.MoveToImmutable();
+        }
+
+        private static string BuildMetadataName(INamedTypeSymbol symbol)
+        {
+            // Fast path: a non-nested type -- by far the common case -- needs no containing-type
+            // walk (or Stack allocation) at all; the general path below produces the identical
+            // string for this shape too, just at needless extra cost.
+            if (symbol.ContainingType == null)
+            {
+                var ns0 = GetNamespace(symbol);
+                return ns0.Length == 0 ? symbol.MetadataName : ns0 + "." + symbol.MetadataName;
+            }
+
+            var parts = new Stack<string>();
+            INamedTypeSymbol? current = symbol;
+            while (current != null)
+            {
+                parts.Push(current.MetadataName);
+                current = current.ContainingType;
+            }
+
+            var ns = GetNamespace(symbol);
+            var nested = string.Join("+", parts);
+            return string.IsNullOrEmpty(ns) ? nested : ns + "." + nested;
         }
     }
 
@@ -120,11 +265,12 @@ public sealed partial class AkkaSerializerGenerator
             string fullyQualifiedName,
             string name,
             int serializerId,
-            string protocolTypeFullName,
+            TypeKey protocolTypeKey,
             bool protocolTypeIsInterface,
             Accessibility declaredAccessibility,
             ImmutableArray<FormatterInfo> formatters,
             ImmutableArray<ClosedGenericRegistrationInfo> closedGenericRegistrations,
+            ImmutableArray<MessageInfo> closedGenericSchemas,
             bool isPartial,
             bool isGeneric,
             bool derivesFromAkkaSerializerBase)
@@ -134,11 +280,12 @@ public sealed partial class AkkaSerializerGenerator
             FullyQualifiedName = fullyQualifiedName;
             Name = name;
             SerializerId = serializerId;
-            ProtocolTypeFullName = protocolTypeFullName;
+            ProtocolTypeKey = protocolTypeKey;
             ProtocolTypeIsInterface = protocolTypeIsInterface;
             DeclaredAccessibility = declaredAccessibility;
             Formatters = formatters;
             ClosedGenericRegistrations = closedGenericRegistrations;
+            ClosedGenericSchemas = closedGenericSchemas.IsDefault ? ImmutableArray<MessageInfo>.Empty : closedGenericSchemas;
             IsPartial = isPartial;
             IsGeneric = isGeneric;
             DerivesFromAkkaSerializerBase = derivesFromAkkaSerializerBase;
@@ -151,18 +298,43 @@ public sealed partial class AkkaSerializerGenerator
         public int SerializerId { get; }
 
         /// <summary>
-        /// Fully-qualified display name of the <c>[AkkaSerializer&lt;TProtocol&gt;]</c> type
-        /// argument; empty when the type argument was not a named type. All protocol matching runs
-        /// on this string (ordinal) -- the symbol itself is never retained.
+        /// Key of the <c>[AkkaSerializer&lt;TProtocol&gt;]</c> type argument; default when the type
+        /// argument was not a named type. All protocol matching runs on this key -- the symbol itself
+        /// is never retained.
         /// </summary>
-        public string ProtocolTypeFullName { get; }
+        public TypeKey ProtocolTypeKey { get; }
+
+        /// <summary>
+        /// Fully-qualified display name of the protocol type, derived from <see cref="ProtocolTypeKey"/>
+        /// -- the single source of truth for anywhere this is read for display or ordinal string
+        /// matching against <see cref="MessageInfo.Protocols"/>. Empty when the type argument was not
+        /// a named type.
+        /// </summary>
+        public string ProtocolTypeFullName => ProtocolTypeKey.DisplayName ?? string.Empty;
 
         /// <summary>Whether the protocol type argument is an interface. See AKKASG033.</summary>
         public bool ProtocolTypeIsInterface { get; }
 
         public Accessibility DeclaredAccessibility { get; }
         public ImmutableArray<FormatterInfo> Formatters { get; }
+
+        /// <summary>
+        /// This serializer's <c>[AkkaSerializable&lt;T&gt;]</c> registrations, as light specs: what to
+        /// target, its manifest, and whether an empty schema is allowed. The full extracted schema for
+        /// each VALID registration lives beside this array, in <see cref="ClosedGenericSchemas"/>, keyed
+        /// the same way as every other message -- not embedded inside the registration itself.
+        /// </summary>
         public ImmutableArray<ClosedGenericRegistrationInfo> ClosedGenericRegistrations { get; }
+
+        /// <summary>
+        /// The full <see cref="MessageInfo"/> for each VALID closed-generic registration's construction,
+        /// extracted once at extraction time (the only phase with symbols) through the same
+        /// <c>ExtractMessageCore</c> routine every other schema goes through. One entry per valid
+        /// registration in <see cref="ClosedGenericRegistrations"/> (invalid registrations have no
+        /// entry here); the resolve stage folds these into its own schema table alongside every
+        /// declared message.
+        /// </summary>
+        public ImmutableArray<MessageInfo> ClosedGenericSchemas { get; }
 
         /// <summary>Whether every syntax declaration of this class carries 'partial'. See AKKASG032.</summary>
         public bool IsPartial { get; }
@@ -186,14 +358,15 @@ public sealed partial class AkkaSerializerGenerator
                 && string.Equals(FullyQualifiedName, other.FullyQualifiedName, StringComparison.Ordinal)
                 && string.Equals(Name, other.Name, StringComparison.Ordinal)
                 && SerializerId == other.SerializerId
-                && string.Equals(ProtocolTypeFullName, other.ProtocolTypeFullName, StringComparison.Ordinal)
+                && ProtocolTypeKey.Equals(other.ProtocolTypeKey)
                 && ProtocolTypeIsInterface == other.ProtocolTypeIsInterface
                 && DeclaredAccessibility == other.DeclaredAccessibility
                 && IsPartial == other.IsPartial
                 && IsGeneric == other.IsGeneric
                 && DerivesFromAkkaSerializerBase == other.DerivesFromAkkaSerializerBase
                 && ValueEquality.SequenceEquals(Formatters, other.Formatters)
-                && ValueEquality.SequenceEquals(ClosedGenericRegistrations, other.ClosedGenericRegistrations);
+                && ValueEquality.SequenceEquals(ClosedGenericRegistrations, other.ClosedGenericRegistrations)
+                && ValueEquality.SequenceEquals(ClosedGenericSchemas, other.ClosedGenericSchemas);
         }
 
         public override bool Equals(object? obj) => Equals(obj as SerializerInfo);
@@ -206,7 +379,7 @@ public sealed partial class AkkaSerializerGenerator
             hash = ValueEquality.Combine(hash, FullyQualifiedName);
             hash = ValueEquality.Combine(hash, Name);
             hash = ValueEquality.Combine(hash, SerializerId);
-            hash = ValueEquality.Combine(hash, ProtocolTypeFullName);
+            hash = ValueEquality.Combine(hash, ProtocolTypeKey.GetHashCode());
             hash = ValueEquality.Combine(hash, ProtocolTypeIsInterface);
             hash = ValueEquality.Combine(hash, (int)DeclaredAccessibility);
             hash = ValueEquality.Combine(hash, IsPartial);
@@ -214,6 +387,7 @@ public sealed partial class AkkaSerializerGenerator
             hash = ValueEquality.Combine(hash, DerivesFromAkkaSerializerBase);
             hash = ValueEquality.Combine(hash, Formatters);
             hash = ValueEquality.Combine(hash, ClosedGenericRegistrations);
+            hash = ValueEquality.Combine(hash, ClosedGenericSchemas);
             return hash;
         }
     }
@@ -222,7 +396,7 @@ public sealed partial class AkkaSerializerGenerator
     {
         public MessageInfo(
             string simpleName,
-            string fullyQualifiedName,
+            TypeKey key,
             string manifest,
             ImmutableArray<FieldInfo> fields,
             ImmutableArray<string> protocols,
@@ -233,7 +407,7 @@ public sealed partial class AkkaSerializerGenerator
             string definitionFullName = "")
         {
             SimpleName = simpleName;
-            FullyQualifiedName = fullyQualifiedName;
+            Key = key;
             Manifest = manifest;
             Fields = fields;
             Protocols = protocols;
@@ -245,7 +419,13 @@ public sealed partial class AkkaSerializerGenerator
         }
 
         public string SimpleName { get; }
-        public string FullyQualifiedName { get; }
+
+        /// <summary>This message's own type key -- the dictionary key every message table in the pipeline is keyed by.</summary>
+        public TypeKey Key { get; }
+
+        /// <summary>Fully-qualified display name of this message's type, derived from <see cref="Key"/> -- the single source of truth for display and emission.</summary>
+        public string FullyQualifiedName => Key.DisplayName ?? string.Empty;
+
         public string Manifest { get; }
         public ImmutableArray<FieldInfo> Fields { get; }
 
@@ -293,7 +473,7 @@ public sealed partial class AkkaSerializerGenerator
         /// </summary>
         public MessageInfo WithFields(ImmutableArray<FieldInfo> fields)
         {
-            return new MessageInfo(SimpleName, FullyQualifiedName, Manifest, fields, Protocols, AllowEmpty, InvalidFields, ConstructionPlan, IsGenericDefinition, DefinitionFullName);
+            return new MessageInfo(SimpleName, Key, Manifest, fields, Protocols, AllowEmpty, InvalidFields, ConstructionPlan, IsGenericDefinition, DefinitionFullName);
         }
 
         public bool Equals(MessageInfo? other)
@@ -305,7 +485,7 @@ public sealed partial class AkkaSerializerGenerator
                 return false;
 
             return string.Equals(SimpleName, other.SimpleName, StringComparison.Ordinal)
-                && string.Equals(FullyQualifiedName, other.FullyQualifiedName, StringComparison.Ordinal)
+                && Key.Equals(other.Key)
                 && string.Equals(Manifest, other.Manifest, StringComparison.Ordinal)
                 && AllowEmpty == other.AllowEmpty
                 && IsGenericDefinition == other.IsGenericDefinition
@@ -322,7 +502,7 @@ public sealed partial class AkkaSerializerGenerator
         {
             var hash = ValueEquality.Seed;
             hash = ValueEquality.Combine(hash, SimpleName);
-            hash = ValueEquality.Combine(hash, FullyQualifiedName);
+            hash = ValueEquality.Combine(hash, Key.GetHashCode());
             hash = ValueEquality.Combine(hash, Manifest);
             hash = ValueEquality.Combine(hash, AllowEmpty);
             hash = ValueEquality.Combine(hash, IsGenericDefinition);
@@ -467,20 +647,29 @@ public sealed partial class AkkaSerializerGenerator
     }
 
     /// <summary>
-    /// A single <c>[AkkaSerializable&lt;T&gt;]</c> registration. <see cref="Message"/> is null
-    /// when the target was invalid (not a type, non-generic, unbound, or its definition lacks
-    /// <c>[AkkaSerializable]</c>) so AKKASG020 fires instead of the registration silently vanishing.
+    /// A single <c>[AkkaSerializable&lt;T&gt;]</c> registration, as a light spec: what to target, its
+    /// manifest, and whether an empty schema is allowed -- nothing else. The full schema for a VALID
+    /// target lives beside this registration, in <see cref="SerializerInfo.ClosedGenericSchemas"/>,
+    /// keyed by <see cref="Target"/> the same way as every other message; a target with no matching
+    /// entry there (not a type, non-generic, unbound, or its definition lacks <c>[AkkaSerializable]</c>)
+    /// is invalid, so AKKASG020 fires instead of the registration silently vanishing.
     /// </summary>
     internal sealed class ClosedGenericRegistrationInfo : IEquatable<ClosedGenericRegistrationInfo>
     {
-        public ClosedGenericRegistrationInfo(string targetDisplayName, MessageInfo? message)
+        public ClosedGenericRegistrationInfo(TypeKey target, string manifest, bool allowEmpty)
         {
-            TargetDisplayName = targetDisplayName;
-            Message = message;
+            Target = target;
+            Manifest = manifest;
+            AllowEmpty = allowEmpty;
         }
 
-        public string TargetDisplayName { get; }
-        public MessageInfo? Message { get; }
+        public TypeKey Target { get; }
+
+        /// <summary>Display name of <see cref="Target"/>, derived -- read only for diagnostics.</summary>
+        public string TargetDisplayName => Target.DisplayName ?? string.Empty;
+
+        public string Manifest { get; }
+        public bool AllowEmpty { get; }
 
         public bool Equals(ClosedGenericRegistrationInfo? other)
         {
@@ -490,8 +679,9 @@ public sealed partial class AkkaSerializerGenerator
             if (other is null)
                 return false;
 
-            return string.Equals(TargetDisplayName, other.TargetDisplayName, StringComparison.Ordinal)
-                && Equals(Message, other.Message);
+            return Target.Equals(other.Target)
+                && string.Equals(Manifest, other.Manifest, StringComparison.Ordinal)
+                && AllowEmpty == other.AllowEmpty;
         }
 
         public override bool Equals(object? obj) => Equals(obj as ClosedGenericRegistrationInfo);
@@ -499,8 +689,9 @@ public sealed partial class AkkaSerializerGenerator
         public override int GetHashCode()
         {
             var hash = ValueEquality.Seed;
-            hash = ValueEquality.Combine(hash, TargetDisplayName);
-            hash = ValueEquality.Combine(hash, Message?.GetHashCode() ?? 0);
+            hash = ValueEquality.Combine(hash, Target.GetHashCode());
+            hash = ValueEquality.Combine(hash, Manifest);
+            hash = ValueEquality.Combine(hash, AllowEmpty);
             return hash;
         }
     }
@@ -581,7 +772,7 @@ public sealed partial class AkkaSerializerGenerator
     {
         public TypeMapping(
             FieldKind kind,
-            string typeFullName = "",
+            TypeKey key = default,
             bool isValueType = false,
             string declaredTypeName = "",
             bool isNullable = false,
@@ -592,7 +783,7 @@ public sealed partial class AkkaSerializerGenerator
             bool isGenericConstruction = false)
         {
             Kind = kind;
-            TypeFullName = typeFullName;
+            Key = key;
             IsValueType = isValueType;
             DeclaredTypeName = declaredTypeName;
             IsNullable = isNullable;
@@ -604,7 +795,12 @@ public sealed partial class AkkaSerializerGenerator
         }
 
         public FieldKind Kind { get; }
-        public string TypeFullName { get; }
+
+        /// <summary>This mapping's type key, for a kind that names a type (Object, Formatted, Enum, MissingSerializableDefinition, UnsupportedEnumUnderlyingType); default for every scalar/collection kind.</summary>
+        public TypeKey Key { get; }
+
+        /// <summary>Fully-qualified display name derived from <see cref="Key"/> -- the single source of truth for display, emission, and dictionary-key matching by display text.</summary>
+        public string TypeFullName => Key.DisplayName ?? string.Empty;
 
         /// <summary>
         /// For <see cref="FieldKind.Object"/>: whether the annotated <c>[AkkaSerializable]</c> nested
@@ -666,11 +862,11 @@ public sealed partial class AkkaSerializerGenerator
         /// </summary>
         public bool IsGenericConstruction { get; }
 
-        public TypeMapping WithTypeFullName(string typeFullName)
-            => new(Kind, typeFullName, IsValueType, DeclaredTypeName, IsNullable, TypeArguments, EnumUnderlyingTypeName, ForeignAssemblyName, SuggestsEnvelopeOrUnion, IsGenericConstruction);
+        public TypeMapping WithKey(TypeKey key)
+            => new(Kind, key, IsValueType, DeclaredTypeName, IsNullable, TypeArguments, EnumUnderlyingTypeName, ForeignAssemblyName, SuggestsEnvelopeOrUnion, IsGenericConstruction);
 
         public TypeMapping AsCollectionElement(string declaredTypeName, bool isNullable)
-            => new(Kind, TypeFullName, IsValueType, declaredTypeName, isNullable, TypeArguments, EnumUnderlyingTypeName, ForeignAssemblyName, SuggestsEnvelopeOrUnion, IsGenericConstruction);
+            => new(Kind, Key, IsValueType, declaredTypeName, isNullable, TypeArguments, EnumUnderlyingTypeName, ForeignAssemblyName, SuggestsEnvelopeOrUnion, IsGenericConstruction);
 
         // Explicit IEquatable implementation: the compiler-provided struct equality would compare
         // the TypeArguments ImmutableArray by underlying-array REFERENCE, breaking value equality
@@ -678,7 +874,7 @@ public sealed partial class AkkaSerializerGenerator
         public bool Equals(TypeMapping other)
         {
             return Kind == other.Kind
-                && string.Equals(TypeFullName, other.TypeFullName, StringComparison.Ordinal)
+                && Key.Equals(other.Key)
                 && IsValueType == other.IsValueType
                 && string.Equals(DeclaredTypeName, other.DeclaredTypeName, StringComparison.Ordinal)
                 && IsNullable == other.IsNullable
@@ -695,7 +891,7 @@ public sealed partial class AkkaSerializerGenerator
         {
             var hash = ValueEquality.Seed;
             hash = ValueEquality.Combine(hash, (int)Kind);
-            hash = ValueEquality.Combine(hash, TypeFullName);
+            hash = ValueEquality.Combine(hash, Key.GetHashCode());
             hash = ValueEquality.Combine(hash, IsValueType);
             hash = ValueEquality.Combine(hash, DeclaredTypeName);
             hash = ValueEquality.Combine(hash, IsNullable);
@@ -716,9 +912,9 @@ public sealed partial class AkkaSerializerGenerator
     /// </summary>
     internal sealed class FormatterInfo : IEquatable<FormatterInfo>
     {
-        public FormatterInfo(string targetTypeFullName, bool isTargetValueType, string formatterTypeFullName, bool isAbstract, FormatterCtorKind ctorKind, bool isTargetSupported)
+        public FormatterInfo(TypeKey targetTypeKey, bool isTargetValueType, string formatterTypeFullName, bool isAbstract, FormatterCtorKind ctorKind, bool isTargetSupported)
         {
-            TargetTypeFullName = targetTypeFullName;
+            TargetTypeKey = targetTypeKey;
             IsTargetValueType = isTargetValueType;
             FormatterTypeFullName = formatterTypeFullName;
             IsAbstract = isAbstract;
@@ -726,7 +922,12 @@ public sealed partial class AkkaSerializerGenerator
             IsTargetSupported = isTargetSupported;
         }
 
-        public string TargetTypeFullName { get; }
+        /// <summary>Key of the formatter's target type -- what the formatter dictionary in <c>ResolveMessages</c> is keyed by.</summary>
+        public TypeKey TargetTypeKey { get; }
+
+        /// <summary>Fully-qualified display name of the target type, derived from <see cref="TargetTypeKey"/> -- read only for diagnostics and the generated formatter field name.</summary>
+        public string TargetTypeFullName => TargetTypeKey.DisplayName ?? string.Empty;
+
         public bool IsTargetValueType { get; }
         public string FormatterTypeFullName { get; }
 
@@ -747,7 +948,7 @@ public sealed partial class AkkaSerializerGenerator
             if (other is null)
                 return false;
 
-            return string.Equals(TargetTypeFullName, other.TargetTypeFullName, StringComparison.Ordinal)
+            return TargetTypeKey.Equals(other.TargetTypeKey)
                 && IsTargetValueType == other.IsTargetValueType
                 && string.Equals(FormatterTypeFullName, other.FormatterTypeFullName, StringComparison.Ordinal)
                 && IsAbstract == other.IsAbstract
@@ -760,7 +961,7 @@ public sealed partial class AkkaSerializerGenerator
         public override int GetHashCode()
         {
             var hash = ValueEquality.Seed;
-            hash = ValueEquality.Combine(hash, TargetTypeFullName);
+            hash = ValueEquality.Combine(hash, TargetTypeKey.GetHashCode());
             hash = ValueEquality.Combine(hash, IsTargetValueType);
             hash = ValueEquality.Combine(hash, FormatterTypeFullName);
             hash = ValueEquality.Combine(hash, IsAbstract);
@@ -819,9 +1020,9 @@ public sealed partial class AkkaSerializerGenerator
     /// </summary>
     internal sealed class UnionMemberInfo : IEquatable<UnionMemberInfo>
     {
-        public UnionMemberInfo(string typeFullName, bool isValueType, bool isAssignable, bool isSupported, bool isSealed, bool isAbstract, string foreignAssemblyName = "")
+        public UnionMemberInfo(TypeKey key, bool isValueType, bool isAssignable, bool isSupported, bool isSealed, bool isAbstract, string foreignAssemblyName = "")
         {
-            TypeFullName = typeFullName;
+            Key = key;
             IsValueType = isValueType;
             IsAssignable = isAssignable;
             IsSupported = isSupported;
@@ -830,8 +1031,11 @@ public sealed partial class AkkaSerializerGenerator
             ForeignAssemblyName = foreignAssemblyName;
         }
 
-        /// <summary>Message-dictionary key for the member type (arity-aware for generics).</summary>
-        public string TypeFullName { get; }
+        /// <summary>Message-dictionary key for the member type.</summary>
+        public TypeKey Key { get; }
+
+        /// <summary>Fully-qualified display name of the member type, derived from <see cref="Key"/>.</summary>
+        public string TypeFullName => Key.DisplayName ?? string.Empty;
 
         public bool IsValueType { get; }
 
@@ -863,7 +1067,7 @@ public sealed partial class AkkaSerializerGenerator
             if (other is null)
                 return false;
 
-            return string.Equals(TypeFullName, other.TypeFullName, StringComparison.Ordinal)
+            return Key.Equals(other.Key)
                 && IsValueType == other.IsValueType
                 && IsAssignable == other.IsAssignable
                 && IsSupported == other.IsSupported
@@ -877,7 +1081,7 @@ public sealed partial class AkkaSerializerGenerator
         public override int GetHashCode()
         {
             var hash = ValueEquality.Seed;
-            hash = ValueEquality.Combine(hash, TypeFullName);
+            hash = ValueEquality.Combine(hash, Key.GetHashCode());
             hash = ValueEquality.Combine(hash, IsValueType);
             hash = ValueEquality.Combine(hash, IsAssignable);
             hash = ValueEquality.Combine(hash, IsSupported);
@@ -1001,14 +1205,18 @@ public sealed partial class AkkaSerializerGenerator
     /// </summary>
     internal sealed class ClosedSetMember : IEquatable<ClosedSetMember>
     {
-        public ClosedSetMember(string typeFullName, string manifest, string methodName)
+        public ClosedSetMember(TypeKey key, string manifest, string methodName)
         {
-            TypeFullName = typeFullName;
+            Key = key;
             Manifest = manifest;
             MethodName = methodName;
         }
 
-        public string TypeFullName { get; }
+        public TypeKey Key { get; }
+
+        /// <summary>Fully-qualified display name of this member's type, derived from <see cref="Key"/> -- read only for emission.</summary>
+        public string TypeFullName => Key.DisplayName ?? string.Empty;
+
         public string Manifest { get; }
         public string MethodName { get; }
 
@@ -1020,7 +1228,7 @@ public sealed partial class AkkaSerializerGenerator
             if (other is null)
                 return false;
 
-            return string.Equals(TypeFullName, other.TypeFullName, StringComparison.Ordinal)
+            return Key.Equals(other.Key)
                 && string.Equals(Manifest, other.Manifest, StringComparison.Ordinal)
                 && string.Equals(MethodName, other.MethodName, StringComparison.Ordinal);
         }
@@ -1030,7 +1238,7 @@ public sealed partial class AkkaSerializerGenerator
         public override int GetHashCode()
         {
             var hash = ValueEquality.Seed;
-            hash = ValueEquality.Combine(hash, TypeFullName);
+            hash = ValueEquality.Combine(hash, Key.GetHashCode());
             hash = ValueEquality.Combine(hash, Manifest);
             hash = ValueEquality.Combine(hash, MethodName);
             return hash;
@@ -1194,10 +1402,10 @@ public sealed partial class AkkaSerializerGenerator
             SerializerInfo serializer,
             bool isEmittable,
             ImmutableArray<DiagnosticSpec> gateDiagnostics,
-            ImmutableDictionary<string, MessageInfo> resolvedMessagesByType,
+            ImmutableDictionary<TypeKey, MessageInfo> resolvedMessagesByType,
             ClosedSet topLevelMessages,
             ImmutableArray<MessageInfo> reachableMessages,
-            ImmutableArray<ClosedGenericRegistrationInfo> resolvedClosedGenericRegistrations,
+            ImmutableDictionary<TypeKey, MessageInfo> closedGenericSchemas,
             ImmutableArray<FormatterInfo> usedFormatters,
             UnionPlan unionPlan,
             ImmutableArray<DiagnosticSpec> validationDiagnostics)
@@ -1208,7 +1416,7 @@ public sealed partial class AkkaSerializerGenerator
             ResolvedMessagesByType = resolvedMessagesByType;
             TopLevelMessages = topLevelMessages;
             ReachableMessages = reachableMessages;
-            ResolvedClosedGenericRegistrations = resolvedClosedGenericRegistrations;
+            ClosedGenericSchemas = closedGenericSchemas;
             UsedFormatters = usedFormatters;
             UnionPlan = unionPlan;
             ValidationDiagnostics = validationDiagnostics;
@@ -1224,7 +1432,7 @@ public sealed partial class AkkaSerializerGenerator
         public ImmutableArray<DiagnosticSpec> GateDiagnostics { get; }
 
         /// <summary>Every message this serializer knows about, with formatters resolved. Empty when <see cref="IsEmittable"/> is false.</summary>
-        public ImmutableDictionary<string, MessageInfo> ResolvedMessagesByType { get; }
+        public ImmutableDictionary<TypeKey, MessageInfo> ResolvedMessagesByType { get; }
 
         /// <summary>This serializer's top-level dispatch set (Manifest/Serialize/Deserialize/SizeHint switches), in declaration order.</summary>
         public ClosedSet TopLevelMessages { get; }
@@ -1233,11 +1441,16 @@ public sealed partial class AkkaSerializerGenerator
         public ImmutableArray<MessageInfo> ReachableMessages { get; }
 
         /// <summary>
-        /// This serializer's <c>[AkkaSerializable&lt;T&gt;]</c> registrations, with each registration's
-        /// <see cref="ClosedGenericRegistrationInfo.Message"/> resolved to its formatter-substituted
-        /// form from <see cref="ResolvedMessagesByType"/> (see <see cref="ResolveClosedGenericRegistrations"/>).
+        /// This serializer's own closed-generic registrations, resolved: <see cref="SerializerInfo.ClosedGenericSchemas"/>
+        /// with formatters substituted, keyed by <see cref="TypeKey"/> -- the one schema table for this
+        /// serializer's own registrations (see <see cref="ResolveClosedGenericSchemas"/>). Built the
+        /// same SELF-SCOPED way as <see cref="UsedFormatters"/>: it depends only on this serializer's
+        /// own <see cref="SerializerInfo.ClosedGenericSchemas"/> and <see cref="SerializerInfo.Formatters"/>,
+        /// never on any other declared message, so an edit to an unrelated message can never change it
+        /// (unlike <see cref="ResolvedMessagesByType"/>'s WHOLE-compilation source table, this one never
+        /// needs narrowing to stay poison-free).
         /// </summary>
-        public ImmutableArray<ClosedGenericRegistrationInfo> ResolvedClosedGenericRegistrations { get; }
+        public ImmutableDictionary<TypeKey, MessageInfo> ClosedGenericSchemas { get; }
 
         /// <summary>The distinct hand-written formatters actually used by <see cref="ReachableMessages"/>, sorted for deterministic field/constructor emission. See <see cref="CollectUsedFormatters"/>.</summary>
         public ImmutableArray<FormatterInfo> UsedFormatters { get; }
@@ -1255,10 +1468,10 @@ public sealed partial class AkkaSerializerGenerator
                 serializer,
                 isEmittable: false,
                 gateDiagnostics: gateDiagnostics,
-                resolvedMessagesByType: ImmutableDictionary<string, MessageInfo>.Empty,
+                resolvedMessagesByType: ImmutableDictionary<TypeKey, MessageInfo>.Empty,
                 topLevelMessages: ClosedSet.Empty,
                 reachableMessages: ImmutableArray<MessageInfo>.Empty,
-                resolvedClosedGenericRegistrations: ImmutableArray<ClosedGenericRegistrationInfo>.Empty,
+                closedGenericSchemas: ImmutableDictionary<TypeKey, MessageInfo>.Empty,
                 usedFormatters: ImmutableArray<FormatterInfo>.Empty,
                 unionPlan: UnionPlan.Empty,
                 validationDiagnostics: ImmutableArray<DiagnosticSpec>.Empty);
@@ -1268,10 +1481,10 @@ public sealed partial class AkkaSerializerGenerator
         public static ResolvedSerializer Emittable(
             SerializerInfo serializer,
             ImmutableArray<DiagnosticSpec> gateDiagnostics,
-            ImmutableDictionary<string, MessageInfo> resolvedMessagesByType,
+            ImmutableDictionary<TypeKey, MessageInfo> resolvedMessagesByType,
             ClosedSet topLevelMessages,
             ImmutableArray<MessageInfo> reachableMessages,
-            ImmutableArray<ClosedGenericRegistrationInfo> resolvedClosedGenericRegistrations,
+            ImmutableDictionary<TypeKey, MessageInfo> closedGenericSchemas,
             ImmutableArray<FormatterInfo> usedFormatters,
             UnionPlan unionPlan,
             ImmutableArray<DiagnosticSpec> validationDiagnostics)
@@ -1283,7 +1496,7 @@ public sealed partial class AkkaSerializerGenerator
                 resolvedMessagesByType,
                 topLevelMessages,
                 reachableMessages,
-                resolvedClosedGenericRegistrations,
+                closedGenericSchemas,
                 usedFormatters,
                 unionPlan,
                 validationDiagnostics);
@@ -1303,10 +1516,10 @@ public sealed partial class AkkaSerializerGenerator
                 && UnionPlan.Equals(other.UnionPlan)
                 && ValueEquality.SequenceEquals(GateDiagnostics, other.GateDiagnostics)
                 && ValueEquality.SequenceEquals(ReachableMessages, other.ReachableMessages)
-                && ValueEquality.SequenceEquals(ResolvedClosedGenericRegistrations, other.ResolvedClosedGenericRegistrations)
                 && ValueEquality.SequenceEquals(UsedFormatters, other.UsedFormatters)
                 && ValueEquality.SequenceEquals(ValidationDiagnostics, other.ValidationDiagnostics)
-                && ValueEquality.DictionaryEquals(ResolvedMessagesByType, other.ResolvedMessagesByType);
+                && ValueEquality.DictionaryEquals(ResolvedMessagesByType, other.ResolvedMessagesByType)
+                && ValueEquality.DictionaryEquals(ClosedGenericSchemas, other.ClosedGenericSchemas);
         }
 
         public override bool Equals(object? obj) => Equals(obj as ResolvedSerializer);
@@ -1320,10 +1533,10 @@ public sealed partial class AkkaSerializerGenerator
             hash = ValueEquality.Combine(hash, UnionPlan.GetHashCode());
             hash = ValueEquality.Combine(hash, GateDiagnostics);
             hash = ValueEquality.Combine(hash, ReachableMessages);
-            hash = ValueEquality.Combine(hash, ResolvedClosedGenericRegistrations);
             hash = ValueEquality.Combine(hash, UsedFormatters);
             hash = ValueEquality.Combine(hash, ValidationDiagnostics);
             hash = ValueEquality.CombineDictionary(hash, ResolvedMessagesByType);
+            hash = ValueEquality.CombineDictionary(hash, ClosedGenericSchemas);
             return hash;
         }
     }

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Validation.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Validation.cs
@@ -290,6 +290,7 @@ public sealed partial class AkkaSerializerGenerator
         if (knownTypes.SerializableAttribute == null)
             return diagnostics.ToImmutable();
 
+        var protocolKey = serializer.ProtocolTypeKey;
         foreach (var candidate in GetSourceDeclaredTypes(compilation))
         {
             // This whole-compilation walk re-runs on every edit (its output combines the
@@ -302,7 +303,7 @@ public sealed partial class AkkaSerializerGenerator
             if (candidate.IsAbstract)
                 continue;
 
-            if (!ImplementsProtocol(candidate, serializer.ProtocolTypeFullName))
+            if (!ImplementsProtocol(candidate, protocolKey))
                 continue;
 
             var isMarked = candidate.GetAttributes()
@@ -317,15 +318,56 @@ public sealed partial class AkkaSerializerGenerator
         return diagnostics.ToImmutable();
     }
 
-    private static bool ImplementsProtocol(INamedTypeSymbol candidate, string protocolTypeFullName)
+    /// <summary>
+    /// Whether <paramref name="candidate"/> implements the protocol identified by <paramref name="protocolKey"/>.
+    /// Builds a comparison-only <see cref="TypeKey"/> (<c>includeDisplayName: false</c>) per
+    /// candidate interface and compares it against <paramref name="protocolKey"/> by METADATA identity
+    /// -- replacing the former per-interface <c>ToDisplayString</c> call and ordinal string compare.
+    /// Equality never reads either side's <see cref="TypeKey.DisplayName"/>, so this scan never
+    /// formats a display string for an interface it does not need one for.
+    /// <see cref="CouldMatchByMetadataName"/> filters out every interface that cannot possibly match
+    /// -- for example a record's compiler-synthesized <c>IEquatable&lt;T&gt;</c>, or any OTHER
+    /// serializer's protocol -- with a single, allocation-free string compare, before paying for a
+    /// full <see cref="TypeKey.FromSymbol"/> (which recurses into type arguments for a generic
+    /// interface). This scan runs once per candidate type per serializer and is never cached (it
+    /// combines with the live <see cref="Compilation"/>), so skipping the expensive path for the
+    /// overwhelming majority of interfaces that were never going to match is the whole saving.
+    /// </summary>
+    private static bool ImplementsProtocol(INamedTypeSymbol candidate, TypeKey protocolKey)
     {
         foreach (var implemented in candidate.AllInterfaces)
         {
-            if (string.Equals(implemented.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), protocolTypeFullName, StringComparison.Ordinal))
+            if (!CouldMatchByMetadataName(protocolKey.MetadataName, implemented.MetadataName))
+                continue;
+
+            if (TypeKey.FromSymbol(implemented, includeDisplayName: false).Equals(protocolKey))
                 return true;
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Cheap, allocation-free pre-filter for <see cref="ImplementsProtocol"/>: whether
+    /// <paramref name="candidateMetadataName"/> (an interface's own simple metadata name, arity
+    /// suffix included) could possibly be the FINAL segment of <paramref name="protocolMetadataName"/>
+    /// (the protocol's full metadata name, as <see cref="TypeKey.MetadataName"/> always builds it --
+    /// a namespace/containing-type prefix, then the type's own simple metadata name last). A
+    /// necessary, not sufficient, condition: a "yes" still falls through to the authoritative full
+    /// <see cref="TypeKey"/> comparison (two different namespaces can share a simple type name), but
+    /// a "no" can never be a false negative, since a genuine match's OWN simple metadata name is
+    /// always exactly this trailing segment.
+    /// </summary>
+    private static bool CouldMatchByMetadataName(string protocolMetadataName, string candidateMetadataName)
+    {
+        if (protocolMetadataName.Length < candidateMetadataName.Length)
+            return false;
+
+        if (!protocolMetadataName.EndsWith(candidateMetadataName, StringComparison.Ordinal))
+            return false;
+
+        var boundaryIndex = protocolMetadataName.Length - candidateMetadataName.Length - 1;
+        return boundaryIndex < 0 || protocolMetadataName[boundaryIndex] is '.' or '+';
     }
 
     /// <summary>
@@ -405,24 +447,36 @@ public sealed partial class AkkaSerializerGenerator
         return isValid;
     }
 
+    /// <summary>
+    /// Fires AKKASG020 when a registration's target has no matching entry in
+    /// <see cref="SerializerInfo.ClosedGenericSchemas"/> -- the light spec (see
+    /// <see cref="ClosedGenericRegistrationInfo"/>) carries only the target's own key, so a target
+    /// this serializer never managed to extract a schema for (not a type, non-generic, unbound, or
+    /// its definition lacks <c>[AkkaSerializable]</c>) is exactly the registration with no matching
+    /// key in <see cref="SerializerInfo.ClosedGenericSchemas"/>.
+    /// </summary>
     private static bool ValidateClosedGenericRegistrations(SerializerInfo serializer, ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
         if (serializer.ClosedGenericRegistrations.IsDefaultOrEmpty)
             return true;
 
+        var schemaKeys = new HashSet<TypeKey>();
+        foreach (var schema in serializer.ClosedGenericSchemas)
+            schemaKeys.Add(schema.Key);
+
         var isValid = true;
-        foreach (var registration in serializer.ClosedGenericRegistrations.Where(registration => registration.Message == null))
+        foreach (var registration in serializer.ClosedGenericRegistrations.Where(registration => !schemaKeys.Contains(registration.Target)))
         {
             diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidClosedGenericRegistration, ToDisplayName(registration.TargetDisplayName), serializer.ClassName));
             isValid = false;
         }
 
         foreach (var duplicate in serializer.ClosedGenericRegistrations
-                     .Where(registration => registration.Message != null)
-                     .GroupBy(registration => registration.TargetDisplayName, StringComparer.Ordinal)
+                     .Where(registration => schemaKeys.Contains(registration.Target))
+                     .GroupBy(registration => registration.Target)
                      .Where(group => group.Count() > 1))
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateClosedGenericRegistration, serializer.ClassName, ToDisplayName(duplicate.Key)));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateClosedGenericRegistration, serializer.ClassName, ToDisplayName(duplicate.Key.DisplayName ?? string.Empty)));
             isValid = false;
         }
 
@@ -446,9 +500,8 @@ public sealed partial class AkkaSerializerGenerator
             if (!definition.Protocols.Contains(serializer.ProtocolTypeFullName))
                 continue;
 
-            var hasRegistration = serializer.ClosedGenericRegistrations.Any(registration =>
-                registration.Message != null &&
-                string.Equals(registration.Message.DefinitionFullName, definition.FullyQualifiedName, StringComparison.Ordinal));
+            var hasRegistration = serializer.ClosedGenericSchemas.Any(schema =>
+                string.Equals(schema.DefinitionFullName, definition.FullyQualifiedName, StringComparison.Ordinal));
             if (hasRegistration)
                 continue;
 
@@ -461,37 +514,37 @@ public sealed partial class AkkaSerializerGenerator
 
     private static ImmutableArray<MessageInfo> CollectReachableMessages(
         ImmutableArray<MessageInfo> topLevelMessages,
-        ImmutableDictionary<string, MessageInfo> allMessagesByType)
+        ImmutableDictionary<TypeKey, MessageInfo> allMessagesByType)
     {
         var messages = ImmutableArray.CreateBuilder<MessageInfo>();
-        var visited = new HashSet<string>();
+        var visited = new HashSet<TypeKey>();
         var pending = new Queue<MessageInfo>(topLevelMessages);
 
         while (pending.Count > 0)
         {
             var message = pending.Dequeue();
-            if (!visited.Add(message.FullyQualifiedName))
+            if (!visited.Add(message.Key))
                 continue;
 
             messages.Add(message);
-            var referencedObjectTypes = new HashSet<string>(StringComparer.Ordinal);
+            var referencedObjectTypes = new HashSet<TypeKey>();
             foreach (var field in message.Fields)
             {
                 foreach (var objectMapping in EnumerateObjectMappings(field.Mapping))
-                    referencedObjectTypes.Add(objectMapping.TypeFullName);
+                    referencedObjectTypes.Add(objectMapping.Key);
 
                 // Union members are reachable exactly like nested Object fields: each member needs
                 // its Write/Read/SizeOf methods generated for the union dispatch to call into.
                 foreach (var unionMember in field.UnionMembers)
                 {
                     if (unionMember.IsSupported)
-                        referencedObjectTypes.Add(unionMember.TypeFullName);
+                        referencedObjectTypes.Add(unionMember.Key);
                 }
             }
 
-            foreach (var typeName in referencedObjectTypes)
+            foreach (var typeKey in referencedObjectTypes)
             {
-                if (allMessagesByType.TryGetValue(typeName, out var nestedMessage))
+                if (allMessagesByType.TryGetValue(typeKey, out var nestedMessage))
                     pending.Enqueue(nestedMessage);
             }
         }
@@ -519,7 +572,7 @@ public sealed partial class AkkaSerializerGenerator
         SerializerInfo serializer,
         ImmutableArray<MessageInfo> topLevelMessages,
         ImmutableArray<MessageInfo> reachableMessages,
-        ImmutableDictionary<string, MessageInfo> messagesByType,
+        ImmutableDictionary<TypeKey, MessageInfo> messagesByType,
         ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
         var isValid = true;
@@ -621,10 +674,10 @@ public sealed partial class AkkaSerializerGenerator
             // wording when the type's declaring assembly says so).
             foreach (var field in message.Fields)
             {
-                var seenTypeNames = new HashSet<string>(StringComparer.Ordinal);
+                var seenTypeKeys = new HashSet<TypeKey>();
                 foreach (var objectMapping in EnumerateObjectMappings(field.Mapping))
                 {
-                    if (!seenTypeNames.Add(objectMapping.TypeFullName) || messagesByType.ContainsKey(objectMapping.TypeFullName))
+                    if (!seenTypeKeys.Add(objectMapping.Key) || messagesByType.ContainsKey(objectMapping.Key))
                         continue;
 
                     ReportMissingNestedSchema(message, field.Name, objectMapping.TypeFullName, objectMapping, serializer.ClassName, diagnostics);
@@ -686,17 +739,18 @@ public sealed partial class AkkaSerializerGenerator
         if (serializer.ClosedGenericRegistrations.IsDefaultOrEmpty || serializer.ProtocolTypeFullName.Length == 0)
             return true;
 
-        var reachableNames = new HashSet<string>(reachableMessages.Select(message => message.FullyQualifiedName), StringComparer.Ordinal);
+        var schemasByKey = serializer.ClosedGenericSchemas.ToDictionary(schema => schema.Key);
+        var reachableKeys = new HashSet<TypeKey>(reachableMessages.Select(message => message.Key));
         var isValid = true;
         foreach (var registration in serializer.ClosedGenericRegistrations)
         {
-            if (registration.Message == null)
+            if (!schemasByKey.TryGetValue(registration.Target, out var schema))
                 continue;
 
-            if (registration.Message.Protocols.Contains(serializer.ProtocolTypeFullName))
+            if (schema.Protocols.Contains(serializer.ProtocolTypeFullName))
                 continue;
 
-            if (reachableNames.Contains(registration.Message.FullyQualifiedName))
+            if (reachableKeys.Contains(schema.Key))
                 continue;
 
             diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ClosedGenericRegistrationNotInProtocol,
@@ -719,7 +773,7 @@ public sealed partial class AkkaSerializerGenerator
     private static bool ValidateUnionField(
         MessageInfo message,
         FieldInfo field,
-        ImmutableDictionary<string, MessageInfo> messagesByType,
+        ImmutableDictionary<TypeKey, MessageInfo> messagesByType,
         string serializerClassName,
         ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
@@ -728,19 +782,21 @@ public sealed partial class AkkaSerializerGenerator
         // AkkaUnionAttribute(Type first, params Type[] rest) makes an empty member set
         // unrepresentable: `first` is a mandatory constructor argument, so [AkkaUnion()] does not
         // compile and field.UnionMembers can never be empty here. The "at least one member type is
-        // required" half of AKKASG019 that used to guard this is gone along with it.
+        // required" half of AKKASG019 that used to guard this is gone along with it. Grouped by
+        // TypeKey (not display text) so two distinct types that happen to render the same display
+        // string are never mistaken for a duplicate declaration of one type.
         foreach (var duplicate in field.UnionMembers
-                     .GroupBy(member => member.TypeFullName, StringComparer.Ordinal)
+                     .GroupBy(member => member.Key)
                      .Where(group => group.Count() > 1))
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidUnionMemberSet, field.Name, ToDisplayName(message.FullyQualifiedName), $"member type '{ToDisplayName(duplicate.Key)}' is declared more than once"));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidUnionMemberSet, field.Name, ToDisplayName(message.FullyQualifiedName), $"member type '{ToDisplayName(duplicate.Key.DisplayName ?? string.Empty)}' is declared more than once"));
             isValid = false;
         }
 
         var manifests = new Dictionary<string, List<string>>(StringComparer.Ordinal);
         foreach (var member in field.UnionMembers)
         {
-            if (!member.IsSupported || !messagesByType.TryGetValue(member.TypeFullName, out var memberMessage))
+            if (!member.IsSupported || !messagesByType.TryGetValue(member.Key, out var memberMessage))
             {
                 ReportUnionMemberNotSerializable(message, field.Name, member, serializerClassName, diagnostics);
                 isValid = false;

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorResolveSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorResolveSpec.cs
@@ -102,7 +102,7 @@ public sealed class GeneratorResolveSpec
         // implement IProtocol.
         resolved.TopLevelMessages.Members.Select(m => m.TypeFullName).Should().Equal(outer.FullyQualifiedName);
         resolved.ReachableMessages.Select(m => m.FullyQualifiedName).Should().BeEquivalentTo(new[] { outer.FullyQualifiedName, nested.FullyQualifiedName });
-        resolved.ResolvedMessagesByType.Keys.Should().BeEquivalentTo(new[] { outer.FullyQualifiedName, nested.FullyQualifiedName });
+        resolved.ResolvedMessagesByType.Keys.Select(key => key.DisplayName).Should().BeEquivalentTo(new[] { outer.FullyQualifiedName, nested.FullyQualifiedName });
     }
 
     [Fact(DisplayName = "ResolveSerializer should plan one union helper with members in declared order")]
@@ -262,11 +262,11 @@ public sealed class GeneratorResolveSpec
         return GeneratorTestHarness.Run(source).OutputCompilation;
     }
 
-    private static string ProtocolFullName(Compilation compilation, string metadataName = "ResolveSample.IProtocol")
+    private static AkkaSerializerGenerator.TypeKey ProtocolFullName(Compilation compilation, string metadataName = "ResolveSample.IProtocol")
     {
         var symbol = compilation.GetTypeByMetadataName(metadataName)
             ?? throw new InvalidOperationException($"Could not resolve '{metadataName}' in the harness compilation.");
-        return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        return AkkaSerializerGenerator.TypeKey.FromSymbol(symbol);
     }
 
     private static AkkaSerializerGenerator.MessageInfo ParseMessage(Compilation compilation, string metadataName)
@@ -277,7 +277,7 @@ public sealed class GeneratorResolveSpec
             ?? throw new InvalidOperationException($"'{metadataName}' was not recognized as [AkkaSerializable].");
     }
 
-    private static AkkaSerializerGenerator.SerializerInfo BuildSerializerInfo(string protocolTypeFullName, string className = "TestSerializer")
+    private static AkkaSerializerGenerator.SerializerInfo BuildSerializerInfo(AkkaSerializerGenerator.TypeKey protocolTypeKey, string className = "TestSerializer")
     {
         return new AkkaSerializerGenerator.SerializerInfo(
             ns: "ResolveSample",
@@ -285,11 +285,12 @@ public sealed class GeneratorResolveSpec
             fullyQualifiedName: $"global::ResolveSample.{className}",
             name: "test-serializer",
             serializerId: 1,
-            protocolTypeFullName: protocolTypeFullName,
+            protocolTypeKey: protocolTypeKey,
             protocolTypeIsInterface: true,
             declaredAccessibility: Accessibility.Public,
             formatters: ImmutableArray<AkkaSerializerGenerator.FormatterInfo>.Empty,
             closedGenericRegistrations: ImmutableArray<AkkaSerializerGenerator.ClosedGenericRegistrationInfo>.Empty,
+            closedGenericSchemas: ImmutableArray<AkkaSerializerGenerator.MessageInfo>.Empty,
             isPartial: true,
             isGeneric: false,
             derivesFromAkkaSerializerBase: true);

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorResolvedSerializerSnapshotSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorResolvedSerializerSnapshotSpec.cs
@@ -132,14 +132,17 @@ public sealed class GeneratorResolvedSerializerSnapshotSpec
             sb.AppendLine($"  {message.FullyQualifiedName}");
 
         sb.AppendLine("ResolvedMessagesByType keys (sorted):");
-        foreach (var key in resolved.ResolvedMessagesByType.Keys.OrderBy(k => k, StringComparer.Ordinal))
-            sb.AppendLine($"  {key}");
+        foreach (var key in resolved.ResolvedMessagesByType.Keys.OrderBy(k => k.DisplayName, StringComparer.Ordinal))
+            sb.AppendLine($"  {key.DisplayName}");
 
-        if (!resolved.ResolvedClosedGenericRegistrations.IsDefaultOrEmpty)
+        if (!resolved.Serializer.ClosedGenericRegistrations.IsDefaultOrEmpty)
         {
             sb.AppendLine("ResolvedClosedGenericRegistrations:");
-            foreach (var registration in resolved.ResolvedClosedGenericRegistrations)
-                sb.AppendLine($"  {registration.TargetDisplayName} -> {(registration.Message == null ? "(invalid)" : registration.Message.FullyQualifiedName)}");
+            foreach (var registration in resolved.Serializer.ClosedGenericRegistrations)
+            {
+                var resolvedMessage = resolved.ClosedGenericSchemas.TryGetValue(registration.Target, out var schema) ? schema.FullyQualifiedName : "(invalid)";
+                sb.AppendLine($"  {registration.TargetDisplayName} -> {resolvedMessage}");
+            }
         }
 
         if (!resolved.UsedFormatters.IsDefaultOrEmpty)

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorValidatorSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorValidatorSpec.cs
@@ -250,9 +250,14 @@ public sealed class GeneratorValidatorSpec
         // closed-construction model like this one -- exactly the shape ExtractClosedGenericRegistrations
         // builds via the (non-test-exposed) ExtractMessageCore in the real pipeline. Building it by
         // hand is simpler and more direct than constructing the Wrapper<int> symbol through Roslyn.
+        var wrapperIntKey = new AkkaSerializerGenerator.TypeKey(
+            "ValidatorSample.Wrapper`1",
+            ImmutableArray.Create(new AkkaSerializerGenerator.TypeKey("System.Int32", ImmutableArray<AkkaSerializerGenerator.TypeKey>.Empty, "int")),
+            "global::ValidatorSample.Wrapper<int>");
+
         var wrapperInt = new AkkaSerializerGenerator.MessageInfo(
             simpleName: "Wrapper",
-            fullyQualifiedName: "global::ValidatorSample.Wrapper<int>",
+            key: wrapperIntKey,
             manifest: "wrapper-int-v1",
             fields: ImmutableArray.Create(
                 new AkkaSerializerGenerator.FieldInfo(1, "Id", "string", new AkkaSerializerGenerator.TypeMapping(AkkaSerializerGenerator.FieldKind.String), isNullable: false),
@@ -264,8 +269,11 @@ public sealed class GeneratorValidatorSpec
             isGenericDefinition: false,
             definitionFullName: "global::ValidatorSample.Wrapper<T>");
 
-        var registration = new AkkaSerializerGenerator.ClosedGenericRegistrationInfo("global::ValidatorSample.Wrapper<int>", wrapperInt);
-        var serializer = BuildSerializerInfo(ProtocolFullName(compilation), closedGenericRegistrations: ImmutableArray.Create(registration));
+        var registration = new AkkaSerializerGenerator.ClosedGenericRegistrationInfo(wrapperInt.Key, manifest: "wrapper-int-v1", allowEmpty: false);
+        var serializer = BuildSerializerInfo(
+            ProtocolFullName(compilation),
+            closedGenericRegistrations: ImmutableArray.Create(registration),
+            closedGenericSchemas: ImmutableArray.Create(wrapperInt));
 
         // Outer neither references Wrapper<int> nor is related to it -- the registration is
         // reachable from nothing, which is exactly the "orphaned" condition AKKASG034 flags.
@@ -308,7 +316,7 @@ public sealed class GeneratorValidatorSpec
     [Fact(DisplayName = "EvaluateGate should report AKKASG032 and gate out a non-partial serializer before any message validation runs")]
     public void EvaluateGate_should_report_AKKASG032_for_non_partial_serializer()
     {
-        var serializer = BuildSerializerInfo(protocolTypeFullName: string.Empty, isPartial: false);
+        var serializer = BuildSerializerInfo(protocolTypeKey: default, isPartial: false);
 
         var gate = AkkaSerializerGenerator.EvaluateGate(
             serializer,
@@ -327,11 +335,11 @@ public sealed class GeneratorValidatorSpec
         return GeneratorTestHarness.Run(source).OutputCompilation;
     }
 
-    private static string ProtocolFullName(Compilation compilation)
+    private static AkkaSerializerGenerator.TypeKey ProtocolFullName(Compilation compilation)
     {
         var symbol = compilation.GetTypeByMetadataName(ProtocolMetadataName)
             ?? throw new InvalidOperationException($"Could not resolve '{ProtocolMetadataName}' in the harness compilation.");
-        return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        return AkkaSerializerGenerator.TypeKey.FromSymbol(symbol);
     }
 
     private static AkkaSerializerGenerator.MessageInfo ParseMessage(Compilation compilation, string metadataName)
@@ -343,9 +351,10 @@ public sealed class GeneratorValidatorSpec
     }
 
     private static AkkaSerializerGenerator.SerializerInfo BuildSerializerInfo(
-        string protocolTypeFullName,
+        AkkaSerializerGenerator.TypeKey protocolTypeKey,
         bool protocolTypeIsInterface = true,
         ImmutableArray<AkkaSerializerGenerator.ClosedGenericRegistrationInfo> closedGenericRegistrations = default,
+        ImmutableArray<AkkaSerializerGenerator.MessageInfo> closedGenericSchemas = default,
         ImmutableArray<AkkaSerializerGenerator.FormatterInfo> formatters = default,
         bool isPartial = true,
         bool isGeneric = false,
@@ -357,11 +366,12 @@ public sealed class GeneratorValidatorSpec
             fullyQualifiedName: "global::ValidatorSample.TestSerializer",
             name: "test-serializer",
             serializerId: 1,
-            protocolTypeFullName: protocolTypeFullName,
+            protocolTypeKey: protocolTypeKey,
             protocolTypeIsInterface: protocolTypeIsInterface,
             declaredAccessibility: Accessibility.Public,
             formatters: formatters.IsDefault ? ImmutableArray<AkkaSerializerGenerator.FormatterInfo>.Empty : formatters,
             closedGenericRegistrations: closedGenericRegistrations.IsDefault ? ImmutableArray<AkkaSerializerGenerator.ClosedGenericRegistrationInfo>.Empty : closedGenericRegistrations,
+            closedGenericSchemas: closedGenericSchemas.IsDefault ? ImmutableArray<AkkaSerializerGenerator.MessageInfo>.Empty : closedGenericSchemas,
             isPartial: isPartial,
             isGeneric: isGeneric,
             derivesFromAkkaSerializerBase: derivesFromAkkaSerializerBase);

--- a/src/core/Akka.Serialization.V2.Tests/TypeKeySpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/TypeKeySpec.cs
@@ -1,0 +1,167 @@
+//-----------------------------------------------------------------------
+// <copyright file="TypeKeySpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Immutable;
+using Akka.Serialization.V2.Generators;
+using Akka.Serialization.V2.Tests.Harness;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// Exercises <see cref="AkkaSerializerGenerator.TypeKey"/> directly -- the S4 architecture pass's
+/// typed replacement for every former string-keyed dictionary lookup in the generator. Covers value
+/// equality (metadata identity only; <see cref="AkkaSerializerGenerator.TypeKey.DisplayName"/> is
+/// carried but never compared), <see cref="AkkaSerializerGenerator.TypeKey.Fold"/>, and the two
+/// collision cases the metadata-name scheme exists to close: a nested type versus a
+/// namespace-qualified type that render the same fully-qualified DISPLAY string, and two closed
+/// constructions of the same generic definition over different type arguments.
+/// </summary>
+public sealed class TypeKeySpec
+{
+    [Fact(DisplayName = "TypeKey equality should compare only MetadataName and TypeArguments, ignoring DisplayName")]
+    public void Equality_should_ignore_DisplayName()
+    {
+        var left = new AkkaSerializerGenerator.TypeKey("Ns.Foo", ImmutableArray<AkkaSerializerGenerator.TypeKey>.Empty, "global::Ns.Foo");
+        var right = new AkkaSerializerGenerator.TypeKey("Ns.Foo", ImmutableArray<AkkaSerializerGenerator.TypeKey>.Empty, "an entirely different display string");
+
+        left.Equals(right).Should().BeTrue();
+        left.GetHashCode().Should().Be(right.GetHashCode());
+        left.DisplayName.Should().Be("global::Ns.Foo");
+        right.DisplayName.Should().Be("an entirely different display string");
+        left.ToString().Should().Be("global::Ns.Foo");
+    }
+
+    [Fact(DisplayName = "TypeKey equality should require matching TypeArguments even when MetadataName matches")]
+    public void Equality_should_require_matching_type_arguments()
+    {
+        var intArg = new AkkaSerializerGenerator.TypeKey("System.Int32", ImmutableArray<AkkaSerializerGenerator.TypeKey>.Empty, "int");
+        var stringArg = new AkkaSerializerGenerator.TypeKey("System.String", ImmutableArray<AkkaSerializerGenerator.TypeKey>.Empty, "string");
+
+        var wrapperOfInt = new AkkaSerializerGenerator.TypeKey("Ns.Wrapper`1", ImmutableArray.Create(intArg), "global::Ns.Wrapper<int>");
+        var wrapperOfIntAgain = new AkkaSerializerGenerator.TypeKey("Ns.Wrapper`1", ImmutableArray.Create(intArg), "global::Ns.Wrapper<int>");
+        var wrapperOfString = new AkkaSerializerGenerator.TypeKey("Ns.Wrapper`1", ImmutableArray.Create(stringArg), "global::Ns.Wrapper<string>");
+
+        wrapperOfInt.Equals(wrapperOfIntAgain).Should().BeTrue();
+        wrapperOfInt.GetHashCode().Should().Be(wrapperOfIntAgain.GetHashCode());
+        wrapperOfInt.Equals(wrapperOfString).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Fold should apply the same compact generated-member-name folding the generator has always produced")]
+    public void Fold_should_match_existing_folding_behavior()
+    {
+        var orderRequest = new AkkaSerializerGenerator.TypeKey("Ns.OrderRequest", ImmutableArray<AkkaSerializerGenerator.TypeKey>.Empty, "global::Ns.OrderRequest");
+        var wrapperOfOrderRequest = new AkkaSerializerGenerator.TypeKey("Ns.Wrapper`1", ImmutableArray.Create(orderRequest), "global::Ns.Wrapper<global::Ns.OrderRequest>");
+
+        wrapperOfOrderRequest.Fold().Should().Be("WrapperOrderRequest");
+    }
+
+    [Fact(DisplayName = "A nested type key and a namespace-qualified type key that render the same display text should be unequal")]
+    public void Nested_type_key_should_not_collide_with_namespace_qualified_type_key()
+    {
+        // Both render "A.Outer.Inner" as a fully-qualified DISPLAY string -- the exact collision the
+        // old string-keyed scheme could not tell apart. TypeKey's MetadataName carries '+' for a
+        // nested type's containment and '.' for a namespace, so the two never compare equal even
+        // though their DisplayName is identical.
+        var nested = new AkkaSerializerGenerator.TypeKey("A.Outer+Inner", ImmutableArray<AkkaSerializerGenerator.TypeKey>.Empty, "global::A.Outer.Inner");
+        var namespaceQualified = new AkkaSerializerGenerator.TypeKey("A.Outer.Inner", ImmutableArray<AkkaSerializerGenerator.TypeKey>.Empty, "global::A.Outer.Inner");
+
+        nested.DisplayName.Should().Be(namespaceQualified.DisplayName, "both must render the same display text for this to be a real collision case");
+        nested.Equals(namespaceQualified).Should().BeFalse();
+        nested.GetHashCode().Should().NotBe(namespaceQualified.GetHashCode());
+    }
+
+    [Fact(DisplayName = "TypeKey.FromSymbol should build '+'-joined metadata names for a real nested type, closing the collision against a real namespace-qualified sibling")]
+    public void FromSymbol_should_close_the_nested_type_collision_for_real_symbols()
+    {
+        const string source = """
+            namespace A
+            {
+                public class Outer
+                {
+                    public class Inner
+                    {
+                    }
+                }
+            }
+
+            namespace A.NsQualified
+            {
+                public class Inner
+                {
+                }
+            }
+            """;
+
+        var compilation = GeneratorTestHarness.Run(source).OutputCompilation;
+        var nestedSymbol = compilation.GetTypeByMetadataName("A.Outer+Inner")
+            ?? throw new InvalidOperationException("Could not resolve 'A.Outer+Inner' in the harness compilation.");
+        var namespaceQualifiedSymbol = compilation.GetTypeByMetadataName("A.NsQualified.Inner")
+            ?? throw new InvalidOperationException("Could not resolve 'A.NsQualified.Inner' in the harness compilation.");
+
+        var nestedKey = AkkaSerializerGenerator.TypeKey.FromSymbol(nestedSymbol);
+        var namespaceQualifiedKey = AkkaSerializerGenerator.TypeKey.FromSymbol(namespaceQualifiedSymbol);
+
+        nestedKey.MetadataName.Should().Be("A.Outer+Inner");
+        nestedKey.Equals(namespaceQualifiedKey).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Wrapper<int> and Wrapper<string> keys should be unequal, while two Wrapper<int> keys should be equal")]
+    public void Closed_generic_construction_keys_should_differ_by_type_argument()
+    {
+        const string source = """
+            namespace GenericsSample
+            {
+                public sealed class Wrapper<T>
+                {
+                }
+            }
+            """;
+
+        var compilation = GeneratorTestHarness.Run(source).OutputCompilation;
+        var wrapperDefinition = compilation.GetTypeByMetadataName("GenericsSample.Wrapper`1")
+            ?? throw new InvalidOperationException("Could not resolve 'GenericsSample.Wrapper`1' in the harness compilation.");
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+
+        var wrapperOfIntOne = AkkaSerializerGenerator.TypeKey.FromSymbol(wrapperDefinition.Construct(intType));
+        var wrapperOfIntTwo = AkkaSerializerGenerator.TypeKey.FromSymbol(wrapperDefinition.Construct(intType));
+        var wrapperOfString = AkkaSerializerGenerator.TypeKey.FromSymbol(wrapperDefinition.Construct(stringType));
+
+        wrapperOfIntOne.Equals(wrapperOfIntTwo).Should().BeTrue();
+        wrapperOfIntOne.GetHashCode().Should().Be(wrapperOfIntTwo.GetHashCode());
+        wrapperOfIntOne.Equals(wrapperOfString).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "FromSymbol with includeDisplayName=false should build a comparison-only key with an empty DisplayName that still compares equal to the full key")]
+    public void FromSymbol_with_includeDisplayName_false_should_omit_display_name()
+    {
+        const string source = """
+            namespace ComparisonSample
+            {
+                public interface IProtocol
+                {
+                }
+            }
+            """;
+
+        var compilation = GeneratorTestHarness.Run(source).OutputCompilation;
+        var symbol = compilation.GetTypeByMetadataName("ComparisonSample.IProtocol")
+            ?? throw new InvalidOperationException("Could not resolve 'ComparisonSample.IProtocol' in the harness compilation.");
+
+        var full = AkkaSerializerGenerator.TypeKey.FromSymbol(symbol);
+        var comparisonOnly = AkkaSerializerGenerator.TypeKey.FromSymbol(symbol, includeDisplayName: false);
+
+        full.DisplayName.Should().Be("global::ComparisonSample.IProtocol");
+        comparisonOnly.DisplayName.Should().BeEmpty();
+        full.Equals(comparisonOnly).Should().BeTrue("equality never reads DisplayName -- this is exactly what lets the AKKASG029 scan skip building one");
+    }
+}


### PR DESCRIPTION
> Stack, bottom to top: S1 #8525 -> S2 #8526 -> S3 #8527 -> object elements #8528 -> S4 #8530 -> S5 #8532 -> S6 #8533 -> F1 #8534 -> F2 #8536 -> F3 #8537 -> S7 #8538. Each PR is one commit on top of the one below it. This PR is S4.

## What changes

Nothing in output or diagnostics. Every lookup keyed by a type now uses a `TypeKey` instead of a name string: the message table, union members, formatter overrides, closed-generic registrations, closed-set members, and the resolved serializer's table.

- **What a `TypeKey` is.** The CLR metadata name, with `+` for a nested type and the arity suffix for a generic one, plus the type arguments. The display name rides along unchanged, so generated code and messages read exactly as before.
- **A collision that would have appeared later is closed now.** A nested `A.Outer+Inner` and a namespace-qualified `A.Outer.Inner` render the same dotted name. Today C# rejects that pair in one assembly. F1 admits types from referenced assemblies, where the pair can come from two assemblies. Two tests pin that the keys differ, one on hand-built keys and one on real Roslyn symbols.
- **One schema table.** A closed-generic registration is now a small record: target key, manifest, `AllowEmpty`. The construction's schema is built by the same extraction routine every message uses and stored beside the serializer, keyed like every other schema.
- **The protocol-coverage scan compares keys** instead of formatting every interface of every type to a string, with a cheap metadata-name check that skips interfaces that cannot match.

One detail this caught: a generic definition's display string changes under the new key, which would have changed the text of AKKASG022. The definition keeps its old display name.

## Savings

Measured back to back on the same machine, base against branch, three paired runs. Allocations are the same on every run.

| Row | Base (S3) | This PR | Change |
|---|---:|---:|---:|
| Fresh driver, full corpus | 22.6 MB | 21.9 MB | -3.1% |
| Warm driver, one field renamed | 13.2 MB | 12.5 MB | -5.3% |
| Warm driver, comment edit | 7.8 MB | 6.8 MB | -13.5% |
| Warm driver, unrelated file edited | 7.8 MB | 6.7 MB | -13.4% |

A first version added about 2 MB per run. Two causes, both measured and fixed: the coverage scan built a full key for every interface of every type, including the compiler-generated `IEquatable<T>` on records, and the key builder made a second pass over the display string and allocated a stack in the common case. That is why the result is below the base instead of level with it.

## How it was checked

309 tests pass (302 plus 7 in `TypeKeySpec`). Generator builds with warnings as errors. `Akka.Remote` builds. Golden, wire, and both model snapshots unchanged. Caching pins unchanged.
