### PR TITLE
Compute compilation-wide facts once per edit instead of once per type (S5)

### DIFF
--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Extraction.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Extraction.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -185,7 +186,7 @@ public sealed partial class AkkaSerializerGenerator
         if (attributes.IsEmpty)
             return (ImmutableArray<ClosedGenericRegistrationInfo>.Empty, ImmutableArray<MessageInfo>.Empty);
 
-        var knownTypes = KnownTypes.From(compilation);
+        var knownTypes = GetKnownTypes(compilation);
         var registrationsBuilder = ImmutableArray.CreateBuilder<ClosedGenericRegistrationInfo>(attributes.Length);
         var schemasBuilder = ImmutableArray.CreateBuilder<MessageInfo>();
         foreach (var attribute in attributes)
@@ -356,7 +357,7 @@ public sealed partial class AkkaSerializerGenerator
         var symbol = (INamedTypeSymbol)context.TargetSymbol;
         var attribute = context.Attributes[0];
         var compilation = context.SemanticModel.Compilation;
-        var knownTypes = KnownTypes.From(compilation);
+        var knownTypes = GetKnownTypes(compilation);
         var manifest = string.Empty;
         var allowEmpty = false;
         foreach (var argument in attribute.NamedArguments)
@@ -430,7 +431,7 @@ public sealed partial class AkkaSerializerGenerator
         if (attribute == null)
             return null;
 
-        var knownTypes = KnownTypes.From(compilation);
+        var knownTypes = GetKnownTypes(compilation);
         var manifest = string.Empty;
         var allowEmpty = false;
         foreach (var argument in attribute.NamedArguments)
@@ -1164,6 +1165,26 @@ public sealed partial class AkkaSerializerGenerator
         }
 
         return string.Join(".", parts);
+    }
+
+    /// <summary>
+    /// Caches one <see cref="KnownTypes"/> per <see cref="Compilation"/> instance. Before S5, both
+    /// attribute transforms (<see cref="ExtractClosedGenericRegistrations"/>, called from
+    /// <see cref="ExtractSerializerCore"/>, and <see cref="ExtractMessage"/>) called
+    /// <see cref="KnownTypes.From"/> independently -- once per ATTRIBUTED TYPE per compilation
+    /// change, each paying for about fifteen <see cref="Compilation.GetTypeByMetadataName(string)"/>
+    /// lookups -- even though every call within one compilation change produces an identical
+    /// result. A <see cref="ConditionalWeakTable{TKey,TValue}"/> ties each cached
+    /// <see cref="KnownTypes"/> to the exact <see cref="Compilation"/> instance that produced it,
+    /// with no broader lifetime and no cross-compilation leakage: once a <see cref="Compilation"/>
+    /// is collected, its entry goes with it, and a brand-new <see cref="Compilation"/> (the next
+    /// edit) always misses and recomputes exactly once, on first use.
+    /// </summary>
+    private static readonly ConditionalWeakTable<Compilation, KnownTypes> KnownTypesCache = new();
+
+    private static KnownTypes GetKnownTypes(Compilation compilation)
+    {
+        return KnownTypesCache.GetValue(compilation, static c => KnownTypes.From(c));
     }
 
     private sealed class KnownTypes

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Facts.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Facts.cs
@@ -1,0 +1,195 @@
+//-----------------------------------------------------------------------
+// <copyright file="AkkaSerializerGenerator.Facts.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+
+namespace Akka.Serialization.V2.Generators;
+
+public sealed partial class AkkaSerializerGenerator
+{
+    /// <summary>
+    /// The S5 whole-compilation facts stage: builds the cached, symbol-free <see cref="CompilationFacts"/>
+    /// for one compilation change, shared by every serializer -- replacing the former shape, where
+    /// <c>ValidateProtocolCoverage</c> re-walked every source-declared type once PER SERIALIZER,
+    /// inside its own diagnostics-only <c>RegisterSourceOutput</c> callback. Registered as
+    /// <c>context.CompilationProvider.Combine(collectedSerializers).Select(...)</c> with tracking
+    /// name <see cref="TrackingNames.CompilationFacts"/> (see <see cref="Initialize"/>).
+    /// <paramref name="serializers"/> is consulted ONLY for each serializer's protocol key -- which
+    /// protocol interfaces anyone actually declared a <c>[AkkaSerializer&lt;TProtocol&gt;]</c> for --
+    /// so the local-implementor walk below considers only the protocols that matter, not every
+    /// interface of every source-declared type.
+    /// </summary>
+    internal static CompilationFacts ComputeCompilationFacts(
+        Compilation compilation,
+        ImmutableArray<SerializerInfo?> serializers,
+        CancellationToken cancellationToken)
+    {
+        var protocolKeys = ComputeDistinctProtocolKeys(serializers);
+        var referencedAssembliesUsingV2 = ComputeReferencedAssembliesUsingV2(compilation, cancellationToken);
+        var localUnmarkedImplementorsByProtocol = ComputeLocalUnmarkedImplementorsByProtocol(compilation, protocolKeys, cancellationToken);
+        var referencedAssemblyImplementorsByProtocol = EnumerateReferencedAssemblyImplementors(
+            compilation, referencedAssembliesUsingV2, protocolKeys, cancellationToken);
+
+        return new CompilationFacts(localUnmarkedImplementorsByProtocol, referencedAssemblyImplementorsByProtocol, referencedAssembliesUsingV2);
+    }
+
+    /// <summary>
+    /// Every distinct protocol key at least one collected serializer declares, in first-seen order.
+    /// A serializer whose <c>[AkkaSerializer&lt;TProtocol&gt;]</c> type argument was not a named
+    /// type (<see cref="SerializerInfo.ProtocolTypeFullName"/> empty) contributes nothing -- there
+    /// is no protocol interface for the facts below to scan for.
+    /// </summary>
+    private static ImmutableArray<TypeKey> ComputeDistinctProtocolKeys(ImmutableArray<SerializerInfo?> serializers)
+    {
+        var seen = new HashSet<TypeKey>();
+        var builder = ImmutableArray.CreateBuilder<TypeKey>();
+        foreach (var serializer in serializers)
+        {
+            if (serializer == null || serializer.ProtocolTypeFullName.Length == 0)
+                continue;
+
+            if (seen.Add(serializer.ProtocolTypeKey))
+                builder.Add(serializer.ProtocolTypeKey);
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// The AKKASG029 input (see <see cref="ValidateProtocolCoverage"/>): walks every source-declared
+    /// type in <paramref name="compilation"/> EXACTLY ONCE -- not once per protocol, and not once
+    /// per serializer, as the pre-S5 shape inside <c>ValidateProtocolCoverage</c> did -- testing
+    /// each non-abstract class/struct candidate against every requested protocol key at once and
+    /// bucketing the unmarked matches. Returns one entry per <paramref name="protocolKeys"/> element,
+    /// even one whose bucket ends up empty (a protocol with clean coverage), so a lookup miss in
+    /// <see cref="CompilationFacts.LocalUnmarkedImplementorsByProtocol"/> unambiguously means "no
+    /// serializer asked about this protocol", not "no implementors, or we never looked". Each
+    /// bucket's implementor list is sorted by <see cref="TypeKey.MetadataName"/> (ordinal) for a
+    /// deterministic diagnostic order across runs.
+    /// </summary>
+    private static ImmutableDictionary<TypeKey, ImmutableArray<TypeKey>> ComputeLocalUnmarkedImplementorsByProtocol(
+        Compilation compilation,
+        ImmutableArray<TypeKey> protocolKeys,
+        CancellationToken cancellationToken)
+    {
+        if (protocolKeys.IsEmpty)
+            return ImmutableDictionary<TypeKey, ImmutableArray<TypeKey>>.Empty;
+
+        var knownTypes = GetKnownTypes(compilation);
+        if (knownTypes.SerializableAttribute == null)
+            return ImmutableDictionary<TypeKey, ImmutableArray<TypeKey>>.Empty;
+
+        var buckets = new Dictionary<TypeKey, List<TypeKey>>();
+        foreach (var protocolKey in protocolKeys)
+            buckets[protocolKey] = new List<TypeKey>();
+
+        foreach (var candidate in GetSourceDeclaredTypes(compilation))
+        {
+            // This whole-compilation walk re-runs on every edit (its output combines the
+            // CompilationProvider by necessity); honor IDE cancellation between candidates, exactly
+            // as the pre-S5 per-serializer walk did.
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (candidate.TypeKind is not (TypeKind.Class or TypeKind.Struct) || candidate.IsAbstract)
+                continue;
+
+            var isMarked = candidate.GetAttributes()
+                .Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, knownTypes.SerializableAttribute));
+            if (isMarked)
+                continue;
+
+            foreach (var protocolKey in protocolKeys)
+            {
+                if (ImplementsProtocol(candidate, protocolKey))
+                    buckets[protocolKey].Add(TypeKey.FromSymbol(candidate));
+            }
+        }
+
+        var result = ImmutableDictionary.CreateBuilder<TypeKey, ImmutableArray<TypeKey>>();
+        foreach (var pair in buckets)
+        {
+            pair.Value.Sort(static (a, b) => string.CompareOrdinal(a.MetadataName, b.MetadataName));
+            result[pair.Key] = pair.Value.ToImmutableArray();
+        }
+
+        return result.ToImmutable();
+    }
+
+    /// <summary>
+    /// The sorted (ordinal) names of every assembly <paramref name="compilation"/> references that
+    /// itself references Akka.Serialization.V2 -- Decision 19's pre-filter (see
+    /// <see cref="CompilationFacts.ReferencedAssembliesUsingV2"/>). An assembly that does not
+    /// reference V2 cannot declare an <c>[AkkaSerializable]</c> type (the attribute lives in V2), so
+    /// this narrows the candidate set the eventual Decision 19 walk needs to visit down to only the
+    /// assemblies that could possibly matter. Reads each referenced assembly's OWN metadata
+    /// AssemblyRef table (<see cref="IModuleSymbol.ReferencedAssemblies"/>), never its member types,
+    /// so this stays cheap even for a large reference closure.
+    /// </summary>
+    private static ImmutableArray<string> ComputeReferencedAssembliesUsingV2(Compilation compilation, CancellationToken cancellationToken)
+    {
+        var names = new List<string>();
+        foreach (var assembly in compilation.SourceModule.ReferencedAssemblySymbols)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (ReferencesAkkaSerializationV2(assembly))
+                names.Add(assembly.Name);
+        }
+
+        names.Sort(StringComparer.Ordinal);
+        return names.ToImmutableArray();
+    }
+
+    private const string AkkaSerializationV2AssemblyName = "Akka.Serialization.V2";
+
+    private static bool ReferencesAkkaSerializationV2(IAssemblySymbol assembly)
+    {
+        foreach (var module in assembly.Modules)
+        {
+            foreach (var identity in module.ReferencedAssemblies)
+            {
+                if (string.Equals(identity.Name, AkkaSerializationV2AssemblyName, StringComparison.Ordinal))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Decision 19's referenced-assembly implementor walk (design.md's "Protocol Implementors From
+    /// Referenced Assemblies" section), plus its Decision 21 extension to marked union bases: for
+    /// every protocol key, the <c>[AkkaSerializable]</c>-marked implementors of that protocol
+    /// declared in one of <paramref name="referencedAssembliesUsingV2"/>.
+    /// A SKELETON today: it always returns an empty implementor list for every protocol key.
+    /// Actually walking a qualifying referenced assembly's public type members from metadata --
+    /// matching its own <c>[AkkaSerializable]</c> usages, extracting a schema the way
+    /// <c>ExtractMessageCore</c> does for a local type -- is Decision 19's own follow-up
+    /// implementation work, not part of this change. What IS real here: the filter above
+    /// (<paramref name="referencedAssembliesUsingV2"/>) already narrows the candidate assembly set
+    /// down to only the ones such a walk could ever need to visit, <paramref name="protocolKeys"/>
+    /// already narrows which protocols it would need to test against, and this method already takes
+    /// and honors a <paramref name="cancellationToken"/> -- so wiring in the real walk later needs
+    /// no signature change here or at either call site.
+    /// </summary>
+    private static ImmutableDictionary<TypeKey, ImmutableArray<TypeKey>> EnumerateReferencedAssemblyImplementors(
+        Compilation compilation,
+        ImmutableArray<string> referencedAssembliesUsingV2,
+        ImmutableArray<TypeKey> protocolKeys,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ImmutableDictionary<TypeKey, ImmutableArray<TypeKey>>.Empty;
+    }
+}

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Models.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Models.cs
@@ -114,6 +114,54 @@ public sealed partial class AkkaSerializerGenerator
 
             return Combine(hash, entriesHash);
         }
+
+        /// <summary>
+        /// Value equality for an <see cref="ImmutableDictionary{TKey,TValue}"/>-shaped cached model
+        /// member whose VALUE is itself an <see cref="ImmutableArray{T}"/> (<see cref="CompilationFacts"/>'s
+        /// two implementor-by-protocol maps): same key set, and for each key, the same ORDERED
+        /// element sequence via <see cref="SequenceEquals{T}"/> -- deliberately NOT
+        /// <see cref="DictionaryEquals{TKey,TValue}"/>'s <c>EqualityComparer&lt;TValue&gt;.Default</c>,
+        /// which for <c>TValue</c> = <see cref="ImmutableArray{T}"/> would resolve to
+        /// <see cref="ImmutableArray{T}"/>'s OWN <see cref="IEquatable{T}"/> implementation --
+        /// reference equality on the wrapped array, not a structural compare -- and would wrongly
+        /// treat two independently-built arrays with identical content as unequal.
+        /// </summary>
+        public static bool ArrayDictionaryEquals<TKey, TValue>(ImmutableDictionary<TKey, ImmutableArray<TValue>> left, ImmutableDictionary<TKey, ImmutableArray<TValue>> right)
+            where TKey : notnull
+        {
+            if (ReferenceEquals(left, right))
+                return true;
+
+            if (left.Count != right.Count)
+                return false;
+
+            foreach (var pair in left)
+            {
+                if (!right.TryGetValue(pair.Key, out var otherValue) || !SequenceEquals(pair.Value, otherValue))
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>Order-independent hash companion to <see cref="ArrayDictionaryEquals{TKey,TValue}"/>, mirroring <see cref="CombineDictionary{TKey,TValue}"/>.</summary>
+        public static int CombineArrayDictionary<TKey, TValue>(int hash, ImmutableDictionary<TKey, ImmutableArray<TValue>> dictionary)
+            where TKey : notnull
+        {
+            hash = Combine(hash, dictionary.Count);
+
+            var entriesHash = 0;
+            foreach (var pair in dictionary)
+            {
+                var entryHash = Combine(Combine(Seed, EqualityComparer<TKey>.Default.GetHashCode(pair.Key)), pair.Value);
+                unchecked
+                {
+                    entriesHash += entryHash;
+                }
+            }
+
+            return Combine(hash, entriesHash);
+        }
     }
 
     /// <summary>
@@ -1537,6 +1585,93 @@ public sealed partial class AkkaSerializerGenerator
             hash = ValueEquality.Combine(hash, ValidationDiagnostics);
             hash = ValueEquality.CombineDictionary(hash, ResolvedMessagesByType);
             hash = ValueEquality.CombineDictionary(hash, ClosedGenericSchemas);
+            return hash;
+        }
+    }
+
+    /// <summary>
+    /// The S5 compilation-facts stage's cached output (see <see cref="ComputeCompilationFacts"/>):
+    /// everything the pipeline needs to know about the WHOLE compilation, computed once per
+    /// compilation change and shared by every serializer, rather than recomputed per serializer
+    /// inside a diagnostics-only output that also consumed the live <see cref="Compilation"/>
+    /// directly (the pre-S5 shape of <c>ValidateProtocolCoverage</c>). Symbol-free and
+    /// value-equatable like every other cached pipeline model, so this stage's OUTPUT compares equal
+    /// across two compilations that differ only by something none of these facts cares about (an
+    /// edit to an unrelated file, a metadata reference that does not touch Akka.Serialization.V2),
+    /// keeping the AKKASG029 coverage output -- and, per Decision 19 in
+    /// openspec/changes/messagepack-sourcegen-validation/design.md, eventually the resolve stage too
+    /// -- cached instead of re-diagnosing on every keystroke. See
+    /// <see cref="AkkaSerializerGenerator.TrackingNames.CompilationFacts"/> for why this is NOT yet
+    /// combined into <see cref="ResolvedSerializer"/>'s own inputs.
+    /// </summary>
+    internal sealed class CompilationFacts : IEquatable<CompilationFacts>
+    {
+        public static readonly CompilationFacts Empty = new(
+            ImmutableDictionary<TypeKey, ImmutableArray<TypeKey>>.Empty,
+            ImmutableDictionary<TypeKey, ImmutableArray<TypeKey>>.Empty,
+            ImmutableArray<string>.Empty);
+
+        public CompilationFacts(
+            ImmutableDictionary<TypeKey, ImmutableArray<TypeKey>> localUnmarkedImplementorsByProtocol,
+            ImmutableDictionary<TypeKey, ImmutableArray<TypeKey>> referencedAssemblyImplementorsByProtocol,
+            ImmutableArray<string> referencedAssembliesUsingV2)
+        {
+            LocalUnmarkedImplementorsByProtocol = localUnmarkedImplementorsByProtocol;
+            ReferencedAssemblyImplementorsByProtocol = referencedAssemblyImplementorsByProtocol;
+            ReferencedAssembliesUsingV2 = referencedAssembliesUsingV2.IsDefault ? ImmutableArray<string>.Empty : referencedAssembliesUsingV2;
+        }
+
+        /// <summary>
+        /// Per protocol key, the type keys of every non-abstract class/struct DECLARED IN THIS
+        /// COMPILATION that implements the protocol interface without an <c>[AkkaSerializable]</c>
+        /// attribute -- the AKKASG029 input (see <see cref="AkkaSerializerGenerator.ValidateProtocolCoverage"/>).
+        /// Sorted by <see cref="TypeKey.MetadataName"/> (ordinal) for a deterministic diagnostic
+        /// order. One entry per protocol key that at least one collected
+        /// <c>[AkkaSerializer&lt;TProtocol&gt;]</c> declares, even when that entry's array is empty
+        /// (a protocol with clean coverage) -- see <see cref="AkkaSerializerGenerator.ComputeLocalUnmarkedImplementorsByProtocol"/>.
+        /// </summary>
+        public ImmutableDictionary<TypeKey, ImmutableArray<TypeKey>> LocalUnmarkedImplementorsByProtocol { get; }
+
+        /// <summary>
+        /// Per protocol key, the type keys of every <c>[AkkaSerializable]</c>-marked implementor of
+        /// that protocol (or of a marked union base, per Decision 21) DECLARED IN A REFERENCED
+        /// ASSEMBLY -- Decision 19's input. EMPTY for every compilation today: the enumeration
+        /// behind it is a skeleton that always returns no implementors (see
+        /// <see cref="AkkaSerializerGenerator.EnumerateReferencedAssemblyImplementors"/>); only
+        /// <see cref="ReferencedAssembliesUsingV2"/> (the filter that walk will use) is real yet.
+        /// </summary>
+        public ImmutableDictionary<TypeKey, ImmutableArray<TypeKey>> ReferencedAssemblyImplementorsByProtocol { get; }
+
+        /// <summary>
+        /// The sorted (ordinal) names of every referenced assembly that itself references
+        /// Akka.Serialization.V2 -- the set the eventual Decision 19 implementor walk will need to
+        /// visit. An assembly that does not reference V2 cannot declare an
+        /// <c>[AkkaSerializable]</c> type (the attribute lives in V2), so narrowing to this set
+        /// first is what keeps that future walk cheap.
+        /// </summary>
+        public ImmutableArray<string> ReferencedAssembliesUsingV2 { get; }
+
+        public bool Equals(CompilationFacts? other)
+        {
+            if (ReferenceEquals(this, other))
+                return true;
+
+            if (other is null)
+                return false;
+
+            return ValueEquality.SequenceEquals(ReferencedAssembliesUsingV2, other.ReferencedAssembliesUsingV2)
+                && ValueEquality.ArrayDictionaryEquals(LocalUnmarkedImplementorsByProtocol, other.LocalUnmarkedImplementorsByProtocol)
+                && ValueEquality.ArrayDictionaryEquals(ReferencedAssemblyImplementorsByProtocol, other.ReferencedAssemblyImplementorsByProtocol);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as CompilationFacts);
+
+        public override int GetHashCode()
+        {
+            var hash = ValueEquality.Seed;
+            hash = ValueEquality.Combine(hash, ReferencedAssembliesUsingV2);
+            hash = ValueEquality.CombineArrayDictionary(hash, LocalUnmarkedImplementorsByProtocol);
+            hash = ValueEquality.CombineArrayDictionary(hash, ReferencedAssemblyImplementorsByProtocol);
             return hash;
         }
     }

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Validation.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Validation.cs
@@ -12,7 +12,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -53,16 +52,15 @@ public sealed partial class AkkaSerializerGenerator
     /// the gate has already been decided once, per serializer, by <see cref="ResolveSerializer"/>.
     /// <see cref="ResolvedSerializer.GateDiagnostics"/> are NOT reported here (they are reported
     /// once, by <see cref="EmitResolvedSerializer"/>); reporting them again here would duplicate
-    /// every pre-coverage diagnostic. This output still combines the live <see cref="Compilation"/>
-    /// (AKKASG029's whole-compilation scan genuinely needs it), so it re-runs on every edit exactly
-    /// as before -- only the GATE check underneath it got cheaper.
+    /// every pre-coverage diagnostic. As of S5 this combines the cached <see cref="CompilationFacts"/>
+    /// instead of the live <see cref="Compilation"/> -- see <see cref="ValidateProtocolCoverage"/>.
     /// </summary>
-    private static void ReportProtocolCoverage(SourceProductionContext context, ResolvedSerializer resolved, Compilation compilation)
+    private static void ReportProtocolCoverage(SourceProductionContext context, ResolvedSerializer resolved, CompilationFacts facts)
     {
         if (!resolved.IsEmittable)
             return;
 
-        var protocolCoverageDiagnostics = ValidateProtocolCoverage(resolved.Serializer, compilation, context.CancellationToken);
+        var protocolCoverageDiagnostics = ValidateProtocolCoverage(resolved.Serializer, facts);
         foreach (var diagnostic in protocolCoverageDiagnostics)
             context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(diagnostic));
     }
@@ -268,51 +266,28 @@ public sealed partial class AkkaSerializerGenerator
     /// constructions could ever be registered with [AkkaSerializable&lt;T&gt;] in the first place.
     /// A type this flags is invisible to the generated Manifest/Serialize/Deserialize switches
     /// today and only fails at runtime, the first time it is sent.
-    /// The protocol interface is matched by fully-qualified name against each candidate's
-    /// <see cref="ITypeSymbol.AllInterfaces"/>: the cached <see cref="SerializerInfo"/> is
-    /// deliberately symbol-free, and within one compilation a fully-qualified name identifies
-    /// exactly one type, so the string comparison is equivalent to the former
-    /// <see cref="SymbolEqualityComparer.Default"/> lookup.
-    /// This is the one validation step that genuinely needs a <see cref="Compilation"/> (the
-    /// whole-compilation type scan below), so unlike its neighbors it is not "model-only" -- but it
-    /// still returns <see cref="DiagnosticSpec"/> values rather than reporting through a
-    /// <see cref="SourceProductionContext"/> directly, so it can be driven by a plain
-    /// <see cref="CancellationToken"/> and asserted against directly in tests.
+    /// As of S5, the whole-compilation scan that used to run HERE, per serializer, now runs exactly
+    /// once per compilation change for every serializer's protocol at once, inside
+    /// <see cref="ComputeCompilationFacts"/> (see <see cref="ComputeLocalUnmarkedImplementorsByProtocol"/>).
+    /// This method is now a pure, symbol-free, Compilation-free function of the resolved serializer
+    /// plus that precomputed <see cref="CompilationFacts"/> -- it only formats the diagnostic for
+    /// each already-identified implementor. Diagnostic id, text, and trigger conditions are
+    /// unchanged from before the split.
     /// </summary>
-    internal static ImmutableArray<DiagnosticSpec> ValidateProtocolCoverage(SerializerInfo serializer, Compilation compilation, CancellationToken cancellationToken)
+    internal static ImmutableArray<DiagnosticSpec> ValidateProtocolCoverage(SerializerInfo serializer, CompilationFacts facts)
     {
         var diagnostics = ImmutableArray.CreateBuilder<DiagnosticSpec>();
 
         if (serializer.ProtocolTypeFullName.Length == 0)
             return diagnostics.ToImmutable();
 
-        var knownTypes = KnownTypes.From(compilation);
-        if (knownTypes.SerializableAttribute == null)
+        if (!facts.LocalUnmarkedImplementorsByProtocol.TryGetValue(serializer.ProtocolTypeKey, out var implementors))
             return diagnostics.ToImmutable();
 
-        var protocolKey = serializer.ProtocolTypeKey;
-        foreach (var candidate in GetSourceDeclaredTypes(compilation))
+        foreach (var implementor in implementors)
         {
-            // This whole-compilation walk re-runs on every edit (its output combines the
-            // CompilationProvider by necessity); honor IDE cancellation between candidates.
-            cancellationToken.ThrowIfCancellationRequested();
-
-            if (candidate.TypeKind is not (TypeKind.Class or TypeKind.Struct))
-                continue;
-
-            if (candidate.IsAbstract)
-                continue;
-
-            if (!ImplementsProtocol(candidate, protocolKey))
-                continue;
-
-            var isMarked = candidate.GetAttributes()
-                .Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, knownTypes.SerializableAttribute));
-            if (isMarked)
-                continue;
-
             diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ProtocolMessageNotSerializable,
-                ToDisplayName(GetFullyQualifiedTypeName(candidate)), ToDisplayName(serializer.ProtocolTypeFullName), serializer.ClassName));
+                ToDisplayName(implementor.DisplayName ?? string.Empty), ToDisplayName(serializer.ProtocolTypeFullName), serializer.ClassName));
         }
 
         return diagnostics.ToImmutable();
@@ -329,9 +304,12 @@ public sealed partial class AkkaSerializerGenerator
     /// -- for example a record's compiler-synthesized <c>IEquatable&lt;T&gt;</c>, or any OTHER
     /// serializer's protocol -- with a single, allocation-free string compare, before paying for a
     /// full <see cref="TypeKey.FromSymbol"/> (which recurses into type arguments for a generic
-    /// interface). This scan runs once per candidate type per serializer and is never cached (it
-    /// combines with the live <see cref="Compilation"/>), so skipping the expensive path for the
-    /// overwhelming majority of interfaces that were never going to match is the whole saving.
+    /// interface). As of S5 this runs once per candidate type per PROTOCOL KEY, inside
+    /// <see cref="ComputeLocalUnmarkedImplementorsByProtocol"/> -- once for the whole compilation,
+    /// not once per serializer as before -- and its result is never itself cached across candidates
+    /// (only the caller's aggregated <see cref="CompilationFacts"/> output is), so skipping the
+    /// expensive path for the overwhelming majority of interfaces that were never going to match is
+    /// still the whole saving.
     /// </summary>
     private static bool ImplementsProtocol(INamedTypeSymbol candidate, TypeKey protocolKey)
     {
@@ -373,8 +351,9 @@ public sealed partial class AkkaSerializerGenerator
     /// <summary>
     /// Every named type declared in <paramref name="compilation"/>'s OWN source (never a referenced
     /// assembly: <see cref="Compilation.Assembly"/> is the assembly being compiled), recursively
-    /// including nested types. Used only by <see cref="ValidateProtocolCoverage"/>, transiently,
-    /// inside the diagnostics-only coverage callback -- never stored in a cached provider.
+    /// including nested types. Used by <see cref="ComputeLocalUnmarkedImplementorsByProtocol"/>,
+    /// transiently, inside the S5 compilation-facts stage -- never stored in a cached provider
+    /// itself (its CALLER's output is what gets cached; see <see cref="CompilationFacts"/>).
     /// </summary>
     private static IEnumerable<INamedTypeSymbol> GetSourceDeclaredTypes(Compilation compilation)
     {

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.cs
@@ -26,8 +26,12 @@ namespace Akka.Serialization.V2.Generators;
 //   AkkaSerializerGenerator.Diagnostics.cs - every DiagnosticDescriptor, in id order.
 //   AkkaSerializerGenerator.Extraction.cs  - symbol-to-model extraction: ExtractSerializer*,
 //                                             ExtractMessageCore, ExtractClosedGenericRegistrations,
-//                                             ExtractUnionMembers, field-type mapping, KnownTypes,
-//                                             constructor matching.
+//                                             ExtractUnionMembers, field-type mapping, KnownTypes
+//                                             (and its per-Compilation cache), constructor matching.
+//   AkkaSerializerGenerator.Facts.cs       - the S5 whole-compilation facts stage: ComputeCompilationFacts
+//                                             and its helpers (the local-implementor walk, the
+//                                             referenced-assembly-references-V2 filter, and the
+//                                             Decision 19 referenced-assembly implementor skeleton).
 //   AkkaSerializerGenerator.Validation.cs  - validation over the collected models and diagnostic
 //                                             reporting: ValidateMessages, ValidateUnionField,
 //                                             ValidateClosedGenericProtocolCoverage,
@@ -36,7 +40,7 @@ namespace Akka.Serialization.V2.Generators;
 //                                             and source emission: EmitResolvedSerializer, Generate*,
 //                                             union helper planning, naming/folding, collision handling.
 //   AkkaSerializerGenerator.Models.cs      - the model records (SerializerInfo, MessageInfo,
-//                                             FieldInfo, TypeMapping, UnionMemberInfo, ...).
+//                                             FieldInfo, TypeMapping, UnionMemberInfo, CompilationFacts, ...).
 [Generator]
 public sealed partial class AkkaSerializerGenerator : IIncrementalGenerator
 {
@@ -64,8 +68,22 @@ public sealed partial class AkkaSerializerGenerator : IIncrementalGenerator
         /// </summary>
         public const string ResolvedSerializers = nameof(ResolvedSerializers);
 
+        /// <summary>
+        /// The S5 whole-compilation facts stage: <c>context.CompilationProvider.Combine(CollectedSerializers).Select(...)</c>,
+        /// producing one cached <see cref="CompilationFacts"/> value per compilation change (see
+        /// <see cref="ComputeCompilationFacts"/>). Feeds the AKKASG029 coverage output in place of
+        /// the raw <see cref="Compilation"/> that output used to combine with directly -- see
+        /// <see cref="ReportProtocolCoverage"/>. Deliberately NOT combined into
+        /// <see cref="ResolvedSerializers"/>'s own inputs yet: nothing this stage computes today
+        /// (Decision 19's referenced-assembly implementor map is always empty in this change) is
+        /// something <see cref="ResolveSerializer"/> needs to consume, so wiring it in now would add
+        /// an equality-risk surface for no behavioral change. That wiring is expected once Decision
+        /// 19's referenced-assembly implementor walk is real.
+        /// </summary>
+        public const string CompilationFacts = nameof(CompilationFacts);
+
         public static ImmutableArray<string> All { get; } = ImmutableArray.Create(
-            ExtractedSerializers, CollectedSerializers, ExtractedMessages, CollectedMessages, ResolvedSerializers);
+            ExtractedSerializers, CollectedSerializers, ExtractedMessages, CollectedMessages, ResolvedSerializers, CompilationFacts);
     }
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -124,6 +142,22 @@ public sealed partial class AkkaSerializerGenerator : IIncrementalGenerator
             })
             .WithTrackingName(TrackingNames.ResolvedSerializers);
 
+        // The S5 whole-compilation facts stage: everything the pipeline needs to know about the
+        // WHOLE compilation, computed ONCE per compilation change and shared by every serializer --
+        // see ComputeCompilationFacts and CompilationFacts's own doc comment. Combines the live
+        // Compilation (this stage genuinely needs it, exactly like the coverage scan it replaces)
+        // with the collected serializers (only for their protocol keys: which protocol interfaces
+        // anyone actually asked about, so the local-implementor walk below doesn't have to consider
+        // every interface of every source-declared type). The OUTPUT is symbol-free and
+        // value-equatable, so -- unlike the raw Compilation this used to be combined with directly
+        // -- a downstream consumer wired to THIS stage can report Unchanged/Cached whenever nothing
+        // these facts care about changed, even though the stage itself reruns on every edit (the
+        // CompilationProvider input never itself compares equal across edits).
+        var compilationFacts = context.CompilationProvider
+            .Combine(serializers)
+            .Select(static (pair, cancellationToken) => ComputeCompilationFacts(pair.Left, pair.Right, cancellationToken))
+            .WithTrackingName(TrackingNames.CompilationFacts);
+
         // Code emission consumes ONLY the cached, value-equatable, symbol-free ResolvedSerializer
         // model -- never the Compilation, and never another serializer's data. Registered on the
         // VALUES provider (one independent output per serializer) rather than a Collect()'d array,
@@ -141,13 +175,19 @@ public sealed partial class AkkaSerializerGenerator : IIncrementalGenerator
             serializers.Combine(messages),
             static (ctx, pair) => ReportCrossSerializerDiagnostics(ctx, pair.Left, pair.Right));
 
-        // AKKASG029's whole-compilation protocol-coverage scan (ValidateProtocolCoverage) is the
-        // one check that genuinely needs the Compilation ("does any source-declared type implement
-        // this protocol interface without [AkkaSerializable]?"), so it lives in this SEPARATE,
-        // diagnostics-only output: the Compilation input changes on every edit, but only this cheap
-        // re-scan pays for that -- code emission above stays cached. It combines the cached
-        // ResolvedSerializer (for its gate) with the live Compilation (for the scan itself), so a
-        // serializer's own gate is decided once, by ResolveSerializer, and never recomputed here.
+        // AKKASG029's whole-compilation protocol-coverage check ("does any source-declared type
+        // implement this protocol interface without [AkkaSerializable]?") no longer touches the
+        // live Compilation from inside this per-serializer output. As of S5, the walk itself runs
+        // exactly once per compilation change, in the CompilationFacts stage above -- for every
+        // serializer's protocol at once, not once per serializer -- so this diagnostics-only output
+        // now combines the cached ResolvedSerializer (for its gate) with the cached CompilationFacts
+        // (for the precomputed implementor list): ValidateProtocolCoverage is a pure function of the
+        // two, with no Compilation parameter at all. Diagnostic id, text, and trigger conditions are
+        // unchanged -- only where the whole-compilation walk lives, and how many times per edit it
+        // runs, has moved. CompilationFacts still recomputes on every edit (it combines
+        // context.CompilationProvider directly), but its OUTPUT compares equal whenever nothing it
+        // tracks changed, which is what lets this output -- like code emission above -- report
+        // Cached instead of Modified for an edit these facts do not care about.
         //
         // Design decision: coverage errors no longer gate emission (the old terminal stage skipped
         // AddSource for a serializer whose coverage check failed). This is the standard split for
@@ -157,7 +197,7 @@ public sealed partial class AkkaSerializerGenerator : IIncrementalGenerator
         // while the user fixes the gap) and lets the emission stage surface OTHER diagnostics that
         // the old early-return used to hide until the coverage error was fixed.
         context.RegisterSourceOutput(
-            resolvedSerializers.Combine(context.CompilationProvider),
+            resolvedSerializers.Combine(compilationFacts),
             static (ctx, pair) => ReportProtocolCoverage(ctx, pair.Left, pair.Right));
     }
 }

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorCompilationFactsSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorCompilationFactsSpec.cs
@@ -1,0 +1,190 @@
+//-----------------------------------------------------------------------
+// <copyright file="GeneratorCompilationFactsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Akka.Serialization.V2.Generators;
+using Akka.Serialization.V2.Tests.Harness;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// Exercises the S5 whole-compilation facts stage's PURE compute entry point,
+/// <see cref="AkkaSerializerGenerator.ComputeCompilationFacts"/>, directly on a
+/// <see cref="Compilation"/> built by <see cref="GeneratorTestHarness"/> -- with no driver, no
+/// incremental pipeline, and no <see cref="SourceProductionContext"/> involved. Complements
+/// <see cref="GeneratorIncrementalScenariosSpec"/>, which asserts this stage's CACHING behavior
+/// (<see cref="Microsoft.CodeAnalysis.IncrementalStepRunReason"/>) across edits; this spec asserts
+/// what the stage actually COMPUTES.
+/// </summary>
+public sealed class GeneratorCompilationFactsSpec
+{
+    private const string LocalImplementorsSource = """
+        #nullable enable
+        using Akka.Serialization.V2;
+
+        namespace FactsSample;
+
+        public interface IProtocol
+        {
+        }
+
+        public interface IUnrelatedProtocol
+        {
+        }
+
+        [AkkaSerializable(Manifest = "marked-v1")]
+        public sealed record Marked(string Value) : IProtocol;
+
+        // Declared out of alphabetical order deliberately -- Zeta before Alpha -- so a sorted
+        // result is actual proof of sorting, not an accident of declaration order.
+        public sealed record ZetaUnmarked(string Value) : IProtocol;
+
+        public sealed record AlphaUnmarked(string Value) : IProtocol;
+
+        // Exempt: never a concrete runtime message type (AKKASG029's own documented exemption).
+        public abstract class AbstractUnmarked : IProtocol
+        {
+        }
+        """;
+
+    [Fact(DisplayName = "ComputeCompilationFacts should find every local unmarked implementor of a serializer's protocol, sorted deterministically")]
+    public void Should_find_sorted_local_unmarked_implementors()
+    {
+        var compilation = Compile(LocalImplementorsSource);
+        var protocolKey = ProtocolKey(compilation, "FactsSample.IProtocol");
+        var serializer = BuildSerializerInfo(protocolKey);
+
+        var facts = AkkaSerializerGenerator.ComputeCompilationFacts(
+            compilation, ImmutableArray.Create<AkkaSerializerGenerator.SerializerInfo?>(serializer), CancellationToken.None);
+
+        facts.LocalUnmarkedImplementorsByProtocol.Should().ContainKey(protocolKey);
+        var implementors = facts.LocalUnmarkedImplementorsByProtocol[protocolKey];
+
+        // Marked (has [AkkaSerializable]) and AbstractUnmarked (abstract) are excluded; only the
+        // two concrete, unmarked implementors remain, in ASCENDING metadata-name order even though
+        // Zeta was declared before Alpha in source.
+        implementors.Select(key => key.MetadataName).Should().Equal(
+            "FactsSample.AlphaUnmarked", "FactsSample.ZetaUnmarked");
+
+        // A protocol nothing implements (unmarked) still gets its own entry, but empty -- a lookup
+        // MISS means "no serializer asked about this protocol", not "no implementors".
+        facts.LocalUnmarkedImplementorsByProtocol.Should().NotContainKey(ProtocolKey(compilation, "FactsSample.IUnrelatedProtocol"));
+
+        // Decision 19's referenced-assembly implementor walk is a skeleton in this change: always
+        // empty, regardless of what local implementors were found.
+        facts.ReferencedAssemblyImplementorsByProtocol.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "ComputeCompilationFacts should produce equal facts across two independent builds of the same compilation")]
+    public void Should_produce_equal_facts_across_two_builds_of_the_same_compilation()
+    {
+        var compilationA = Compile(LocalImplementorsSource);
+        var compilationB = Compile(LocalImplementorsSource);
+
+        var serializerA = BuildSerializerInfo(ProtocolKey(compilationA, "FactsSample.IProtocol"));
+        var serializerB = BuildSerializerInfo(ProtocolKey(compilationB, "FactsSample.IProtocol"));
+
+        var factsA = AkkaSerializerGenerator.ComputeCompilationFacts(
+            compilationA, ImmutableArray.Create<AkkaSerializerGenerator.SerializerInfo?>(serializerA), CancellationToken.None);
+        var factsB = AkkaSerializerGenerator.ComputeCompilationFacts(
+            compilationB, ImmutableArray.Create<AkkaSerializerGenerator.SerializerInfo?>(serializerB), CancellationToken.None);
+
+        // Two structurally identical compilations (fresh symbols each time -- TWO separate Compile()
+        // calls, never the same Compilation instance) must still produce EQUAL, symbol-free facts:
+        // this is exactly the property that keeps the coverage output (and any future consumer)
+        // cached across an edit these facts do not care about.
+        factsA.Should().Be(factsB);
+        factsA.Equals(factsB).Should().BeTrue();
+        factsA.GetHashCode().Should().Be(factsB.GetHashCode());
+    }
+
+    private const string ExtraReferenceSourceUsingV2 = """
+        using Akka.Serialization.V2;
+
+        namespace FactsSample.ReferencedAssembly;
+
+        [AkkaSerializable(Manifest = "referenced-marker-v1")]
+        public sealed class ReferencedMarker
+        {
+        }
+        """;
+
+    private const string ExtraReferenceSourceWithoutV2 = """
+        namespace FactsSample.PlainReferencedAssembly;
+
+        public static class PlainHelper
+        {
+            public static int Value => 1;
+        }
+        """;
+
+    [Fact(DisplayName = "ComputeCompilationFacts should list a referenced assembly that itself references Akka.Serialization.V2, and ignore one that does not")]
+    public void Should_filter_referenced_assemblies_by_whether_they_reference_v2()
+    {
+        var referenceUsingV2 = GeneratorTestHarness.CompileToReference(ExtraReferenceSourceUsingV2, "FactsReferencedAssemblyUsingV2");
+        var referenceWithoutV2 = GeneratorTestHarness.CompileToReference(ExtraReferenceSourceWithoutV2, "FactsReferencedAssemblyWithoutV2");
+
+        var compilation = Compile(LocalImplementorsSource, referenceUsingV2, referenceWithoutV2);
+
+        var facts = AkkaSerializerGenerator.ComputeCompilationFacts(
+            compilation, ImmutableArray<AkkaSerializerGenerator.SerializerInfo?>.Empty, CancellationToken.None);
+
+        // FactsReferencedAssemblyUsingV2 actually USES a type from Akka.Serialization.V2
+        // ([AkkaSerializable] on ReferencedMarker), so the C# compiler emits a genuine AssemblyRef
+        // to Akka.Serialization.V2 into its own compiled metadata -- picked up here.
+        facts.ReferencedAssembliesUsingV2.Should().Contain("FactsReferencedAssemblyUsingV2");
+
+        // FactsReferencedAssemblyWithoutV2 uses nothing from V2 at all: even though BOTH assemblies
+        // were supplied as MetadataReferences to the SAME base reference set (which itself includes
+        // Akka.Serialization.V2), an assembly's own AssemblyRef table only names assemblies it
+        // actually uses -- an unused supplied reference is never emitted into it.
+        facts.ReferencedAssembliesUsingV2.Should().NotContain("FactsReferencedAssemblyWithoutV2");
+
+        // Sorted (ordinal) -- verified generically rather than pinning an exact full list (the
+        // harness's own base references, e.g. the executing test assembly, also reference V2 and
+        // legitimately appear here too).
+        facts.ReferencedAssembliesUsingV2.Should().Equal(facts.ReferencedAssembliesUsingV2.OrderBy(name => name, StringComparer.Ordinal));
+    }
+
+    private static Compilation Compile(string source, params MetadataReference[] extraReferences)
+    {
+        return GeneratorTestHarness.Run(source, extraReferences).OutputCompilation;
+    }
+
+    private static AkkaSerializerGenerator.TypeKey ProtocolKey(Compilation compilation, string metadataName)
+    {
+        var symbol = compilation.GetTypeByMetadataName(metadataName)
+            ?? throw new InvalidOperationException($"Could not resolve '{metadataName}' in the harness compilation.");
+        return AkkaSerializerGenerator.TypeKey.FromSymbol(symbol);
+    }
+
+    private static AkkaSerializerGenerator.SerializerInfo BuildSerializerInfo(AkkaSerializerGenerator.TypeKey protocolTypeKey)
+    {
+        return new AkkaSerializerGenerator.SerializerInfo(
+            ns: "FactsSample",
+            className: "TestSerializer",
+            fullyQualifiedName: "global::FactsSample.TestSerializer",
+            name: "test-serializer",
+            serializerId: 1,
+            protocolTypeKey: protocolTypeKey,
+            protocolTypeIsInterface: true,
+            declaredAccessibility: Accessibility.Public,
+            formatters: ImmutableArray<AkkaSerializerGenerator.FormatterInfo>.Empty,
+            closedGenericRegistrations: ImmutableArray<AkkaSerializerGenerator.ClosedGenericRegistrationInfo>.Empty,
+            closedGenericSchemas: ImmutableArray<AkkaSerializerGenerator.MessageInfo>.Empty,
+            isPartial: true,
+            isGeneric: false,
+            derivesFromAkkaSerializerBase: true);
+    }
+}

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorIncrementalCachingSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorIncrementalCachingSpec.cs
@@ -175,6 +175,24 @@ public sealed class GeneratorIncrementalCachingSpec
             .ToList();
         resolvedSerializerReasons.Should().HaveCount(1);
         ((AkkaSerializerGenerator.ResolvedSerializer)resolvedSerializerReasons[0].Value).IsEmittable.Should().BeTrue();
+
+        // CompilationFacts specifically (the S5 whole-compilation facts stage): exactly one value
+        // (it is a Combine/Select, not a per-element SelectMany like ResolvedSerializers), and it
+        // must carry REAL data -- a false-Cached read that silently produced an empty/default facts
+        // value would defeat the point of this guard just as surely as for ResolvedSerializers above.
+        // IProtocol has two source-declared implementors (Wrapper<T>'s generic definition and
+        // Outer), both [AkkaSerializable]-marked, so its local-unmarked-implementor bucket exists
+        // (SampleSerializer declared [AkkaSerializer<IProtocol>]) but is empty -- clean coverage.
+        // ReferencedAssembliesUsingV2 is non-empty because this very test assembly references
+        // Akka.Serialization.V2 (it uses AkkaSerializableAttribute throughout), which is exactly the
+        // shape ComputeReferencedAssembliesUsingV2 is meant to detect.
+        var compilationFactsReasons = trackedSteps[AkkaSerializerGenerator.TrackingNames.CompilationFacts]
+            .SelectMany(step => step.Outputs)
+            .ToList();
+        compilationFactsReasons.Should().HaveCount(1);
+        var compilationFacts = (AkkaSerializerGenerator.CompilationFacts)compilationFactsReasons[0].Value;
+        compilationFacts.ReferencedAssembliesUsingV2.Should().NotBeEmpty();
+        compilationFacts.LocalUnmarkedImplementorsByProtocol.Values.SelectMany(implementors => implementors).Should().BeEmpty();
     }
 
     [Fact(DisplayName = "Generator should emit source alongside an AKKASG029 coverage error")]

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorIncrementalScenariosSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorIncrementalScenariosSpec.cs
@@ -104,23 +104,41 @@ public sealed class GeneratorIncrementalScenariosSpec
         }
         """;
 
+    // Unlike ExtraReferenceSource above, this one USES a type from Akka.Serialization.V2
+    // ([AkkaSerializable] on MarkerMessage), so the compiled assembly's own AssemblyRef table
+    // genuinely names Akka.Serialization.V2 -- the shape CompilationFacts.ReferencedAssembliesUsingV2
+    // is meant to detect. MarkerMessage implements neither IAlphaProtocol nor IBetaProtocol, so
+    // adding this reference cannot also perturb either protocol's local-implementor bucket.
+    private const string ExtraReferenceSourceUsingV2 = """
+        using Akka.Serialization.V2;
+
+        namespace ScenarioSample.ExtraReferenceWithV2;
+
+        [AkkaSerializable(Manifest = "extra-v2-marker-v1")]
+        public sealed class MarkerMessage
+        {
+        }
+        """;
+
     [Fact(DisplayName = "Tracked pipeline stages should match TrackingNames.All exactly (a new stage must update this spec)")]
     public void TrackingNames_should_match_expected_stage_count()
     {
-        // Pins today's stage count. Adding a sixth (or removing one) named pipeline stage is a
+        // Pins today's stage count. Adding a seventh (or removing one) named pipeline stage is a
         // deliberate architectural change -- this assertion makes it fail loudly here instead of
         // only surfacing as a silent gap in the scenarios below. ResolvedSerializers (the
-        // per-serializer resolve stage from the S3 architecture pass) is the fifth: it was ADDED
-        // downstream of the four stages above, which is why scenarios (a)/(c)/(d)/(e) below still
-        // pin the exact same reasons for those four as before.
-        AkkaSerializerGenerator.TrackingNames.All.Should().HaveCount(5);
+        // per-serializer resolve stage from the S3 architecture pass) is the fifth; CompilationFacts
+        // (the whole-compilation facts stage from the S5 architecture pass) is the sixth. Both were
+        // ADDED downstream of the four stages above, which is why scenarios (a)/(c)/(d)/(e) below
+        // still pin the exact same reasons for those four as before.
+        AkkaSerializerGenerator.TrackingNames.All.Should().HaveCount(6);
         AkkaSerializerGenerator.TrackingNames.All.Should().BeEquivalentTo(new[]
         {
             AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
             AkkaSerializerGenerator.TrackingNames.CollectedSerializers,
             AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
             AkkaSerializerGenerator.TrackingNames.CollectedMessages,
-            AkkaSerializerGenerator.TrackingNames.ResolvedSerializers
+            AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
+            AkkaSerializerGenerator.TrackingNames.CompilationFacts
         });
     }
 
@@ -162,6 +180,13 @@ public sealed class GeneratorIncrementalScenariosSpec
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
             IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
 
+        // S5: CompilationFacts' Select reruns every time (it combines context.CompilationProvider
+        // directly, which never itself compares equal across an edit), but neither protocol's
+        // local-implementor set nor the referenced-assembly-using-V2 list is touched by an edit to
+        // an unrelated file, so its OUTPUT compares equal to the previous run -- Unchanged (ran,
+        // but equal), not Cached (which would mean it never ran at all).
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CompilationFacts, IncrementalStepRunReason.Unchanged);
+
         // TARGET: none -- this IS the caching discipline PR 1 pins as the baseline; PRs 2, 3, 5, 6
         // must not regress it. No hint name's text should change.
         ChangedHintNames(result).Should().BeEmpty();
@@ -197,6 +222,11 @@ public sealed class GeneratorIncrementalScenariosSpec
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
             IncrementalStepRunReason.Modified, IncrementalStepRunReason.Unchanged);
 
+        // S5: renaming a field changes nothing CompilationFacts tracks -- AlphaTwo is marked
+        // [AkkaSerializable] either way, so it was never a candidate for either protocol's
+        // local-implementor bucket, and no reference changed. Unchanged, exactly like scenario (a).
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CompilationFacts, IncrementalStepRunReason.Unchanged);
+
         // Because RegisterSourceOutput is now registered directly on the ResolvedSerializers values
         // provider (one independent output per serializer, not one output over the whole collected
         // pair), BetaSerializer's Unchanged resolved model means its AddSource callback is never
@@ -230,6 +260,10 @@ public sealed class GeneratorIncrementalScenariosSpec
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
             IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
 
+        // Same as scenario (a): a comment carries no semantic information CompilationFacts cares
+        // about either, so it reruns but compares equal -- Unchanged.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CompilationFacts, IncrementalStepRunReason.Unchanged);
+
         // TARGET: unchanged from today -- a comment-only edit re-emitting nothing is already the
         // desired behavior; no migration PR needs to touch this.
         ChangedHintNames(result).Should().BeEmpty();
@@ -257,19 +291,28 @@ public sealed class GeneratorIncrementalScenariosSpec
         // steps are skipped entirely (Cached).
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
             IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
+
+        // TARGET (S5), and this scenario's namesake pin: CompilationFacts -- the stage that now
+        // carries the AKKASG029 whole-compilation coverage walk -- reruns (its Select combines
+        // context.CompilationProvider directly, which never itself compares equal across an edit)
+        // but produces the SAME implementor lists and the SAME referenced-assembly-using-V2 list as
+        // before, since this edit lands in a file the generator never looks at. Its output therefore
+        // reports Unchanged, not Modified: this PIN is what proves the walk's OUTPUT, not just the
+        // walk's cost, is now shared/cached machinery rather than a bespoke non-tracked re-scan. If
+        // a future change makes this report Modified instead, that is a real behavior change to call
+        // out here, not a silent regression.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CompilationFacts, IncrementalStepRunReason.Unchanged);
         ChangedHintNames(result).Should().BeEmpty();
 
-        // TARGET: the coverage scan (AKKASG029, ReportProtocolCoverage) is registered on
-        // resolvedSerializers.Combine(context.CompilationProvider) with NO tracking name of its
-        // own -- it is not gated by the same equality contract as the five named stages above, and
-        // is not observable through GetRunResult().Results[0].TrackedSteps at all. OBSERVED today:
-        // it produces the SAME (empty) diagnostics both before and after this trivial edit -- the
+        // The coverage output itself (AKKASG029, ReportProtocolCoverage) is still registered on
+        // resolvedSerializers.Combine(compilationFacts) with NO tracking name of its own -- it is
+        // not gated by the same equality contract as the six named stages above, and is not
+        // observable through GetRunResult().Results[0].TrackedSteps at all. OBSERVED today: it
+        // produces the SAME (empty) diagnostics both before and after this trivial edit -- the
         // fixture is coverage-clean -- which is the externally-visible half of "it still re-runs
-        // every time": the CompilationProvider input this output depends on changes identity on
-        // every edit, so the scan re-executes on this one too, it just has nothing new to report.
-        // As of S3, this scan's per-serializer GATE check is read straight off the cached
-        // ResolvedSerializer instead of being recomputed -- only the whole-compilation scan itself
-        // still re-runs every time, which is unavoidable (it genuinely needs the live Compilation).
+        // every time": the callback itself is invoked on every edit (RegisterSourceOutput has no
+        // caching of its own), it just now does far less work when it runs, since CompilationFacts
+        // already did the whole-compilation walk once, for every serializer, upstream of it.
         result.Before.CompileDiagnostics.Where(d => d.Id == "AKKASG029").Should().BeEmpty();
         result.After.CompileDiagnostics.Where(d => d.Id == "AKKASG029").Should().BeEmpty();
         result.Before.RunResult.Diagnostics.Where(d => d.Id == "AKKASG029").Should().BeEmpty();
@@ -303,9 +346,67 @@ public sealed class GeneratorIncrementalScenariosSpec
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
             IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
 
+        // TARGET (S5): the added assembly's own emitted metadata never actually references
+        // Akka.Serialization.V2 (ExtraReferenceSource declares a plain class that uses none of its
+        // types, and an unused MetadataReference does not turn into an AssemblyRef entry in the
+        // compiled PE), so CompilationFacts.ReferencedAssembliesUsingV2 -- and therefore every other
+        // fact -- compares equal to the previous run: Unchanged, not Modified. Contrast
+        // Scenario_e2_metadata_reference_that_references_v2_added below, where the added reference
+        // DOES touch V2 and this same stage reports Modified instead.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CompilationFacts, IncrementalStepRunReason.Unchanged);
+
         // TARGET: unchanged from today -- an unused added reference re-emitting nothing is already
         // the desired behavior; no migration PR needs to touch this.
         ChangedHintNames(result).Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Scenario (e2): adding a metadata reference that itself references Akka.Serialization.V2 changes CompilationFacts but re-emits no file")]
+    public void Scenario_e2_metadata_reference_that_references_v2_added()
+    {
+        // Unlike ExtraReferenceSource (scenario (e), above), this assembly actually USES a type from
+        // Akka.Serialization.V2 ([AkkaSerializable] on MarkerMessage) -- so the C# compiler DOES
+        // emit an AssemblyRef to Akka.Serialization.V2 into this compiled assembly's own metadata,
+        // making it exactly the shape CompilationFacts.ReferencedAssembliesUsingV2 (Decision 19's
+        // pre-filter) exists to detect. MarkerMessage implements neither IAlphaProtocol nor
+        // IBetaProtocol, so this cannot also change either protocol's local-implementor bucket --
+        // the ONLY fact this edit can move is the referenced-assembly-name list itself.
+        var extraReference = GeneratorTestHarness.CompileToReference(ExtraReferenceSourceUsingV2, "ScenarioExtraReferenceAssemblyUsingV2");
+
+        var result = GeneratorTestHarness.RunIncremental(
+            new[] { new SourceFile("Main.cs", FixtureSource) },
+            new[] { new SourceFile("Main.cs", FixtureSource) },
+            beforeExtraReferences: Array.Empty<MetadataReference>(),
+            afterExtraReferences: new[] { extraReference });
+
+        // Same profile as scenario (e) up through ResolvedSerializers: nothing in the fixture itself
+        // changed, so every extracted/collected/resolved model still compares equal.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedSerializers, IncrementalStepRunReason.Cached);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged,
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
+
+        // TARGET (S5): CompilationFacts is NOT combined into ResolvedSerializers' inputs (see
+        // TrackingNames.CompilationFacts's own doc comment for why that wiring is deliberately
+        // deferred), so a CompilationFacts change alone cannot move ResolvedSerializers -- both
+        // serializers stay Cached even though CompilationFacts itself reports Modified below.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
+
+        // THE SCENARIO FLIP: the newly added reference DOES reference Akka.Serialization.V2, so
+        // CompilationFacts.ReferencedAssembliesUsingV2 gains an entry -- the computed CompilationFacts
+        // value genuinely differs from the previous run, so this stage reports Modified, not
+        // Unchanged. This is the behavioral proof that ComputeReferencedAssembliesUsingV2 is real
+        // and wired up, not merely present with no effect.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CompilationFacts, IncrementalStepRunReason.Modified);
+
+        // No serializer's own message table changed and MarkerMessage implements neither protocol,
+        // so -- even though CompilationFacts itself changed -- no file is re-emitted and no new
+        // AKKASG029 diagnostic appears.
+        ChangedHintNames(result).Should().BeEmpty();
+        result.After.RunResult.Diagnostics.Where(d => d.Id == "AKKASG029").Should().BeEmpty();
     }
 
     private static void AssertReasons(IncrementalGeneratorRunResult result, string trackingName, params IncrementalStepRunReason[] expected)

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorValidatorSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorValidatorSpec.cs
@@ -304,7 +304,9 @@ public sealed class GeneratorValidatorSpec
         var compilation = Compile(source);
         var serializer = BuildSerializerInfo(ProtocolFullName(compilation));
 
-        var diagnostics = AkkaSerializerGenerator.ValidateProtocolCoverage(serializer, compilation, CancellationToken.None);
+        var facts = AkkaSerializerGenerator.ComputeCompilationFacts(
+            compilation, ImmutableArray.Create<AkkaSerializerGenerator.SerializerInfo?>(serializer), CancellationToken.None);
+        var diagnostics = AkkaSerializerGenerator.ValidateProtocolCoverage(serializer, facts);
 
         diagnostics.Should().Contain(diagnostic =>
             diagnostic.Key == AkkaSerializerGenerator.DiagnosticKey.ProtocolMessageNotSerializable &&


### PR DESCRIPTION
> Stack, bottom to top: S1 #8525 -> S2 #8526 -> S3 #8527 -> object elements #8528 -> S4 #8530 -> S5 #8532 -> S6 #8533 -> F1 #8534 -> F2 #8536 -> F3 #8537 -> S7 #8538. Each PR is one commit on top of the one below it. This PR is S5.

## What changes

Nothing in output or diagnostics. Every keystroke got 4 to 8 times cheaper.

- **The known-types table is built once per compilation.** The generator looks up about fifteen well-known types by name to classify fields. Before, every attributed type's step rebuilt that table on every edit: about 7,500 lookups per keystroke in a project with 500 messages. Now a weak table keyed on the compilation instance computes it once.
- **A facts stage.** A new step, `CompilationFacts`, computes what the pipeline needs to know about the whole compilation, once per edit, and hands it down as plain values that compare by content. The protocol-coverage check (AKKASG029) reads its result instead of walking every type once per serializer.
- **Groundwork for Decision 19.** The stage also records which referenced assemblies reference Akka.Serialization.V2. That is the filter the later implementor walk uses. A new scenario proves the filter is live. The walk itself is a skeleton with the right signature.
- **Not wired into resolve yet.** Nothing the facts compute today changes a resolved serializer, so wiring them in would add risk for no gain. F1 does the wiring when it needs it.

Two small helpers were needed: an `ImmutableArray<T>` compares by reference, so a dictionary whose values are arrays needs a compare that looks inside.

## Scenarios

Scenario d, a keystroke in an unrelated file, is this PR's pin: the facts stage runs and reports its output unchanged.

| Scenario | Facts stage |
|---|---|
| a. unrelated file edited | Unchanged |
| b. field renamed | Unchanged |
| c. comment added | Unchanged |
| d. trivial keystroke | Unchanged |
| e. unused reference added | Unchanged |
| e2. reference that itself references V2 added | Modified |

## Savings

Base is the S4 tip, measured in a paired run on the same machine. This PR's row was measured twice in separate runs: allocations were identical, and means agreed within 5 percent.

| Row | Base (S4) | This PR | Change |
|---|---:|---:|---:|
| Fresh driver, full corpus | 78 ms, 21.9 MB | 22 ms, 18.1 MB | 3.5x faster, -18% allocated |
| Warm driver, one field renamed | 65 ms, 12.5 MB | 14 ms, 8.6 MB | 4.8x faster, -31% allocated |
| Warm driver, comment edit | 59 ms, 6.8 MB | 8.8 ms, 3.0 MB | 6.7x faster, -56% allocated |
| Warm driver, unrelated file edited | 53 ms, 6.7 MB | 6.5 ms, 2.9 MB | 8.1x faster, -57% allocated |

The S1 baseline blamed the no-change floor on Roslyn re-running the per-type step. Most of that floor was ours. A keystroke in an unrelated file now costs about 6 ms and 3 MB at 500 messages.

## How it was checked

313 tests pass (309 plus 3 facts tests and 1 scenario). Generator builds with warnings as errors. `Akka.Remote` builds. Golden, wire, and both model snapshots unchanged.
