### PR TITLE
Report every generator diagnostic at its source line (S6)

### DIFF
--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Diagnostics.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Diagnostics.cs
@@ -420,13 +420,25 @@ public sealed partial class AkkaSerializerGenerator
             _ => throw new ArgumentOutOfRangeException(nameof(key), key, "Unknown DiagnosticKey: add a case mapping it to its DiagnosticDescriptor.")
         };
 
-        public static Diagnostic ToDiagnostic(DiagnosticSpec spec)
+        /// <summary>
+        /// Turns a <see cref="DiagnosticSpec"/> into a real <see cref="Diagnostic"/>, resolving
+        /// <see cref="DiagnosticSpec.At"/> against <paramref name="locations"/> -- the ONE place in
+        /// this generator a <see cref="Location"/> is ever attached to a reported diagnostic. Falls
+        /// back to <see cref="Location.None"/> when <see cref="DiagnosticSpec.At"/> is null or
+        /// <paramref name="locations"/> has no entry for it (a site this generator could not resolve,
+        /// for example because the underlying syntax reference could not be re-materialized).
+        /// </summary>
+        public static Diagnostic ToDiagnostic(DiagnosticSpec spec, LocationBag locations)
         {
             var args = new object[spec.MessageArgs.Length];
             for (var i = 0; i < spec.MessageArgs.Length; i++)
                 args[i] = spec.MessageArgs[i];
 
-            return Diagnostic.Create(Resolve(spec.Key), Location.None, args);
+            var location = spec.At is { } key && locations.TryGetLocation(key, out var found)
+                ? found.ToLocation()
+                : Location.None;
+
+            return Diagnostic.Create(Resolve(spec.Key), location, args);
         }
     }
 }

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Emission.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Emission.cs
@@ -87,18 +87,26 @@ public sealed partial class AkkaSerializerGenerator
     /// ONCE regardless of how many serializers are declared -- the per-serializer output would
     /// otherwise need to single out one serializer as the "owner" to avoid reporting a duplicate-id
     /// pair once per serializer in the group. This mirrors the diagnostics-only shape
-    /// <see cref="ReportProtocolCoverage"/> already used for AKKASG029.
+    /// <see cref="ReportProtocolCoverage"/> already used for AKKASG029. As of S6 this also combines
+    /// the merged <see cref="LocationBag"/>: AKKASG013/AKKASG031 report at the FIRST serializer in
+    /// their duplicate group (declaration order, i.e. array order) since no single serializer owns a
+    /// group spanning several of them; AKKASG037 reports at the generic definition's OWN message
+    /// location, since it is not serializer-scoped at all.
     /// </summary>
     private static void ReportCrossSerializerDiagnostics(
         SourceProductionContext context,
         ImmutableArray<SerializerInfo?> serializers,
-        ImmutableArray<MessageInfo?> messages)
+        ImmutableArray<MessageInfo?> messages,
+        LocationBag locations)
     {
         var duplicateSerializerIds = ComputeDuplicateSerializerIds(serializers);
 
         foreach (var duplicate in duplicateSerializerIds)
         {
-            context.ReportDiagnostic(Diagnostic.Create(DuplicateSerializerId, Location.None, duplicate.Key, duplicate.Value));
+            SerializerInfo owner = serializers.First(s => s != null && s.SerializerId == duplicate.Key)!;
+            var spec = new DiagnosticSpec(DiagnosticKey.DuplicateSerializerId, new LocationKey(owner.Key, string.Empty),
+                duplicate.Key.ToString(), duplicate.Value);
+            context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(spec, locations));
         }
 
         // Same computation as duplicateSerializerIds above, grouped on the protocol interface
@@ -108,7 +116,10 @@ public sealed partial class AkkaSerializerGenerator
 
         foreach (var duplicate in duplicateProtocolBindings)
         {
-            context.ReportDiagnostic(Diagnostic.Create(DuplicateProtocolBinding, Location.None, ToDisplayName(duplicate.Key), duplicate.Value));
+            SerializerInfo owner = serializers.First(s => s != null && string.Equals(s.ProtocolTypeFullName, duplicate.Key, StringComparison.Ordinal))!;
+            var spec = new DiagnosticSpec(DiagnosticKey.DuplicateProtocolBinding, new LocationKey(owner.Key, string.Empty),
+                ToDisplayName(duplicate.Key), duplicate.Value);
+            context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(spec, locations));
         }
 
         var declaredMessages = ComputeDeclaredMessages(messages);
@@ -116,10 +127,13 @@ public sealed partial class AkkaSerializerGenerator
         // Advisory only (AKKASG037): a Manifest on a generic [AkkaSerializable] DEFINITION is
         // silently ignored -- the definition is never serialized directly (see ExtractMessage),
         // and every registered closed construction carries its own per-construction Manifest from
-        // [AkkaSerializable<T>]. Reported once per definition, independent of any serializer.
+        // [AkkaSerializable<T>]. Reported once per definition, independent of any serializer, at the
+        // definition's own message-level location.
         foreach (var definition in declaredMessages.Where(message => message.IsGenericDefinition && !string.IsNullOrWhiteSpace(message.Manifest)))
         {
-            context.ReportDiagnostic(Diagnostic.Create(ManifestIgnoredOnGenericDefinition, Location.None, ToDisplayName(definition.FullyQualifiedName), definition.Manifest));
+            var spec = new DiagnosticSpec(DiagnosticKey.ManifestIgnoredOnGenericDefinition, new LocationKey(definition.Key, string.Empty),
+                ToDisplayName(definition.FullyQualifiedName), definition.Manifest);
+            context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(spec, locations));
         }
     }
 
@@ -225,25 +239,24 @@ public sealed partial class AkkaSerializerGenerator
     }
 
     /// <summary>
-    /// Reports a resolved serializer's own diagnostics (gate, then validation -- the same order
-    /// <see cref="ResolveSerializer"/>'s predecessor, the single-output <c>EmitSerializers</c>, used
-    /// to report them in) and emits its generated source, PURELY over the resolved model -- no
-    /// <see cref="Compilation"/>, no other serializer's data. Registered directly on the
+    /// Emits a resolved serializer's generated source, PURELY over the resolved model -- no
+    /// <see cref="Compilation"/>, no location, no other serializer's data. Registered directly on the
     /// <see cref="TrackingNames.ResolvedSerializers"/> values provider in <see cref="Initialize"/>,
     /// so the driver's own per-element caching (not any code here) is what makes an unrelated
     /// serializer's <c>AddSource</c> call Cached instead of re-running: this callback simply never
-    /// executes for an element whose resolved model still compares equal to last time.
+    /// executes for an element whose resolved model still compares equal to last time. As of S6 this
+    /// callback no longer reports any diagnostic -- see <see cref="ReportResolvedSerializerDiagnostics"/>,
+    /// a separate diagnostics-only output that also has the merged location bag -- so this stage's
+    /// own caching is never affected by a location-only edit (it never combines the location bag at
+    /// all). It still reads <see cref="ResolvedSerializer.GateDiagnostics"/>/
+    /// <see cref="ResolvedSerializer.ValidationDiagnostics"/> to decide EMITTABILITY, exactly as
+    /// before: a serializer whose own declaration failed the gate, or whose message table has an
+    /// Error-severity validation diagnostic, still gets no generated file.
     /// </summary>
     private static void EmitResolvedSerializer(SourceProductionContext context, ResolvedSerializer resolved)
     {
-        foreach (var gateDiagnostic in resolved.GateDiagnostics)
-            context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(gateDiagnostic));
-
         if (!resolved.IsEmittable)
             return;
-
-        foreach (var diagnostic in resolved.ValidationDiagnostics)
-            context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(diagnostic));
 
         // Emission is suppressed by an ERROR-severity diagnostic only -- a Warning (e.g. AKKASG027)
         // or Info (e.g. AKKASG025) still lets the serializer generate normally, exactly as the old
@@ -252,6 +265,29 @@ public sealed partial class AkkaSerializerGenerator
             return;
 
         context.AddSource(resolved.Serializer.ClassName + ".AkkaSerialization.g.cs", Generate(resolved));
+    }
+
+    /// <summary>
+    /// Reports a resolved serializer's own diagnostics (gate, then validation -- the same order the
+    /// pre-S6 <see cref="EmitResolvedSerializer"/> used to report them in): a diagnostics-only output
+    /// registered on <see cref="TrackingNames.ResolvedSerializers"/> combined with the merged
+    /// <see cref="LocationBag"/>, so it can resolve each <see cref="DiagnosticSpec.At"/> into a real
+    /// <see cref="Location"/> without making code emission itself depend on the (whitespace-sensitive)
+    /// location bag. <see cref="ResolvedSerializer.GateDiagnostics"/> are reported unconditionally
+    /// (they fire whether or not the gate itself passes -- mirrors <see cref="EvaluateGate"/>'s own
+    /// contract); <see cref="ResolvedSerializer.ValidationDiagnostics"/> only when the serializer
+    /// cleared the gate (a serializer with no message table has nothing to validate).
+    /// </summary>
+    private static void ReportResolvedSerializerDiagnostics(SourceProductionContext context, ResolvedSerializer resolved, LocationBag locations)
+    {
+        foreach (var gateDiagnostic in resolved.GateDiagnostics)
+            context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(gateDiagnostic, locations));
+
+        if (!resolved.IsEmittable)
+            return;
+
+        foreach (var diagnostic in resolved.ValidationDiagnostics)
+            context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(diagnostic, locations));
     }
 
     /// <summary>

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Extraction.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Extraction.cs
@@ -37,7 +37,7 @@ public sealed partial class AkkaSerializerGenerator
 
     private const string AkkaSerializerBaseTypeFullName = "Akka.Serialization.V2.AkkaSerializer";
 
-    private static SerializerInfo? ExtractSerializer(GeneratorAttributeSyntaxContext context, CancellationToken cancellationToken)
+    private static ExtractedSerializer ExtractSerializer(GeneratorAttributeSyntaxContext context, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -50,7 +50,19 @@ public sealed partial class AkkaSerializerGenerator
         // rejected with CS0579 ("Duplicate 'AkkaSerializer<>' attribute") even though IA and IB
         // differ, so at most one [AkkaSerializer<T>] ever reaches this method. No AKKASG030 is
         // needed for this case.
-        return ExtractSerializerCore(symbol, context.Attributes[0], context.SemanticModel.Compilation);
+        var attribute = context.Attributes[0];
+        var compilation = context.SemanticModel.Compilation;
+        var knownTypes = GetKnownTypes(compilation);
+
+        // One shared builder for every location entry this serializer contributes: its own
+        // attribute, each formatter/closed-generic registration attribute (appended below by
+        // BuildSerializerLocationBag), AND every [AkkaField] property of each closed-generic SCHEMA
+        // this serializer registers (appended inline by ExtractSerializerCore -> ExtractClosedGenericRegistrations
+        // -> ExtractMessageCore, the same inlining ExtractMessage below uses for ordinary messages).
+        var locationEntries = ImmutableArray.CreateBuilder<LocationEntry>();
+        var info = ExtractSerializerCore(symbol, attribute, compilation, knownTypes, locationEntries);
+        BuildSerializerLocationBag(locationEntries, symbol, attribute, info.Key, knownTypes, cancellationToken);
+        return new ExtractedSerializer(info, new LocationBag(locationEntries.ToImmutable()));
     }
 
     /// <summary>
@@ -71,10 +83,15 @@ public sealed partial class AkkaSerializerGenerator
         if (attribute == null)
             return null;
 
-        return ExtractSerializerCore(symbol, attribute, compilation);
+        return ExtractSerializerCore(symbol, attribute, compilation, GetKnownTypes(compilation));
     }
 
-    private static SerializerInfo ExtractSerializerCore(INamedTypeSymbol symbol, AttributeData attribute, Compilation compilation)
+    private static SerializerInfo ExtractSerializerCore(
+        INamedTypeSymbol symbol,
+        AttributeData attribute,
+        Compilation compilation,
+        KnownTypes knownTypes,
+        ImmutableArray<LocationEntry>.Builder? locationEntries = null)
     {
         string? name = null;
         var serializerId = 0;
@@ -99,14 +116,14 @@ public sealed partial class AkkaSerializerGenerator
         var protocolTypeKey = protocolType != null ? TypeKey.FromSymbol(protocolType) : default;
         var protocolTypeIsInterface = protocolType?.TypeKind == TypeKind.Interface;
 
-        var formatterAttributeType = compilation.GetTypeByMetadataName(FormatterAttributeFullName);
         var extendedActorSystemType = compilation.GetTypeByMetadataName(ExtendedActorSystemFullName);
-        var formatters = ExtractFormatters(symbol, formatterAttributeType, extendedActorSystemType);
-        var (closedGenericRegistrations, closedGenericSchemas) = ExtractClosedGenericRegistrations(symbol, compilation);
+        var formatters = ExtractFormatters(symbol, knownTypes.FormatterAttribute, extendedActorSystemType);
+        var (closedGenericRegistrations, closedGenericSchemas) = ExtractClosedGenericRegistrations(symbol, compilation, knownTypes, locationEntries);
 
         return new SerializerInfo(
             GetNamespace(symbol),
             symbol.Name,
+            TypeKey.FromSymbol(symbol),
             GetFullyQualifiedTypeName(symbol),
             name ?? string.Empty,
             serializerId,
@@ -174,19 +191,21 @@ public sealed partial class AkkaSerializerGenerator
     /// with no matching schema entry, so AKKASG020 fires instead of the registration silently
     /// vanishing.
     /// </summary>
-    private static (ImmutableArray<ClosedGenericRegistrationInfo> Registrations, ImmutableArray<MessageInfo> Schemas) ExtractClosedGenericRegistrations(INamedTypeSymbol symbol, Compilation compilation)
+    private static (ImmutableArray<ClosedGenericRegistrationInfo> Registrations, ImmutableArray<MessageInfo> Schemas) ExtractClosedGenericRegistrations(
+        INamedTypeSymbol symbol,
+        Compilation compilation,
+        KnownTypes knownTypes,
+        ImmutableArray<LocationEntry>.Builder? locationEntries = null)
     {
-        var genericSerializableAttribute = compilation.GetTypeByMetadataName(GenericSerializableAttributeFullName);
-        if (genericSerializableAttribute == null)
+        if (knownTypes.GenericSerializableAttribute == null)
             return (ImmutableArray<ClosedGenericRegistrationInfo>.Empty, ImmutableArray<MessageInfo>.Empty);
 
         var attributes = symbol.GetAttributes()
-            .Where(attr => attr.AttributeClass is { IsGenericType: true } ac && SymbolEqualityComparer.Default.Equals(ac.OriginalDefinition, genericSerializableAttribute))
+            .Where(attr => attr.AttributeClass is { IsGenericType: true } ac && SymbolEqualityComparer.Default.Equals(ac.OriginalDefinition, knownTypes.GenericSerializableAttribute))
             .ToImmutableArray();
         if (attributes.IsEmpty)
             return (ImmutableArray<ClosedGenericRegistrationInfo>.Empty, ImmutableArray<MessageInfo>.Empty);
 
-        var knownTypes = GetKnownTypes(compilation);
         var registrationsBuilder = ImmutableArray.CreateBuilder<ClosedGenericRegistrationInfo>(attributes.Length);
         var schemasBuilder = ImmutableArray.CreateBuilder<MessageInfo>();
         foreach (var attribute in attributes)
@@ -225,7 +244,8 @@ public sealed partial class AkkaSerializerGenerator
                 allowEmpty,
                 knownTypes,
                 compilation,
-                definitionFullName: GetFullyQualifiedTypeName(target!.OriginalDefinition));
+                definitionFullName: GetFullyQualifiedTypeName(target!.OriginalDefinition),
+                locationEntries);
             registrationsBuilder.Add(new ClosedGenericRegistrationInfo(targetTypeKey, manifest, allowEmpty));
             schemasBuilder.Add(message);
         }
@@ -350,7 +370,7 @@ public sealed partial class AkkaSerializerGenerator
         return hasParameterlessCtor ? FormatterCtorKind.Parameterless : FormatterCtorKind.None;
     }
 
-    private static MessageInfo? ExtractMessage(GeneratorAttributeSyntaxContext context, CancellationToken cancellationToken)
+    private static ExtractedMessage ExtractMessage(GeneratorAttributeSyntaxContext context, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -375,9 +395,10 @@ public sealed partial class AkkaSerializerGenerator
         // as Unsupported and produce a misleading AKKASG003 against the definition.
         if (symbol.IsGenericType)
         {
-            return new MessageInfo(
+            var definitionKey = BuildGenericDefinitionKey(symbol);
+            var definitionInfo = new MessageInfo(
                 symbol.Name,
-                BuildGenericDefinitionKey(symbol),
+                definitionKey,
                 manifest,
                 ImmutableArray<FieldInfo>.Empty,
                 GetProtocolNames(symbol),
@@ -386,9 +407,21 @@ public sealed partial class AkkaSerializerGenerator
                 definitionFullName: GetFullyQualifiedTypeName(symbol),
                 invalidFields: ImmutableArray<InvalidFieldInfo>.Empty,
                 constructionPlan: ConstructionPlan.Empty);
+
+            // A generic definition has no fields (see above), so it needs only its own type-level
+            // location entry -- no property walk at all.
+            return new ExtractedMessage(definitionInfo, BuildTypeOnlyLocationBag(symbol, definitionKey));
         }
 
-        return ExtractMessageCore(symbol, TypeKey.FromSymbol(symbol), manifest, allowEmpty, knownTypes, compilation, definitionFullName: string.Empty);
+        var key = TypeKey.FromSymbol(symbol);
+
+        // Field-level location capture is INLINED into ExtractMessageCore's own property walk (see
+        // this file's own header comment for why a second full re-walk here would be wasteful); only
+        // the type's own declaration entry is added here, once, up front.
+        var locationEntries = ImmutableArray.CreateBuilder<LocationEntry>();
+        AddLocationEntry(locationEntries, new LocationKey(key, string.Empty), FirstLocationOrNull(symbol.Locations));
+        var info = ExtractMessageCore(symbol, key, manifest, allowEmpty, knownTypes, compilation, definitionFullName: string.Empty, locationEntries);
+        return new ExtractedMessage(info, new LocationBag(locationEntries.ToImmutable()));
     }
 
     /// <summary>
@@ -475,7 +508,8 @@ public sealed partial class AkkaSerializerGenerator
         bool allowEmpty,
         KnownTypes knownTypes,
         Compilation compilation,
-        string definitionFullName)
+        string definitionFullName,
+        ImmutableArray<LocationEntry>.Builder? locationEntries = null)
     {
         var fields = new List<FieldInfo>();
         var fieldSymbols = new List<IPropertySymbol>();
@@ -486,6 +520,16 @@ public sealed partial class AkkaSerializerGenerator
                 .FirstOrDefault(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, knownTypes.FieldAttribute));
             if (fieldAttribute == null || fieldAttribute.ConstructorArguments.Length != 1)
                 continue;
+
+            // S6 "locations": captured here, reusing the SAME [AkkaField] check above instead of a
+            // second GetAttributes() walk over every property -- see this file's own header comment.
+            // Every [AkkaField] property gets an entry, valid or structurally invalid alike (the
+            // static/getter checks below can still reject it), so AKKASG028 always finds its site.
+            // For a closed generic construction's SUBSTITUTED member, Locations still resolves back
+            // to the GENERIC DEFINITION's own declared property -- the right site, since the
+            // construction itself has no separate syntax.
+            if (locationEntries != null)
+                AddLocationEntry(locationEntries, new LocationKey(key, member.Name), FirstLocationOrNull(member.Locations));
 
             // A static or getter-inaccessible [AkkaField] property can never be read by the
             // generated Write path (`message.Property`) -- record it as invalid (AKKASG028) instead
@@ -1195,6 +1239,8 @@ public sealed partial class AkkaSerializerGenerator
             FieldAttribute = compilation.GetTypeByMetadataName(FieldAttributeFullName);
             UnionAttribute = compilation.GetTypeByMetadataName(UnionAttributeFullName);
             SerializableAttribute = compilation.GetTypeByMetadataName(SerializableAttributeFullName);
+            FormatterAttribute = compilation.GetTypeByMetadataName(FormatterAttributeFullName);
+            GenericSerializableAttribute = compilation.GetTypeByMetadataName(GenericSerializableAttributeFullName);
             Guid = compilation.GetTypeByMetadataName("System.Guid");
             DateTimeOffset = compilation.GetTypeByMetadataName("System.DateTimeOffset");
             ActorRef = compilation.GetTypeByMetadataName("Akka.Actor.IActorRef");
@@ -1220,6 +1266,13 @@ public sealed partial class AkkaSerializerGenerator
         public INamedTypeSymbol? FieldAttribute { get; }
         public INamedTypeSymbol? UnionAttribute { get; }
         public INamedTypeSymbol? SerializableAttribute { get; }
+
+        /// <summary>The open <c>AkkaSerializerFormatterAttribute&lt;TTarget, TFormatter&gt;</c> definition -- resolved once per compilation, shared by <see cref="ExtractFormatters"/> and <see cref="BuildSerializerLocationBag"/>.</summary>
+        public INamedTypeSymbol? FormatterAttribute { get; }
+
+        /// <summary>The open <c>AkkaSerializableAttribute&lt;TMessage&gt;</c> definition -- resolved once per compilation, shared by <see cref="ExtractClosedGenericRegistrations"/> and <see cref="BuildSerializerLocationBag"/>.</summary>
+        public INamedTypeSymbol? GenericSerializableAttribute { get; }
+
         public INamedTypeSymbol? Guid { get; }
         public INamedTypeSymbol? DateTimeOffset { get; }
         public INamedTypeSymbol? ActorRef { get; }

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Locations.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Locations.cs
@@ -1,0 +1,377 @@
+//-----------------------------------------------------------------------
+// <copyright file="AkkaSerializerGenerator.Locations.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Akka.Serialization.V2.Generators;
+
+// S6 "locations": every diagnostic must report at the local reference site (Decision 16 in
+// openspec/changes/messagepack-sourcegen-validation/design.md), never at Location.None. A Location
+// itself can never enter a cached model (a whitespace edit changes every span, so a model carrying
+// one would never compare equal across an edit -- see GeneratorArchitectureSpec). This file carries
+// locations BESIDE the model instead:
+//   - LocationSpec   a value-equatable stand-in for a real Location, built once at extraction time.
+//   - LocationKey    identifies WHAT a location is for -- a type declaration, its own attribute, or
+//                     one of its named members (a field, or a specific attribute application) --
+//                     without saying WHERE it is. DiagnosticSpec.At carries one of these, never a
+//                     LocationSpec directly.
+//   - LocationBag    the extracted location entries for ONE serializer or message declaration.
+//                     ExtractedSerializer/ExtractedMessage carry a LocationBag alongside (never
+//                     inside) their schema model, so the schema stays whitespace-insensitive while
+//                     the location bag alone absorbs a text-shifting edit.
+//
+// PERFORMANCE: a location bag is built for EVERY attributed declaration on EVERY extraction re-run
+// (the same "every node reruns" cost every other extraction transform already pays -- see
+// GeneratorIncrementalScenariosSpec's own doc comment), so its construction cost multiplies by the
+// corpus size on every edit, not just the edited node. Two rules keep that cost down:
+//   1. A bag stores its entries as a plain ImmutableArray, never an ImmutableDictionary: building a
+//      handful of array elements is one allocation; building a handful of dictionary entries is one
+//      tree-node allocation PER entry. Lookup (TryGetLocation) is a linear scan, which is fine -- a
+//      bag holds a handful of entries, and a lookup only happens when a diagnostic is actually being
+//      reported, which is rare compared to how often a bag is built.
+//   2. Field-location capture is INLINED into the SAME symbol.GetMembers()/GetAttributes() walk
+//      ExtractMessageCore already does for schema extraction (via the optional locationEntries
+//      parameter), instead of a second full re-walk. A second walk would re-run GetAttributes() on
+//      every property a second time -- redundant work Roslyn does not cache away for free.
+//
+// THE LOCATION RULE (applied at every DiagnosticSpec call site in Validation.cs/Emission.cs):
+//   - field-level diagnostic            -> LocationKey(message.Key, field.Name): the offending
+//                                           [AkkaField] property, including a cross-assembly variant
+//                                           (Decision 16: report at the LOCAL referencing property,
+//                                           never inside the foreign assembly, which gets no
+//                                           diagnostic at all).
+//   - message type-level diagnostic     -> LocationKey(message.Key, ""): the message type's own
+//                                           declaration (its identifier).
+//   - serializer-level diagnostic       -> LocationKey(serializer.Key, ""): the [AkkaSerializer<T>]
+//                                           attribute application, including AKKASG029 protocol
+//                                           coverage (the unmarked implementor is not an attributed
+//                                           type in THIS generator's model at all, so there is no
+//                                           local site on it to point at, and the facts stage must
+//                                           stay whitespace-insensitive to that implementor's own
+//                                           declaration).
+//   - a specific formatter registration -> LocationKey(serializer.Key, FormatterLocationMember(...)):
+//                                           the [AkkaSerializerFormatter<TTarget,TFormatter>]
+//                                           application for that target.
+//   - a specific closed-generic
+//     registration                      -> LocationKey(serializer.Key, ClosedGenericLocationMember(...)):
+//                                           the [AkkaSerializable<T>] application for that target
+//                                           (Decision 16: "the registration attribute for a closed
+//                                           generic"). A closed-generic SCHEMA's own fields are keyed
+//                                           by the CONSTRUCTION's TypeKey (e.g. Wrapper<int>), not the
+//                                           serializer -- ExtractMessageCore's substituted property
+//                                           symbols still resolve Locations back to the GENERIC
+//                                           DEFINITION's own declared property, which is exactly the
+//                                           right site (there is no separate syntax for Wrapper<int>).
+//   - a diagnostic spanning MULTIPLE messages or serializers (duplicate manifest, duplicate
+//     generated name, duplicate serializer id, duplicate protocol binding) has no single owning
+//     message -> reported at the serializer's attribute (or, for a duplicate-id/duplicate-protocol
+//     group spanning several serializers, the first serializer in the group).
+public sealed partial class AkkaSerializerGenerator
+{
+    /// <summary>
+    /// A value-equatable stand-in for a real <see cref="Microsoft.CodeAnalysis.Location"/>, captured
+    /// once at extraction time. Every field here shifts on a text edit anywhere earlier in the same
+    /// file -- that is expected and correct, not a caching bug: it is what lets
+    /// <see cref="ToLocation"/> reconstruct a squiggle at the exact right place on THIS run, while
+    /// keeping the location entirely OUT of <see cref="SerializerInfo"/>/<see cref="MessageInfo"/>
+    /// so neither one's equality (and therefore Collect/Resolve/Emit caching) is ever affected by it.
+    /// </summary>
+    internal readonly record struct LocationSpec(
+        string FilePath,
+        int Start,
+        int Length,
+        int StartLine,
+        int StartCharacter,
+        int EndLine,
+        int EndCharacter)
+    {
+        /// <summary>Reconstructs a real <see cref="Microsoft.CodeAnalysis.Location"/> from this spec.</summary>
+        public Location ToLocation() => Location.Create(
+            FilePath,
+            new TextSpan(Start, Length),
+            new LinePositionSpan(new LinePosition(StartLine, StartCharacter), new LinePosition(EndLine, EndCharacter)));
+
+        /// <summary>
+        /// Captures a live <see cref="Microsoft.CodeAnalysis.Location"/> into this value-equatable
+        /// form. This is the only place in the generator that reads a live <see cref="Location"/>'s
+        /// span/line data; every other consumer works from the captured spec.
+        /// </summary>
+        public static LocationSpec FromLocation(Location location)
+        {
+            var span = location.SourceSpan;
+            var lineSpan = location.GetLineSpan();
+            return new LocationSpec(
+                lineSpan.Path ?? string.Empty,
+                span.Start,
+                span.Length,
+                lineSpan.StartLinePosition.Line,
+                lineSpan.StartLinePosition.Character,
+                lineSpan.EndLinePosition.Line,
+                lineSpan.EndLinePosition.Character);
+        }
+    }
+
+    /// <summary>
+    /// Identifies WHAT a location is for -- never WHERE it is (that is <see cref="LocationSpec"/>'s
+    /// job). <see cref="Owner"/> is the declaring serializer's or message's own <see cref="TypeKey"/>;
+    /// <see cref="Member"/> names a specific child site within it. An empty <see cref="Member"/>
+    /// means "the type itself" for a message (its declaration) or "its own attribute" for a
+    /// serializer (the <c>[AkkaSerializer&lt;TProtocol&gt;]</c> application) -- see
+    /// <see cref="FormatterLocationMember"/>/<see cref="ClosedGenericLocationMember"/> for the two
+    /// other member shapes a serializer's location bag carries.
+    /// </summary>
+    internal readonly record struct LocationKey(TypeKey Owner, string Member);
+
+    /// <summary>One (<see cref="LocationKey"/>, <see cref="LocationSpec"/>) pair inside a <see cref="LocationBag"/>.</summary>
+    internal readonly record struct LocationEntry(LocationKey Key, LocationSpec Location);
+
+    /// <summary>
+    /// The <see cref="LocationKey.Member"/> for a specific <c>[AkkaSerializerFormatter&lt;TTarget,
+    /// TFormatter&gt;]</c> application, keyed by its target type's display name (the same string
+    /// <see cref="FormatterInfo.TargetTypeFullName"/> already carries, so a diagnostic built from a
+    /// resolved <see cref="FormatterInfo"/> always finds the matching entry the location bag recorded
+    /// from the same attribute at extraction time).
+    /// </summary>
+    private static string FormatterLocationMember(string targetTypeFullName) => "formatter:" + targetTypeFullName;
+
+    /// <summary>
+    /// The <see cref="LocationKey.Member"/> for a specific <c>[AkkaSerializable&lt;T&gt;]</c>
+    /// registration application, keyed by its target type's display name (the same string
+    /// <see cref="ClosedGenericRegistrationInfo.TargetDisplayName"/> already carries).
+    /// </summary>
+    private static string ClosedGenericLocationMember(string targetTypeDisplayName) => "closedGeneric:" + targetTypeDisplayName;
+
+    /// <summary>
+    /// The location entries extracted for ONE serializer or message declaration. Kept beside -- never
+    /// inside -- <see cref="SerializerInfo"/>/<see cref="MessageInfo"/>, and merged (see
+    /// <see cref="MergeLocationBags"/>) into one compilation-wide bag that every diagnostics-only
+    /// output combines, purely to resolve <see cref="DiagnosticSpec.At"/> at report time. Backed by a
+    /// plain <see cref="ImmutableArray{T}"/>, not a dictionary -- see this file's own header comment
+    /// for why that matters for a bag built on every extraction re-run.
+    /// </summary>
+    internal sealed class LocationBag : IEquatable<LocationBag>
+    {
+        public static readonly LocationBag Empty = new(ImmutableArray<LocationEntry>.Empty);
+
+        public LocationBag(ImmutableArray<LocationEntry> entries)
+        {
+            Entries = entries.IsDefault ? ImmutableArray<LocationEntry>.Empty : entries;
+        }
+
+        public ImmutableArray<LocationEntry> Entries { get; }
+
+        /// <summary>Linear scan: bags are small, and a lookup only happens when a diagnostic is actually reported.</summary>
+        public bool TryGetLocation(LocationKey key, out LocationSpec location)
+        {
+            foreach (var entry in Entries)
+            {
+                if (entry.Key.Equals(key))
+                {
+                    location = entry.Location;
+                    return true;
+                }
+            }
+
+            location = default;
+            return false;
+        }
+
+        public bool Equals(LocationBag? other)
+        {
+            if (ReferenceEquals(this, other))
+                return true;
+
+            if (other is null)
+                return false;
+
+            return ValueEquality.SequenceEquals(Entries, other.Entries);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as LocationBag);
+
+        public override int GetHashCode()
+        {
+            var hash = ValueEquality.Seed;
+            hash = ValueEquality.Combine(hash, Entries);
+            return hash;
+        }
+    }
+
+    /// <summary>
+    /// The raw per-node output of the serializer extraction transform: the schema
+    /// (<see cref="Info"/>, symbol-free and whitespace-insensitive) plus this declaration's
+    /// <see cref="LocationBag"/> (whitespace-SENSITIVE by design). <see cref="Initialize"/> projects
+    /// out a schemas-only <see cref="TrackingNames.SerializerSchemas"/> stage for Collect/Resolve/Emit
+    /// -- unaffected by a text-shifting edit that changes only <see cref="Locations"/> -- and
+    /// collects THIS type directly (no separate locations-only projection) to build the merged
+    /// location bag; see <see cref="MergeExtractedLocations"/>.
+    /// </summary>
+    internal readonly record struct ExtractedSerializer(SerializerInfo? Info, LocationBag Locations);
+
+    /// <summary>The message extraction transform's counterpart to <see cref="ExtractedSerializer"/>.</summary>
+    internal readonly record struct ExtractedMessage(MessageInfo? Info, LocationBag Locations);
+
+    /// <summary>
+    /// Merges every extracted serializer's and message's location bag into ONE compilation-wide bag,
+    /// by plain concatenation into a single pre-sized array -- cheaper than folding into a dictionary
+    /// one entry at a time. <see cref="LocationKey"/> values never collide across a serializer and a
+    /// message (each key's <see cref="TypeKey"/> owner identifies exactly one declared type), so no
+    /// de-duplication is needed. Reads <see cref="ExtractedSerializer.Locations"/>/
+    /// <see cref="ExtractedMessage.Locations"/> straight off the COLLECTED raw extraction results --
+    /// there is deliberately no separate locations-only <c>Select</c> stage feeding this (see
+    /// <see cref="Initialize"/>'s own comment on <c>allLocations</c>): a per-node Select still builds
+    /// its own incremental state table over every node on every edit for a value this function reads
+    /// back only once, batched, so collecting the raw values directly and projecting HERE is the same
+    /// merged bag for one fewer per-node Select.
+    /// </summary>
+    private static LocationBag MergeExtractedLocations(
+        ImmutableArray<ExtractedSerializer> serializers,
+        ImmutableArray<ExtractedMessage> messages,
+        CancellationToken cancellationToken)
+    {
+        var total = 0;
+        foreach (var extracted in serializers)
+            total += extracted.Locations.Entries.Length;
+        foreach (var extracted in messages)
+            total += extracted.Locations.Entries.Length;
+
+        var builder = ImmutableArray.CreateBuilder<LocationEntry>(total);
+        foreach (var extracted in serializers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            builder.AddRange(extracted.Locations.Entries);
+        }
+
+        foreach (var extracted in messages)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            builder.AddRange(extracted.Locations.Entries);
+        }
+
+        return new LocationBag(builder.MoveToImmutable());
+    }
+
+    /// <summary>Appends an entry for <paramref name="location"/> under <paramref name="key"/>, silently skipping a location this generator could not resolve (never fabricated).</summary>
+    private static void AddLocationEntry(ImmutableArray<LocationEntry>.Builder entries, LocationKey key, Location? location)
+    {
+        if (location != null && location.SourceTree != null)
+            entries.Add(new LocationEntry(key, LocationSpec.FromLocation(location)));
+    }
+
+    /// <summary>
+    /// A symbol's first declared <see cref="Location"/>, or null. Avoids
+    /// <see cref="System.Linq.Enumerable.FirstOrDefault{T}(IEnumerable{T})"/>'s interface-dispatch
+    /// overhead on <see cref="ImmutableArray{T}"/> -- this runs once per <c>[AkkaField]</c> property
+    /// on every extraction re-run (see this file's own header comment), so a plain index check is
+    /// worth it here even though the two are otherwise equivalent.
+    /// </summary>
+    private static Location? FirstLocationOrNull(ImmutableArray<Location> locations)
+    {
+        return locations.Length > 0 ? locations[0] : null;
+    }
+
+    /// <summary>The <see cref="Location"/> of an attribute APPLICATION (e.g. <c>[AkkaSerializer&lt;T&gt;(...)]</c>), not the attribute list's brackets.</summary>
+    private static Location? GetAttributeLocation(AttributeData attribute, CancellationToken cancellationToken)
+    {
+        return attribute.ApplicationSyntaxReference?.GetSyntax(cancellationToken).GetLocation();
+    }
+
+    /// <summary>
+    /// Appends the location entries for one <c>[AkkaSerializer&lt;TProtocol&gt;]</c> declaration into
+    /// <paramref name="entries"/>: the serializer's own attribute (<see cref="LocationKey.Member"/>
+    /// empty), plus one entry per <c>[AkkaSerializerFormatter&lt;TTarget,TFormatter&gt;]</c> and
+    /// <c>[AkkaSerializable&lt;T&gt;]</c> attribute application found directly on the class. Re-scans
+    /// <paramref name="symbol"/>'s attributes independently of <see cref="ExtractFormatters"/>/
+    /// <see cref="ExtractClosedGenericRegistrations"/> -- there are at most a handful of attributes on
+    /// any one serializer class (unlike a message's potentially many <c>[AkkaField]</c> properties, a
+    /// cost this file's header comment calls out separately), so a second small scan here costs far
+    /// less than the field-level duplication would. Reads <see cref="KnownTypes.FormatterAttribute"/>/
+    /// <see cref="KnownTypes.GenericSerializableAttribute"/> from the S5 per-compilation cache (see
+    /// <see cref="GetKnownTypes"/>) instead of its own <c>GetTypeByMetadataName</c> calls -- those two
+    /// symbols never change within one compilation, so re-resolving them per serializer node would be
+    /// exactly the redundant per-node lookup S5 already eliminated for every other attribute type.
+    /// </summary>
+    private static void BuildSerializerLocationBag(
+        ImmutableArray<LocationEntry>.Builder entries,
+        INamedTypeSymbol symbol,
+        AttributeData serializerAttribute,
+        TypeKey serializerKey,
+        KnownTypes knownTypes,
+        CancellationToken cancellationToken)
+    {
+        AddLocationEntry(entries, new LocationKey(serializerKey, string.Empty), GetAttributeLocation(serializerAttribute, cancellationToken));
+
+        if (knownTypes.FormatterAttribute == null && knownTypes.GenericSerializableAttribute == null)
+            return;
+
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (attribute.AttributeClass is not { IsGenericType: true } attributeClass)
+                continue;
+
+            if (knownTypes.FormatterAttribute != null && SymbolEqualityComparer.Default.Equals(attributeClass.OriginalDefinition, knownTypes.FormatterAttribute))
+            {
+                var targetKey = TypeKey.FromSymbol(attributeClass.TypeArguments[0]);
+                var member = FormatterLocationMember(targetKey.DisplayName ?? string.Empty);
+                AddLocationEntry(entries, new LocationKey(serializerKey, member), GetAttributeLocation(attribute, cancellationToken));
+                continue;
+            }
+
+            if (knownTypes.GenericSerializableAttribute != null && SymbolEqualityComparer.Default.Equals(attributeClass.OriginalDefinition, knownTypes.GenericSerializableAttribute))
+            {
+                var targetKey = TypeKey.FromSymbol(attributeClass.TypeArguments[0]);
+                var member = ClosedGenericLocationMember(targetKey.DisplayName ?? string.Empty);
+                AddLocationEntry(entries, new LocationKey(serializerKey, member), GetAttributeLocation(attribute, cancellationToken));
+            }
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="LocationKey"/> for a TYPE-LEVEL diagnostic (<see cref="LocationKey.Member"/>
+    /// empty) on <paramref name="message"/> within <paramref name="serializer"/>'s table. Ordinarily
+    /// this is the message's own declaration (<c>LocationKey(message.Key, "")</c>). But when
+    /// <paramref name="message"/> IS one of <paramref name="serializer"/>'s closed-generic SCHEMA
+    /// entries (its key matches a <see cref="ClosedGenericRegistrationInfo.Target"/>), the message's
+    /// own key has no location bag entry to resolve: a CLOSED CONSTRUCTION (e.g. <c>Wrapper&lt;int&gt;</c>)
+    /// has no separate syntax of its own -- only the GENERIC DEFINITION does. In that case the closed
+    /// construction's own <c>[AkkaSerializable&lt;T&gt;]</c> registration attribute IS the local
+    /// reference site (Decision 16), so this returns that instead -- the SAME key
+    /// <see cref="BuildSerializerLocationBag"/> already populated for it.
+    /// </summary>
+    private static LocationKey MessageTypeLocationKey(SerializerInfo serializer, MessageInfo message)
+    {
+        foreach (var registration in serializer.ClosedGenericRegistrations)
+        {
+            if (registration.Target.Equals(message.Key))
+                return new LocationKey(serializer.Key, ClosedGenericLocationMember(registration.TargetDisplayName));
+        }
+
+        return new LocationKey(message.Key, string.Empty);
+    }
+
+    /// <summary>A location bag holding only a type's own declaration entry -- used for a generic <c>[AkkaSerializable]</c> DEFINITION placeholder, which has no fields of its own to add (see <see cref="ExtractMessage"/>).</summary>
+    private static LocationBag BuildTypeOnlyLocationBag(INamedTypeSymbol symbol, TypeKey key)
+    {
+        var location = FirstLocationOrNull(symbol.Locations);
+        if (location == null || location.SourceTree == null)
+            return LocationBag.Empty;
+
+        return new LocationBag(ImmutableArray.Create(new LocationEntry(new LocationKey(key, string.Empty), LocationSpec.FromLocation(location))));
+    }
+}

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Models.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Models.cs
@@ -310,6 +310,7 @@ public sealed partial class AkkaSerializerGenerator
         public SerializerInfo(
             string ns,
             string className,
+            TypeKey key,
             string fullyQualifiedName,
             string name,
             int serializerId,
@@ -325,6 +326,7 @@ public sealed partial class AkkaSerializerGenerator
         {
             Namespace = ns;
             ClassName = className;
+            Key = key;
             FullyQualifiedName = fullyQualifiedName;
             Name = name;
             SerializerId = serializerId;
@@ -341,6 +343,15 @@ public sealed partial class AkkaSerializerGenerator
 
         public string Namespace { get; }
         public string ClassName { get; }
+
+        /// <summary>
+        /// This serializer's own type key -- what a serializer-level <see cref="DiagnosticSpec.At"/>
+        /// (its <c>[AkkaSerializer&lt;TProtocol&gt;]</c> attribute, a formatter registration, or a
+        /// closed-generic registration) is keyed against in the location bag. See
+        /// <see cref="LocationKey"/>.
+        /// </summary>
+        public TypeKey Key { get; }
+
         public string FullyQualifiedName { get; }
         public string Name { get; }
         public int SerializerId { get; }
@@ -403,6 +414,7 @@ public sealed partial class AkkaSerializerGenerator
 
             return string.Equals(Namespace, other.Namespace, StringComparison.Ordinal)
                 && string.Equals(ClassName, other.ClassName, StringComparison.Ordinal)
+                && Key.Equals(other.Key)
                 && string.Equals(FullyQualifiedName, other.FullyQualifiedName, StringComparison.Ordinal)
                 && string.Equals(Name, other.Name, StringComparison.Ordinal)
                 && SerializerId == other.SerializerId
@@ -424,6 +436,7 @@ public sealed partial class AkkaSerializerGenerator
             var hash = ValueEquality.Seed;
             hash = ValueEquality.Combine(hash, Namespace);
             hash = ValueEquality.Combine(hash, ClassName);
+            hash = ValueEquality.Combine(hash, Key.GetHashCode());
             hash = ValueEquality.Combine(hash, FullyQualifiedName);
             hash = ValueEquality.Combine(hash, Name);
             hash = ValueEquality.Combine(hash, SerializerId);
@@ -1196,27 +1209,42 @@ public sealed partial class AkkaSerializerGenerator
 
     /// <summary>
     /// A diagnostic to report, with no live <see cref="Diagnostic"/>, <see cref="Location"/>, or
-    /// symbol reference: just <see cref="Key"/> (which <see cref="DiagnosticDescriptor"/> field --
-    /// see <see cref="DiagnosticKey"/>) and the already display-formatted message arguments (a
-    /// numeric argument, e.g. AKKASG002's serializer id or AKKASG005's field index, is converted to
-    /// its decimal string ahead of time, since <see cref="MessageArgs"/> is homogeneous). Pure
-    /// validation functions in AkkaSerializerGenerator.Validation.cs return these instead of calling
-    /// <c>SourceProductionContext.ReportDiagnostic</c> directly, so validation runs -- and can be
-    /// asserted against directly, by <see cref="Key"/> and <see cref="MessageArgs"/> rather than by
-    /// message substring -- with no driver, context, or <see cref="Compilation"/> at all. The private
-    /// DiagnosticRegistry in AkkaSerializerGenerator.Diagnostics.cs is the one place a
-    /// <see cref="DiagnosticSpec"/> is turned into a real <see cref="Diagnostic"/>, always at
-    /// <see cref="Location.None"/> (every diagnostic this generator has ever reported already was).
+    /// symbol reference: <see cref="Key"/> (which <see cref="DiagnosticDescriptor"/> field -- see
+    /// <see cref="DiagnosticKey"/>), the already display-formatted message arguments (a numeric
+    /// argument, e.g. AKKASG002's serializer id or AKKASG005's field index, is converted to its
+    /// decimal string ahead of time, since <see cref="MessageArgs"/> is homogeneous), and
+    /// <see cref="At"/> -- WHICH declared site this diagnostic belongs to, never WHERE that site is
+    /// (see <see cref="LocationKey"/>'s own doc comment for the rule each call site follows to choose
+    /// one). Pure validation functions in AkkaSerializerGenerator.Validation.cs return these instead
+    /// of calling <c>SourceProductionContext.ReportDiagnostic</c> directly, so validation runs -- and
+    /// can be asserted against directly, by <see cref="Key"/>, <see cref="MessageArgs"/>, and
+    /// <see cref="At"/> rather than by message substring or live <see cref="Diagnostic"/> -- with no
+    /// driver, context, or <see cref="Compilation"/> at all. The private DiagnosticRegistry in
+    /// AkkaSerializerGenerator.Diagnostics.cs is the one place a <see cref="DiagnosticSpec"/> is
+    /// turned into a real <see cref="Diagnostic"/>: it resolves <see cref="At"/> against the merged
+    /// <see cref="LocationBag"/> collected from every serializer/message declaration, falling back to
+    /// <see cref="Location.None"/> only when <see cref="At"/> is null or the bag has no entry for it
+    /// (a location this generator genuinely could not resolve).
     /// </summary>
     internal sealed class DiagnosticSpec : IEquatable<DiagnosticSpec>
     {
         public DiagnosticSpec(DiagnosticKey key, params string[] messageArgs)
+            : this(key, at: null, messageArgs)
+        {
+        }
+
+        public DiagnosticSpec(DiagnosticKey key, LocationKey? at, params string[] messageArgs)
         {
             Key = key;
+            At = at;
             MessageArgs = messageArgs.Length == 0 ? ImmutableArray<string>.Empty : ImmutableArray.Create(messageArgs);
         }
 
         public DiagnosticKey Key { get; }
+
+        /// <summary>Which declared site this diagnostic belongs to, or null when no site applies (falls back to <see cref="Location.None"/>).</summary>
+        public LocationKey? At { get; }
+
         public ImmutableArray<string> MessageArgs { get; }
 
         public bool Equals(DiagnosticSpec? other)
@@ -1227,7 +1255,7 @@ public sealed partial class AkkaSerializerGenerator
             if (other is null)
                 return false;
 
-            return Key == other.Key && ValueEquality.SequenceEquals(MessageArgs, other.MessageArgs);
+            return Key == other.Key && At.Equals(other.At) && ValueEquality.SequenceEquals(MessageArgs, other.MessageArgs);
         }
 
         public override bool Equals(object? obj) => Equals(obj as DiagnosticSpec);
@@ -1236,6 +1264,7 @@ public sealed partial class AkkaSerializerGenerator
         {
             var hash = ValueEquality.Seed;
             hash = ValueEquality.Combine(hash, (int)Key);
+            hash = ValueEquality.Combine(hash, At?.GetHashCode() ?? 0);
             hash = ValueEquality.Combine(hash, MessageArgs);
             return hash;
         }

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Validation.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.Validation.cs
@@ -51,18 +51,22 @@ public sealed partial class AkkaSerializerGenerator
     /// instead of re-evaluating <see cref="EvaluateGate"/> from the raw collected arrays, now that
     /// the gate has already been decided once, per serializer, by <see cref="ResolveSerializer"/>.
     /// <see cref="ResolvedSerializer.GateDiagnostics"/> are NOT reported here (they are reported
-    /// once, by <see cref="EmitResolvedSerializer"/>); reporting them again here would duplicate
-    /// every pre-coverage diagnostic. As of S5 this combines the cached <see cref="CompilationFacts"/>
-    /// instead of the live <see cref="Compilation"/> -- see <see cref="ValidateProtocolCoverage"/>.
+    /// once, by <see cref="ReportResolvedSerializerDiagnostics"/>); reporting them again here would
+    /// duplicate every pre-coverage diagnostic. As of S5 this combines the cached
+    /// <see cref="CompilationFacts"/> instead of the live <see cref="Compilation"/> -- see
+    /// <see cref="ValidateProtocolCoverage"/>. As of S6 this also combines the merged
+    /// <see cref="LocationBag"/>, so each AKKASG029 diagnostic resolves to a real
+    /// <see cref="Location"/> -- see <see cref="ValidateProtocolCoverage"/>'s own doc comment for
+    /// why it reports at the serializer's own attribute rather than the unmarked implementor.
     /// </summary>
-    private static void ReportProtocolCoverage(SourceProductionContext context, ResolvedSerializer resolved, CompilationFacts facts)
+    private static void ReportProtocolCoverage(SourceProductionContext context, ResolvedSerializer resolved, CompilationFacts facts, LocationBag locations)
     {
         if (!resolved.IsEmittable)
             return;
 
         var protocolCoverageDiagnostics = ValidateProtocolCoverage(resolved.Serializer, facts);
         foreach (var diagnostic in protocolCoverageDiagnostics)
-            context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(diagnostic));
+            context.ReportDiagnostic(DiagnosticRegistry.ToDiagnostic(diagnostic, locations));
     }
 
     private static ImmutableDictionary<int, string> ComputeDuplicateSerializerIds(ImmutableArray<SerializerInfo?> serializers)
@@ -112,15 +116,19 @@ public sealed partial class AkkaSerializerGenerator
     {
         var diagnostics = ImmutableArray.CreateBuilder<DiagnosticSpec>();
 
+        // Every diagnostic in this method is serializer-level: reported at the serializer's own
+        // [AkkaSerializer<TProtocol>] attribute, per the location rule in AkkaSerializerGenerator.Locations.cs.
+        var serializerAt = new LocationKey(serializer.Key, string.Empty);
+
         if (string.IsNullOrWhiteSpace(serializer.Name))
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerName, serializer.ClassName));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerName, serializerAt, serializer.ClassName));
             return new SerializerGate(false, diagnostics.ToImmutable());
         }
 
         if (serializer.SerializerId <= 0)
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerId, serializer.ClassName, serializer.SerializerId.ToString()));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerId, serializerAt, serializer.ClassName, serializer.SerializerId.ToString()));
             return new SerializerGate(false, diagnostics.ToImmutable());
         }
 
@@ -212,24 +220,25 @@ public sealed partial class AkkaSerializerGenerator
     private static bool ValidateSerializerShape(SerializerInfo serializer, ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
         var isValid = true;
+        var at = new LocationKey(serializer.Key, string.Empty);
 
         if (!serializer.IsPartial)
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerShape, serializer.ClassName,
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerShape, at, serializer.ClassName,
                 "must be declared 'partial': the generator emits a second declaration of this class"));
             isValid = false;
         }
 
         if (!serializer.DerivesFromAkkaSerializerBase)
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerShape, serializer.ClassName,
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerShape, at, serializer.ClassName,
                 "must derive from Akka.Serialization.V2.AkkaSerializer: the generated members (Identifier, Manifest, Serialize, Deserialize, SizeHint) are declared as overrides of that base"));
             isValid = false;
         }
 
         if (serializer.IsGeneric)
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerShape, serializer.ClassName,
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidSerializerShape, at, serializer.ClassName,
                 "cannot be a generic type: the generator emits one concrete, closed partial class per [AkkaSerializer] declaration"));
             isValid = false;
         }
@@ -252,7 +261,8 @@ public sealed partial class AkkaSerializerGenerator
         if (serializer.ProtocolTypeFullName.Length == 0 || serializer.ProtocolTypeIsInterface)
             return true;
 
-        diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ProtocolTypeMustBeInterface, serializer.ClassName, ToDisplayName(serializer.ProtocolTypeFullName)));
+        diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ProtocolTypeMustBeInterface, new LocationKey(serializer.Key, string.Empty),
+            serializer.ClassName, ToDisplayName(serializer.ProtocolTypeFullName)));
         return false;
     }
 
@@ -272,7 +282,12 @@ public sealed partial class AkkaSerializerGenerator
     /// This method is now a pure, symbol-free, Compilation-free function of the resolved serializer
     /// plus that precomputed <see cref="CompilationFacts"/> -- it only formats the diagnostic for
     /// each already-identified implementor. Diagnostic id, text, and trigger conditions are
-    /// unchanged from before the split.
+    /// unchanged from before the split. Reports at the SERIALIZER's own attribute
+    /// (<c>LocationKey(serializer.Key, "")</c>), never at the unmarked implementor: that implementor
+    /// is, by definition, not an attributed type this generator's model knows anything about, and
+    /// <see cref="CompilationFacts"/> deliberately carries no location of its own (it must stay
+    /// whitespace-insensitive to every candidate type's own declaration -- see that type's doc
+    /// comment) so there is no local site on the implementor to point at in the first place.
     /// </summary>
     internal static ImmutableArray<DiagnosticSpec> ValidateProtocolCoverage(SerializerInfo serializer, CompilationFacts facts)
     {
@@ -284,9 +299,10 @@ public sealed partial class AkkaSerializerGenerator
         if (!facts.LocalUnmarkedImplementorsByProtocol.TryGetValue(serializer.ProtocolTypeKey, out var implementors))
             return diagnostics.ToImmutable();
 
+        var at = new LocationKey(serializer.Key, string.Empty);
         foreach (var implementor in implementors)
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ProtocolMessageNotSerializable,
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ProtocolMessageNotSerializable, at,
                 ToDisplayName(implementor.DisplayName ?? string.Empty), ToDisplayName(serializer.ProtocolTypeFullName), serializer.ClassName));
         }
 
@@ -393,23 +409,28 @@ public sealed partial class AkkaSerializerGenerator
         var isValid = true;
         foreach (var formatter in serializer.Formatters)
         {
+            // Every formatter diagnostic reports at ITS OWN [AkkaSerializerFormatter<TTarget,
+            // TFormatter>] attribute application, not the serializer's main attribute -- see
+            // FormatterLocationMember in AkkaSerializerGenerator.Locations.cs.
+            var at = new LocationKey(serializer.Key, FormatterLocationMember(formatter.TargetTypeFullName));
+
             if (!formatter.IsTargetSupported)
             {
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.FormatterTargetNotSupported, ToDisplayName(formatter.TargetTypeFullName), serializer.ClassName));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.FormatterTargetNotSupported, at, ToDisplayName(formatter.TargetTypeFullName), serializer.ClassName));
                 isValid = false;
                 continue;
             }
 
             if (formatter.IsAbstract)
             {
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidFormatterType, ToDisplayName(formatter.FormatterTypeFullName), serializer.ClassName, ToDisplayName(formatter.TargetTypeFullName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidFormatterType, at, ToDisplayName(formatter.FormatterTypeFullName), serializer.ClassName, ToDisplayName(formatter.TargetTypeFullName)));
                 isValid = false;
                 continue;
             }
 
             if (formatter.CtorKind == FormatterCtorKind.None)
             {
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.FormatterConstructorNotUsable, ToDisplayName(formatter.FormatterTypeFullName), serializer.ClassName));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.FormatterConstructorNotUsable, at, ToDisplayName(formatter.FormatterTypeFullName), serializer.ClassName));
                 isValid = false;
             }
         }
@@ -419,7 +440,8 @@ public sealed partial class AkkaSerializerGenerator
                      .GroupBy(formatter => formatter.TargetTypeFullName, StringComparer.Ordinal)
                      .Where(group => group.Count() > 1))
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateFormatterRegistration, serializer.ClassName, ToDisplayName(duplicate.Key)));
+            var at = new LocationKey(serializer.Key, FormatterLocationMember(duplicate.Key));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateFormatterRegistration, at, serializer.ClassName, ToDisplayName(duplicate.Key)));
             isValid = false;
         }
 
@@ -446,7 +468,10 @@ public sealed partial class AkkaSerializerGenerator
         var isValid = true;
         foreach (var registration in serializer.ClosedGenericRegistrations.Where(registration => !schemaKeys.Contains(registration.Target)))
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidClosedGenericRegistration, ToDisplayName(registration.TargetDisplayName), serializer.ClassName));
+            // Reports at THIS registration's own [AkkaSerializable<T>] attribute application --
+            // Decision 16: "the registration attribute for a closed generic".
+            var at = new LocationKey(serializer.Key, ClosedGenericLocationMember(registration.TargetDisplayName));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidClosedGenericRegistration, at, ToDisplayName(registration.TargetDisplayName), serializer.ClassName));
             isValid = false;
         }
 
@@ -455,7 +480,9 @@ public sealed partial class AkkaSerializerGenerator
                      .GroupBy(registration => registration.Target)
                      .Where(group => group.Count() > 1))
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateClosedGenericRegistration, serializer.ClassName, ToDisplayName(duplicate.Key.DisplayName ?? string.Empty)));
+            var targetDisplayName = duplicate.Key.DisplayName ?? string.Empty;
+            var at = new LocationKey(serializer.Key, ClosedGenericLocationMember(targetDisplayName));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateClosedGenericRegistration, at, serializer.ClassName, ToDisplayName(targetDisplayName)));
             isValid = false;
         }
 
@@ -484,7 +511,11 @@ public sealed partial class AkkaSerializerGenerator
             if (hasRegistration)
                 continue;
 
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.GenericSerializableRequiresRegistration, ToDisplayName(definition.FullyQualifiedName), ToDisplayName(serializer.ProtocolTypeFullName), serializer.ClassName));
+            // Reports at the SERIALIZER's own attribute: the fix ("register each closed construction
+            // with [AkkaSerializable<T>] ... on the serializer class") is an edit to the serializer,
+            // not to the generic definition itself.
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.GenericSerializableRequiresRegistration, new LocationKey(serializer.Key, string.Empty),
+                ToDisplayName(definition.FullyQualifiedName), ToDisplayName(serializer.ProtocolTypeFullName), serializer.ClassName));
             isValid = false;
         }
 
@@ -557,7 +588,10 @@ public sealed partial class AkkaSerializerGenerator
         var isValid = true;
         foreach (var message in topLevelMessages.Where(message => string.IsNullOrWhiteSpace(message.Manifest)))
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.MissingManifest, ToDisplayName(message.FullyQualifiedName)));
+            // A closed-generic SCHEMA can be top-level too (its construction implements the
+            // protocol directly) -- MessageTypeLocationKey redirects to its own registration
+            // attribute in that case, since the construction itself has no separate syntax.
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.MissingManifest, MessageTypeLocationKey(serializer, message), ToDisplayName(message.FullyQualifiedName)));
             isValid = false;
         }
 
@@ -567,21 +601,30 @@ public sealed partial class AkkaSerializerGenerator
                      .Where(group => group.Count() > 1))
         {
             var typeNames = string.Join(", ", duplicate.Select(m => ToDisplayName(m.FullyQualifiedName)));
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateManifest, serializer.ClassName, duplicate.Key, typeNames));
+
+            // Spans multiple messages -- no single message owns this diagnostic, so it reports at the
+            // serializer's own attribute instead.
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateManifest, new LocationKey(serializer.Key, string.Empty), serializer.ClassName, duplicate.Key, typeNames));
             isValid = false;
         }
 
         foreach (var message in reachableMessages)
         {
+            // Type-level diagnostics on a closed-generic SCHEMA (MissingFields, NoMatchingConstructor,
+            // ConstructorParameterNotCovered, DuplicateFieldIndex below) redirect to that
+            // construction's own registration attribute -- see MessageTypeLocationKey's doc comment.
+            var messageAt = MessageTypeLocationKey(serializer, message);
+
             if (message.Fields.Length == 0 && !message.AllowEmpty)
             {
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.MissingFields, ToDisplayName(message.FullyQualifiedName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.MissingFields, messageAt, ToDisplayName(message.FullyQualifiedName)));
                 isValid = false;
             }
 
             foreach (var duplicate in message.Fields.GroupBy(field => field.Index).Where(group => group.Count() > 1))
             {
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateFieldIndex, ToDisplayName(message.FullyQualifiedName), duplicate.Key.ToString()));
+                // Spans multiple fields of the same message -- reports at the message type itself.
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateFieldIndex, messageAt, ToDisplayName(message.FullyQualifiedName), duplicate.Key.ToString()));
                 isValid = false;
             }
 
@@ -590,25 +633,28 @@ public sealed partial class AkkaSerializerGenerator
             // message.Fields, so they cannot double-report through any of the checks below.
             foreach (var invalidField in message.InvalidFields)
             {
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.FieldPropertyNotAccessible, invalidField.PropertyName, ToDisplayName(message.FullyQualifiedName), invalidField.Reason));
+                var at = new LocationKey(message.Key, invalidField.PropertyName);
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.FieldPropertyNotAccessible, at, invalidField.PropertyName, ToDisplayName(message.FullyQualifiedName), invalidField.Reason));
                 isValid = false;
             }
 
             // Read-side reconstruction: either no constructor could be selected, or the selected
             // constructor leaves [AkkaField] properties uncovered with no accessible setter to fall
-            // back on -- both make deserialize impossible to generate.
+            // back on -- both make deserialize impossible to generate. Not any one field's fault, so
+            // reports at the message type itself.
             foreach (var error in message.ConstructionPlan.Errors)
             {
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.NoMatchingConstructor, ToDisplayName(message.FullyQualifiedName), error));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.NoMatchingConstructor, messageAt, ToDisplayName(message.FullyQualifiedName), error));
                 isValid = false;
             }
 
             // Advisory only: the selected constructor still works (its defaulted parameter is simply
             // never supplied), but the parameter's value silently reverts to its default on every
-            // deserialize because no [AkkaField] property feeds it.
+            // deserialize because no [AkkaField] property feeds it. The parameter need not even
+            // correspond to an [AkkaField] property, so this reports at the message type itself too.
             foreach (var parameterName in message.ConstructionPlan.UncoveredDefaultedParameters)
             {
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ConstructorParameterNotCovered, parameterName, ToDisplayName(message.FullyQualifiedName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ConstructorParameterNotCovered, messageAt, parameterName, ToDisplayName(message.FullyQualifiedName)));
             }
 
             // Error (AKKASG038): an object-typed property is always the envelope-payload boundary
@@ -616,15 +662,16 @@ public sealed partial class AkkaSerializerGenerator
             // never take effect, so this is contradictory author intent, not a harmless no-op.
             foreach (var field in message.Fields.Where(field => field.UnionDeclaredOnObjectField))
             {
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionDeclaredOnObjectField, field.Name, ToDisplayName(message.FullyQualifiedName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionDeclaredOnObjectField, new LocationKey(message.Key, field.Name), field.Name, ToDisplayName(message.FullyQualifiedName)));
                 isValid = false;
             }
 
             foreach (var field in message.Fields.Where(field => field.Mapping.Kind == FieldKind.Unsupported))
             {
+                var at = new LocationKey(message.Key, field.Name);
                 diagnostics.Add(field.Mapping.SuggestsEnvelopeOrUnion
-                    ? new DiagnosticSpec(DiagnosticKey.UnsupportedFieldTypePolymorphic, field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.TypeFullName))
-                    : new DiagnosticSpec(DiagnosticKey.UnsupportedFieldType, field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.TypeFullName)));
+                    ? new DiagnosticSpec(DiagnosticKey.UnsupportedFieldTypePolymorphic, at, field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.TypeFullName))
+                    : new DiagnosticSpec(DiagnosticKey.UnsupportedFieldType, at, field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.TypeFullName)));
                 isValid = false;
             }
 
@@ -636,7 +683,8 @@ public sealed partial class AkkaSerializerGenerator
 
             foreach (var field in message.Fields.Where(field => field.Mapping.Kind == FieldKind.UnsupportedEnumUnderlyingType))
             {
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnsupportedEnumUnderlyingType, field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.Mapping.TypeFullName), ToDisplayName(field.Mapping.EnumUnderlyingTypeName)));
+                var at = new LocationKey(message.Key, field.Name);
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnsupportedEnumUnderlyingType, at, field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.Mapping.TypeFullName), ToDisplayName(field.Mapping.EnumUnderlyingTypeName)));
                 isValid = false;
             }
 
@@ -673,7 +721,10 @@ public sealed partial class AkkaSerializerGenerator
                      .Where(group => group.Select(m => m.FullyQualifiedName).Distinct(StringComparer.Ordinal).Count() > 1))
         {
             var typeNames = string.Join(", ", collision.Select(m => ToDisplayName(m.FullyQualifiedName)));
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateGeneratedName, serializer.ClassName, collision.Key, typeNames));
+
+            // Spans multiple messages -- no single message owns this diagnostic, so it reports at the
+            // serializer's own attribute instead.
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.DuplicateGeneratedName, new LocationKey(serializer.Key, string.Empty), serializer.ClassName, collision.Key, typeNames));
             isValid = false;
         }
 
@@ -683,7 +734,9 @@ public sealed partial class AkkaSerializerGenerator
     // Decision table for a nested type this generator cannot serialize today: a closed generic
     // construction reports AKKASG023 (register it with [AkkaSerializable<T>]); a type declared in a
     // referenced assembly reports the AKKASG007 cross-assembly wording; anything else reports the
-    // plain AKKASG007 message.
+    // plain AKKASG007 message. Reports at the LOCAL referencing property -- per Decision 16, this is
+    // true even for the cross-assembly variant: the foreign type's own assembly gets no diagnostic at
+    // all, since no generator work runs there.
     private static void ReportMissingNestedSchema(
         MessageInfo message,
         string fieldName,
@@ -692,15 +745,17 @@ public sealed partial class AkkaSerializerGenerator
         string serializerClassName,
         ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
+        var at = new LocationKey(message.Key, fieldName);
+
         if (mapping.IsGenericConstruction)
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnregisteredClosedGenericField, fieldName, ToDisplayName(message.FullyQualifiedName), ToDisplayName(typeFullName), serializerClassName));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnregisteredClosedGenericField, at, fieldName, ToDisplayName(message.FullyQualifiedName), ToDisplayName(typeFullName), serializerClassName));
             return;
         }
 
         diagnostics.Add(mapping.ForeignAssemblyName.Length > 0
-            ? new DiagnosticSpec(DiagnosticKey.MissingNestedSerializableDefinitionCrossAssembly, fieldName, ToDisplayName(message.FullyQualifiedName), ToDisplayName(typeFullName), mapping.ForeignAssemblyName, serializerClassName)
-            : new DiagnosticSpec(DiagnosticKey.MissingNestedSerializableDefinition, fieldName, ToDisplayName(message.FullyQualifiedName), ToDisplayName(typeFullName)));
+            ? new DiagnosticSpec(DiagnosticKey.MissingNestedSerializableDefinitionCrossAssembly, at, fieldName, ToDisplayName(message.FullyQualifiedName), ToDisplayName(typeFullName), mapping.ForeignAssemblyName, serializerClassName)
+            : new DiagnosticSpec(DiagnosticKey.MissingNestedSerializableDefinition, at, fieldName, ToDisplayName(message.FullyQualifiedName), ToDisplayName(typeFullName)));
     }
 
     /// <summary>
@@ -732,7 +787,10 @@ public sealed partial class AkkaSerializerGenerator
             if (reachableKeys.Contains(schema.Key))
                 continue;
 
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ClosedGenericRegistrationNotInProtocol,
+            // Reports at THIS registration's own [AkkaSerializable<T>] attribute application --
+            // Decision 16: "the registration attribute for a closed generic".
+            var at = new LocationKey(serializer.Key, ClosedGenericLocationMember(registration.TargetDisplayName));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.ClosedGenericRegistrationNotInProtocol, at,
                 ToDisplayName(registration.TargetDisplayName), serializer.ClassName, ToDisplayName(serializer.ProtocolTypeFullName)));
             isValid = false;
         }
@@ -744,9 +802,12 @@ public sealed partial class AkkaSerializerGenerator
     // gets the cross-assembly wording; a same-assembly member gets the plain message.
     private static void ReportUnionMemberNotSerializable(MessageInfo message, string fieldName, UnionMemberInfo member, string serializerClassName, ImmutableArray<DiagnosticSpec>.Builder diagnostics)
     {
+        // Cross-assembly variant reports at the LOCAL referencing field too -- per Decision 16, the
+        // foreign member type's own assembly gets no diagnostic at all.
+        var at = new LocationKey(message.Key, fieldName);
         diagnostics.Add(member.ForeignAssemblyName.Length > 0
-            ? new DiagnosticSpec(DiagnosticKey.UnionMemberNotSerializableCrossAssembly, ToDisplayName(member.TypeFullName), fieldName, ToDisplayName(message.FullyQualifiedName), member.ForeignAssemblyName, serializerClassName)
-            : new DiagnosticSpec(DiagnosticKey.UnionMemberNotSerializable, ToDisplayName(member.TypeFullName), fieldName, ToDisplayName(message.FullyQualifiedName)));
+            ? new DiagnosticSpec(DiagnosticKey.UnionMemberNotSerializableCrossAssembly, at, ToDisplayName(member.TypeFullName), fieldName, ToDisplayName(message.FullyQualifiedName), member.ForeignAssemblyName, serializerClassName)
+            : new DiagnosticSpec(DiagnosticKey.UnionMemberNotSerializable, at, ToDisplayName(member.TypeFullName), fieldName, ToDisplayName(message.FullyQualifiedName)));
     }
 
     private static bool ValidateUnionField(
@@ -758,6 +819,10 @@ public sealed partial class AkkaSerializerGenerator
     {
         var isValid = true;
 
+        // Every union diagnostic below reports at the FIELD carrying the union -- not at any one
+        // member's own declaration, which may not even be in this compilation.
+        var at = new LocationKey(message.Key, field.Name);
+
         // AkkaUnionAttribute(Type first, params Type[] rest) makes an empty member set
         // unrepresentable: `first` is a mandatory constructor argument, so [AkkaUnion()] does not
         // compile and field.UnionMembers can never be empty here. The "at least one member type is
@@ -768,7 +833,7 @@ public sealed partial class AkkaSerializerGenerator
                      .GroupBy(member => member.Key)
                      .Where(group => group.Count() > 1))
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidUnionMemberSet, field.Name, ToDisplayName(message.FullyQualifiedName), $"member type '{ToDisplayName(duplicate.Key.DisplayName ?? string.Empty)}' is declared more than once"));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.InvalidUnionMemberSet, at, field.Name, ToDisplayName(message.FullyQualifiedName), $"member type '{ToDisplayName(duplicate.Key.DisplayName ?? string.Empty)}' is declared more than once"));
             isValid = false;
         }
 
@@ -784,7 +849,7 @@ public sealed partial class AkkaSerializerGenerator
 
             if (!member.IsAssignable)
             {
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberNotAssignable, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.TypeFullName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberNotAssignable, at, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName), ToDisplayName(field.TypeFullName)));
                 isValid = false;
             }
 
@@ -796,13 +861,13 @@ public sealed partial class AkkaSerializerGenerator
             // An abstract member fires AKKASG036 ONLY: it is definitionally unsealed, and stacking
             // the weaker AKKASG025 on top of it would be noise.
             if (member.IsAbstract)
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberAbstract, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberAbstract, at, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName)));
             else if (!member.IsSealed)
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberNotSealed, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberNotSealed, at, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName)));
 
             if (string.IsNullOrWhiteSpace(memberMessage.Manifest))
             {
-                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberMissingManifest, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName)));
+                diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberMissingManifest, at, ToDisplayName(member.TypeFullName), field.Name, ToDisplayName(message.FullyQualifiedName)));
                 isValid = false;
                 continue;
             }
@@ -818,7 +883,7 @@ public sealed partial class AkkaSerializerGenerator
 
         foreach (var collision in manifests.Where(pair => pair.Value.Distinct(StringComparer.Ordinal).Count() > 1))
         {
-            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberManifestCollision, field.Name, ToDisplayName(message.FullyQualifiedName), collision.Key, string.Join(", ", collision.Value.Select(ToDisplayName))));
+            diagnostics.Add(new DiagnosticSpec(DiagnosticKey.UnionMemberManifestCollision, at, field.Name, ToDisplayName(message.FullyQualifiedName), collision.Key, string.Join(", ", collision.Value.Select(ToDisplayName))));
             isValid = false;
         }
 

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.cs
@@ -52,9 +52,36 @@ public sealed partial class AkkaSerializerGenerator : IIncrementalGenerator
     /// </summary>
     public static class TrackingNames
     {
+        /// <summary>
+        /// The raw per-node serializer extraction transform: <see cref="ExtractedSerializer"/>, the
+        /// schema PLUS its location bag. Whitespace-SENSITIVE (a text-shifting edit anywhere earlier
+        /// in the file changes the location bag's spans), unlike every stage downstream of
+        /// <see cref="SerializerSchemas"/> -- see that constant's own doc comment.
+        /// </summary>
         public const string ExtractedSerializers = nameof(ExtractedSerializers);
+
+        /// <summary>
+        /// The schemas-only projection of <see cref="ExtractedSerializers"/> (<c>.Select(e =&gt;
+        /// e.Info)</c>): whitespace-INSENSITIVE, since <see cref="SerializerInfo"/> carries no
+        /// location. Feeds <see cref="CollectedSerializers"/>, <see cref="ResolvedSerializers"/>, and
+        /// code emission -- exactly what <see cref="ExtractedSerializers"/> itself used to feed before
+        /// S6 added locations, so those stages stay cached on an edit that only shifts spans. There is
+        /// deliberately NO locations-only counterpart to this stage: an earlier version of this
+        /// pipeline had one (<c>SerializerLocations</c>/<c>MessageLocations</c>), but a per-node Select
+        /// still builds its own incremental state table over every node on every edit, for a value read
+        /// back only once, batched -- see <see cref="Initialize"/>'s own comment on
+        /// <c>allLocations</c> for why collecting the raw extracted values directly is cheaper.
+        /// </summary>
+        public const string SerializerSchemas = nameof(SerializerSchemas);
+
         public const string CollectedSerializers = nameof(CollectedSerializers);
+
+        /// <summary>The message extraction transform's counterpart to <see cref="ExtractedSerializers"/>. See that constant's doc comment.</summary>
         public const string ExtractedMessages = nameof(ExtractedMessages);
+
+        /// <summary>The message extraction transform's counterpart to <see cref="SerializerSchemas"/>. See that constant's doc comment.</summary>
+        public const string MessageSchemas = nameof(MessageSchemas);
+
         public const string CollectedMessages = nameof(CollectedMessages);
 
         /// <summary>
@@ -83,30 +110,68 @@ public sealed partial class AkkaSerializerGenerator : IIncrementalGenerator
         public const string CompilationFacts = nameof(CompilationFacts);
 
         public static ImmutableArray<string> All { get; } = ImmutableArray.Create(
-            ExtractedSerializers, CollectedSerializers, ExtractedMessages, CollectedMessages, ResolvedSerializers, CompilationFacts);
+            ExtractedSerializers, SerializerSchemas, CollectedSerializers,
+            ExtractedMessages, MessageSchemas, CollectedMessages,
+            ResolvedSerializers, CompilationFacts);
     }
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var serializers = context.SyntaxProvider
+        // S6 "locations": the raw per-node transform returns the schema PLUS a location bag (see
+        // ExtractedSerializer/AkkaSerializerGenerator.Locations.cs) -- a text-shifting edit anywhere
+        // earlier in the file changes the bag's spans, so this raw stage is whitespace-SENSITIVE,
+        // unlike every stage before S6. A schemas-only projection immediately splits the schema back
+        // out and feeds Collect/Resolve/Emit exactly as the raw stage itself used to
+        // (whitespace-insensitive, since SerializerInfo carries no location). This is what lets a
+        // comment-only edit still report Collect/Resolve/Emit as Cached even though the raw
+        // extraction step itself reports Modified for it -- see GeneratorIncrementalScenariosSpec's
+        // scenario (c).
+        //
+        // There is deliberately NO separate locations-only Select node here (an earlier version of
+        // this stage had one per side): a per-node Select still builds its own incremental state
+        // table over every node on every edit, for a value (LocationBag) that is read back only once,
+        // batched, a few lines down. Collecting the raw ExtractedSerializer/ExtractedMessage values
+        // directly and reading .Locations inside MergeExtractedLocations gets the same merged bag one
+        // Select cheaper. The schemas-only projections below are NOT removed the same way: Resolve and
+        // Emit depend on them directly, so they earn their keep as separate nodes.
+        var extractedSerializers = context.SyntaxProvider
             .ForAttributeWithMetadataName(
                 SerializerAttributeFullName,
                 static (node, _) => node is ClassDeclarationSyntax,
                 static (ctx, cancellationToken) => ExtractSerializer(ctx, cancellationToken))
-            .WithTrackingName(TrackingNames.ExtractedSerializers)
+            .WithTrackingName(TrackingNames.ExtractedSerializers);
+
+        var serializerSchemas = extractedSerializers
+            .Select(static (extracted, _) => extracted.Info)
+            .WithTrackingName(TrackingNames.SerializerSchemas);
+
+        var serializers = serializerSchemas
             .Where(static info => info != null)
             .Collect()
             .WithTrackingName(TrackingNames.CollectedSerializers);
 
-        var messages = context.SyntaxProvider
+        var extractedMessages = context.SyntaxProvider
             .ForAttributeWithMetadataName(
                 SerializableAttributeFullName,
                 static (node, _) => node is ClassDeclarationSyntax or StructDeclarationSyntax or RecordDeclarationSyntax,
                 static (ctx, cancellationToken) => ExtractMessage(ctx, cancellationToken))
-            .WithTrackingName(TrackingNames.ExtractedMessages)
+            .WithTrackingName(TrackingNames.ExtractedMessages);
+
+        var messageSchemas = extractedMessages
+            .Select(static (extracted, _) => extracted.Info)
+            .WithTrackingName(TrackingNames.MessageSchemas);
+
+        var messages = messageSchemas
             .Where(static info => info != null)
             .Collect()
             .WithTrackingName(TrackingNames.CollectedMessages);
+
+        // Every serializer's and message's location bag, merged into ONE compilation-wide lookup.
+        // Feeds every diagnostics-only Report output below, never Collect/Resolve/Emit -- see
+        // MergeExtractedLocations's own doc comment.
+        var allLocations = extractedSerializers.Collect()
+            .Combine(extractedMessages.Collect())
+            .Select(static (pair, cancellationToken) => MergeExtractedLocations(pair.Left, pair.Right, cancellationToken));
 
         // The per-serializer resolve stage: each serializer plus ALL collected messages (a message's
         // top-level/reachable status can only be judged against the full set) resolves, via
@@ -159,21 +224,40 @@ public sealed partial class AkkaSerializerGenerator : IIncrementalGenerator
             .WithTrackingName(TrackingNames.CompilationFacts);
 
         // Code emission consumes ONLY the cached, value-equatable, symbol-free ResolvedSerializer
-        // model -- never the Compilation, and never another serializer's data. Registered on the
-        // VALUES provider (one independent output per serializer) rather than a Collect()'d array,
-        // so editing a message owned by one serializer re-emits only that serializer's file: the
-        // driver skips this callback entirely for any OTHER serializer whose resolved model still
-        // compares equal to last run.
+        // model -- never the Compilation, never a location, and never another serializer's data.
+        // Registered on the VALUES provider (one independent output per serializer) rather than a
+        // Collect()'d array, so editing a message owned by one serializer re-emits only that
+        // serializer's file: the driver skips this callback entirely for any OTHER serializer whose
+        // resolved model still compares equal to last run. As of S6 this callback no longer reports
+        // any diagnostic (see ReportResolvedSerializerDiagnostics below) -- it only decides, from
+        // ResolvedSerializer.IsEmittable and ResolvedSerializer.ValidationDiagnostics' severities,
+        // whether to skip AddSource. That split keeps emission's own caching untouched by a
+        // location-only edit: this stage never combines the location bag, so it stays Cached exactly
+        // when it always did.
         context.RegisterSourceOutput(resolvedSerializers, static (ctx, resolved) => EmitResolvedSerializer(ctx, resolved));
+
+        // S6 "locations": ALL diagnostic reporting for a resolved serializer's own gate/validation
+        // diagnostics moved OUT of EmitResolvedSerializer and into this diagnostics-only output, so it
+        // can combine the merged location bag without dragging that whitespace-sensitive input into
+        // code emission's own cache key. Diagnostic id, text, and trigger conditions are unchanged --
+        // only WHERE they are reported from, and now WITH a real Location, has moved.
+        context.RegisterSourceOutput(
+            resolvedSerializers.Combine(allLocations),
+            static (ctx, pair) => ReportResolvedSerializerDiagnostics(ctx, pair.Left, pair.Right));
 
         // The cross-serializer diagnostics (AKKASG013 duplicate ids, AKKASG031 duplicate protocol
         // bindings, AKKASG037 manifest ignored on a generic definition) cannot be attached to any
         // one serializer's ResolvedSerializer without either duplicating them or picking an
         // arbitrary "owner" -- see ReportCrossSerializerDiagnostics's doc comment. Reported exactly
-        // once each, from a small diagnostics-only output over the same two collected arrays.
+        // once each, from a small diagnostics-only output over the same two collected arrays, now also
+        // combined with the merged location bag so each can report at its chosen local site instead of
+        // Location.None. Kept as its OWN output (rather than folded into ReportResolvedSerializerDiagnostics
+        // above) because its input shape -- the whole collected arrays, not one resolved serializer at
+        // a time -- is genuinely different: folding them together would force this output to
+        // re-execute once per serializer instead of once per compilation change.
         context.RegisterSourceOutput(
-            serializers.Combine(messages),
-            static (ctx, pair) => ReportCrossSerializerDiagnostics(ctx, pair.Left, pair.Right));
+            serializers.Combine(messages).Combine(allLocations),
+            static (ctx, pair) => ReportCrossSerializerDiagnostics(ctx, pair.Left.Left, pair.Left.Right, pair.Right));
 
         // AKKASG029's whole-compilation protocol-coverage check ("does any source-declared type
         // implement this protocol interface without [AkkaSerializable]?") no longer touches the
@@ -187,7 +271,12 @@ public sealed partial class AkkaSerializerGenerator : IIncrementalGenerator
         // runs, has moved. CompilationFacts still recomputes on every edit (it combines
         // context.CompilationProvider directly), but its OUTPUT compares equal whenever nothing it
         // tracks changed, which is what lets this output -- like code emission above -- report
-        // Cached instead of Modified for an edit these facts do not care about.
+        // Cached instead of Modified for an edit these facts do not care about. As of S6 this ALSO
+        // combines the merged location bag: AKKASG029 reports at the serializer's own attribute
+        // (LocationKey(serializer.Key, "")) because the unmarked implementor found by the facts stage
+        // is not itself an attributed type in this generator's model -- there is no local site on it
+        // to point at, and the facts stage must stay whitespace-insensitive to that implementor's own
+        // declaration (see ComputeCompilationFacts's doc comment).
         //
         // Design decision: coverage errors no longer gate emission (the old terminal stage skipped
         // AddSource for a serializer whose coverage check failed). This is the standard split for
@@ -197,7 +286,7 @@ public sealed partial class AkkaSerializerGenerator : IIncrementalGenerator
         // while the user fixes the gap) and lets the emission stage surface OTHER diagnostics that
         // the old early-return used to hide until the coverage error was fixed.
         context.RegisterSourceOutput(
-            resolvedSerializers.Combine(compilationFacts),
-            static (ctx, pair) => ReportProtocolCoverage(ctx, pair.Left, pair.Right));
+            resolvedSerializers.Combine(compilationFacts).Combine(allLocations),
+            static (ctx, pair) => ReportProtocolCoverage(ctx, pair.Left.Left, pair.Left.Right, pair.Right));
     }
 }

--- a/src/core/Akka.Serialization.V2.Generators/IsExternalInit.cs
+++ b/src/core/Akka.Serialization.V2.Generators/IsExternalInit.cs
@@ -1,0 +1,20 @@
+//-----------------------------------------------------------------------
+// <copyright file="IsExternalInit.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+// Shim for init-only properties and records on netstandard2.0, this project's only target
+// framework. System.Runtime.CompilerServices.IsExternalInit is defined in .NET 5+; providing it
+// here lets the C# 12 compiler (see Directory.Build.props' LangVersion) emit `init` accessors and
+// `record`/`record struct` types against netstandard2.0. Used by the small, immutable location
+// models in AkkaSerializerGenerator.Locations.cs (LocationSpec, LocationKey, ExtractedSerializer,
+// ExtractedMessage) -- everything else in this generator predates C# 9 record syntax and stays as
+// hand-written structs/classes, so this shim is scoped to exactly the types that need it.
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit
+    {
+    }
+}

--- a/src/core/Akka.Serialization.V2.Tests/AkkaSerializerGeneratorDiagnosticLocationsSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/AkkaSerializerGeneratorDiagnosticLocationsSpec.cs
@@ -1,0 +1,439 @@
+//-----------------------------------------------------------------------
+// <copyright file="AkkaSerializerGeneratorDiagnosticLocationsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Akka.Serialization.V2.Tests.Harness;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// S6 "locations": every diagnostic this generator reports must carry a real
+/// <see cref="Location"/>, not <see cref="Location.None"/> (see the location rule in
+/// AkkaSerializerGenerator.Locations.cs). <see cref="AkkaSerializerGeneratorDiagnosticsSpec"/> and
+/// <see cref="CrossAssemblyBaselineSpec"/> already cover diagnostic id/message text end to end; this
+/// spec adds the ONE thing they do not check -- where each diagnostic points. It runs a small corpus
+/// of fixtures, one per diagnostic family, and checks two things for each: EVERY generator diagnostic
+/// has a real location, and a representative sample resolves to the EXACT expected source line.
+/// </summary>
+public sealed class AkkaSerializerGeneratorDiagnosticLocationsSpec
+{
+    [Theory(DisplayName = "Every diagnostic in the location-test corpus should report a real Location, not Location.None")]
+    [MemberData(nameof(LocationCorpus))]
+    public void Diagnostics_should_never_report_Location_None(string _, string source, string expectedId)
+    {
+        var diagnostics = GeneratorTestHarness.Run(source).GeneratorDiagnostics;
+
+        var matching = diagnostics.Where(d => d.Id == expectedId).ToImmutableArray();
+        matching.Should().NotBeEmpty($"the fixture should have produced at least one {expectedId} diagnostic");
+
+        foreach (var diagnostic in matching)
+            diagnostic.Location.Should().NotBe(Location.None, $"{expectedId} must report a real location, not Location.None");
+    }
+
+    public static TheoryData<string, string, string> LocationCorpus()
+    {
+        var data = new TheoryData<string, string, string>();
+        foreach (var (name, source, id) in Corpus())
+            data.Add(name, source, id);
+
+        return data;
+    }
+
+    private static (string Name, string Source, string DiagnosticId)[] Corpus() => new[]
+    {
+        ("field-level (AKKASG003)", FieldLevelSource, "AKKASG003"),
+        ("type-level (AKKASG006)", TypeLevelSource, "AKKASG006"),
+        ("serializer-level (AKKASG002)", SerializerLevelSource, "AKKASG002"),
+        ("formatter (AKKASG008)", FormatterSource, "AKKASG008"),
+        ("closed generic registration (AKKASG020)", ClosedGenericSource, "AKKASG020"),
+        ("closed generic missing fields (AKKASG004)", ClosedGenericMissingFieldsSource, "AKKASG004"),
+        ("union member (AKKASG015)", UnionMemberSource, "AKKASG015"),
+        ("duplicate field index (AKKASG005)", DuplicateFieldIndexSource, "AKKASG005"),
+    };
+
+    // ------------------------------------------------------------------------------------------
+    // Field-level: the offending [AkkaField] property's own location.
+    // ------------------------------------------------------------------------------------------
+    private const string FieldLevelSource = """
+        #nullable enable
+        using System;
+        using Akka.Actor;
+        using Akka.Serialization.V2;
+
+        namespace LocationSample.FieldLevel;
+
+        public interface IProtocol
+        {
+        }
+
+        [AkkaSerializer<IProtocol>("field-level", 500001)]
+        public sealed partial class SampleSerializer : AkkaSerializer
+        {
+            public static partial SerializerRegistration CreateRegistration();
+        }
+
+        [AkkaSerializable(Manifest = "outer-v1")]
+        public sealed class Outer : IProtocol
+        {
+            [AkkaField(1)]
+            public Action Callback { get; set; } = () => { };
+        }
+        """;
+
+    [Fact(DisplayName = "Field-level AKKASG003 should report at the offending property's own line")]
+    public void Field_level_diagnostic_should_report_at_property_line()
+    {
+        var diagnostics = GeneratorTestHarness.Run(FieldLevelSource).GeneratorDiagnostics;
+
+        var diagnostic = diagnostics.Should().ContainSingle(d => d.Id == "AKKASG003").Subject;
+        var expectedLine = LineIndexOf(FieldLevelSource, "public Action Callback");
+        diagnostic.Location.GetLineSpan().StartLinePosition.Line.Should().Be(expectedLine);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Type-level: the message type's own declaration line (its identifier).
+    // ------------------------------------------------------------------------------------------
+    private const string TypeLevelSource = """
+        #nullable enable
+        using Akka.Actor;
+        using Akka.Serialization.V2;
+
+        namespace LocationSample.TypeLevel;
+
+        public interface IProtocol
+        {
+        }
+
+        [AkkaSerializer<IProtocol>("type-level", 500002)]
+        public sealed partial class SampleSerializer : AkkaSerializer
+        {
+            public static partial SerializerRegistration CreateRegistration();
+        }
+
+        [AkkaSerializable]
+        public sealed record NoManifest([property: AkkaField(1)] string Value) : IProtocol;
+        """;
+
+    [Fact(DisplayName = "Type-level AKKASG006 should report at the message type's own declaration line")]
+    public void Type_level_diagnostic_should_report_at_message_declaration_line()
+    {
+        var diagnostics = GeneratorTestHarness.Run(TypeLevelSource).GeneratorDiagnostics;
+
+        var diagnostic = diagnostics.Should().ContainSingle(d => d.Id == "AKKASG006").Subject;
+        var expectedLine = LineIndexOf(TypeLevelSource, "public sealed record NoManifest");
+        diagnostic.Location.GetLineSpan().StartLinePosition.Line.Should().Be(expectedLine);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Serializer-level: the [AkkaSerializer<TProtocol>] attribute application, not the class name.
+    // ------------------------------------------------------------------------------------------
+    private const string SerializerLevelSource = """
+        #nullable enable
+        using Akka.Actor;
+        using Akka.Serialization.V2;
+
+        namespace LocationSample.SerializerLevel;
+
+        public interface IProtocol
+        {
+        }
+
+        [AkkaSerializer<IProtocol>("serializer-level", 0)]
+        public sealed partial class SampleSerializer : AkkaSerializer
+        {
+            public static partial SerializerRegistration CreateRegistration();
+        }
+
+        [AkkaSerializable(Manifest = "outer-v1")]
+        public sealed record Outer([property: AkkaField(1)] string Value) : IProtocol;
+        """;
+
+    [Fact(DisplayName = "Serializer-level AKKASG002 should report at the serializer's own attribute line, not its class declaration")]
+    public void Serializer_level_diagnostic_should_report_at_attribute_line()
+    {
+        var diagnostics = GeneratorTestHarness.Run(SerializerLevelSource).GeneratorDiagnostics;
+
+        var diagnostic = diagnostics.Should().ContainSingle(d => d.Id == "AKKASG002").Subject;
+        var expectedLine = LineIndexOf(SerializerLevelSource, "[AkkaSerializer<IProtocol>");
+        var classLine = LineIndexOf(SerializerLevelSource, "public sealed partial class SampleSerializer");
+        diagnostic.Location.GetLineSpan().StartLinePosition.Line.Should().Be(expectedLine);
+        expectedLine.Should().NotBe(classLine, "the attribute and the class declaration must sit on different lines for this assertion to be meaningful");
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // AKKASG029 protocol coverage: the serializer's own attribute (the unmarked implementor has no
+    // local attributed site of its own -- see ValidateProtocolCoverage's doc comment).
+    // ------------------------------------------------------------------------------------------
+    private const string ProtocolCoverageSource = """
+        #nullable enable
+        using Akka.Actor;
+        using Akka.Serialization.V2;
+
+        namespace LocationSample.Coverage;
+
+        public interface IProtocol
+        {
+        }
+
+        [AkkaSerializer<IProtocol>("coverage", 500003)]
+        public sealed partial class SampleSerializer : AkkaSerializer
+        {
+            public static partial SerializerRegistration CreateRegistration();
+        }
+
+        public sealed record Unmarked(string Value) : IProtocol;
+        """;
+
+    [Fact(DisplayName = "AKKASG029 should report at the serializer's own attribute line, not the unmarked implementor")]
+    public void Protocol_coverage_diagnostic_should_report_at_serializer_attribute_line()
+    {
+        var diagnostics = GeneratorTestHarness.Run(ProtocolCoverageSource).GeneratorDiagnostics;
+
+        var diagnostic = diagnostics.Should().ContainSingle(d => d.Id == "AKKASG029").Subject;
+        diagnostic.Location.Should().NotBe(Location.None);
+
+        var expectedLine = LineIndexOf(ProtocolCoverageSource, "[AkkaSerializer<IProtocol>");
+        var unmarkedLine = LineIndexOf(ProtocolCoverageSource, "public sealed record Unmarked");
+        diagnostic.Location.GetLineSpan().StartLinePosition.Line.Should().Be(expectedLine);
+        expectedLine.Should().NotBe(unmarkedLine, "AKKASG029 must not point at the unmarked implementor itself");
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Cross-assembly: the LOCAL referencing property, in THIS compilation -- never a location
+    // inside the referenced assembly, which the generator never even parses (Decision 16).
+    // ------------------------------------------------------------------------------------------
+    private const string CrossAssemblySourceA = """
+        #nullable enable
+        using Akka.Serialization.V2;
+
+        namespace LocationSample.CrossAssembly.AssemblyA;
+
+        [AkkaSerializable]
+        public sealed record Money([property: AkkaField(1)] long Cents);
+        """;
+
+    private const string CrossAssemblySourceB = """
+        #nullable enable
+        using Akka.Actor;
+        using Akka.Serialization.V2;
+        using LocationSample.CrossAssembly.AssemblyA;
+
+        namespace LocationSample.CrossAssembly.AssemblyB;
+
+        public interface IShop
+        {
+        }
+
+        [AkkaSerializable(Manifest = "pay-v1")]
+        public sealed record Pay([property: AkkaField(1)] Money Amount) : IShop;
+
+        [AkkaSerializer<IShop>("shop", 500004)]
+        public sealed partial class ShopSerializer : AkkaSerializer
+        {
+            public static partial SerializerRegistration CreateRegistration();
+        }
+        """;
+
+    [Fact(DisplayName = "Cross-assembly AKKASG007 should report at the LOCAL referencing property in this compilation, never inside the referenced assembly")]
+    public void Cross_assembly_diagnostic_should_report_at_local_referencing_property()
+    {
+        var assemblyA = GeneratorTestHarness.CompileToReference(CrossAssemblySourceA, "LocationSampleCrossAssemblyA");
+        var result = GeneratorTestHarness.Run(CrossAssemblySourceB, assemblyA);
+
+        var diagnostic = result.GeneratorDiagnostics.Should().ContainSingle(d => d.Id == "AKKASG007").Subject;
+        diagnostic.Location.Should().NotBe(Location.None);
+
+        // A DiagnosticSpec's location is reconstructed from a captured LocationSpec via
+        // Location.Create(filePath, span, linePositionSpan) -- an "external" location with no live
+        // SourceTree attached (the tree that produced it is long gone by report time). GetLineSpan()
+        // still resolves correctly from the captured path/positions, which is what a diagnostic
+        // renderer (an IDE, or this assertion) actually reads.
+        var lineSpan = diagnostic.Location.GetLineSpan();
+
+        // The location's file path must be assembly B's own source file, never assembly A's --
+        // proof this is genuinely the LOCAL reference site, not something borrowed from A's tree
+        // (A's syntax tree is never even loaded by the generator; only its metadata is read).
+        lineSpan.Path.Should().NotContain("LocationSampleCrossAssemblyA");
+
+        var expectedLine = LineIndexOf(CrossAssemblySourceB, "public sealed record Pay(");
+        lineSpan.StartLinePosition.Line.Should().Be(expectedLine);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Closed-generic construction, TYPE-LEVEL: a construction has no syntax of its own (only its
+    // GENERIC DEFINITION does), so a type-level diagnostic on it (MissingFields here) must redirect
+    // to that construction's own [AkkaSerializable<T>] registration attribute on the serializer --
+    // see MessageTypeLocationKey's doc comment in AkkaSerializerGenerator.Locations.cs.
+    // ------------------------------------------------------------------------------------------
+    private const string ClosedGenericMissingFieldsSource = """
+        #nullable enable
+        using Akka.Actor;
+        using Akka.Serialization.V2;
+
+        namespace LocationSample.ClosedGenericMissingFields;
+
+        public interface IProtocol
+        {
+        }
+
+        [AkkaSerializable]
+        public sealed class EmptyWrapper<T> : IProtocol
+        {
+        }
+
+        [AkkaSerializer<IProtocol>("closed-generic-missing-fields", 500009)]
+        [AkkaSerializable<EmptyWrapper<int>>(Manifest = "empty-wrapper-v1")]
+        public sealed partial class SampleSerializer : AkkaSerializer
+        {
+            public static partial SerializerRegistration CreateRegistration();
+        }
+        """;
+
+    [Fact(DisplayName = "AKKASG004 on a closed-generic construction should report at its own registration attribute, not the generic definition or the serializer's main attribute")]
+    public void Closed_generic_type_level_diagnostic_should_report_at_registration_attribute_line()
+    {
+        var diagnostics = GeneratorTestHarness.Run(ClosedGenericMissingFieldsSource).GeneratorDiagnostics;
+
+        var diagnostic = diagnostics.Should().ContainSingle(d => d.Id == "AKKASG004").Subject;
+        diagnostic.Location.Should().NotBe(Location.None);
+
+        var expectedLine = LineIndexOf(ClosedGenericMissingFieldsSource, "[AkkaSerializable<EmptyWrapper<int>>");
+        var definitionLine = LineIndexOf(ClosedGenericMissingFieldsSource, "public sealed class EmptyWrapper<T>");
+        var serializerAttributeLine = LineIndexOf(ClosedGenericMissingFieldsSource, "[AkkaSerializer<IProtocol>");
+
+        diagnostic.Location.GetLineSpan().StartLinePosition.Line.Should().Be(expectedLine);
+        expectedLine.Should().NotBe(definitionLine, "the construction has no syntax of its own -- the generic definition's own declaration is the wrong site");
+        expectedLine.Should().NotBe(serializerAttributeLine, "this diagnostic is about ONE registration, not the serializer as a whole");
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Additional corpus fixtures feeding Diagnostics_should_never_report_Location_None above.
+    // ------------------------------------------------------------------------------------------
+    private const string FormatterSource = """
+        #nullable enable
+        using Akka.Actor;
+        using Akka.Serialization.V2;
+        using MessagePack;
+
+        namespace LocationSample.Formatter;
+
+        public interface IProtocol
+        {
+        }
+
+        public sealed record Foreign(string Value);
+
+        public abstract class AbstractFormatter : IAkkaMessagePackFormatter<Foreign>
+        {
+            public abstract void Write(ref MessagePackWriter writer, Foreign value);
+            public abstract Foreign Read(ref MessagePackReader reader);
+            public abstract int SizeOf(Foreign value);
+        }
+
+        [AkkaSerializer<IProtocol>("formatter", 500005)]
+        [AkkaSerializerFormatter<Foreign, AbstractFormatter>]
+        public sealed partial class SampleSerializer : AkkaSerializer
+        {
+            public static partial SerializerRegistration CreateRegistration();
+        }
+
+        [AkkaSerializable(Manifest = "outer-v1")]
+        public sealed record Outer([property: AkkaField(1)] Foreign Value) : IProtocol;
+        """;
+
+    private const string ClosedGenericSource = """
+        #nullable enable
+        using Akka.Actor;
+        using Akka.Serialization.V2;
+
+        namespace LocationSample.ClosedGeneric;
+
+        public interface IProtocol
+        {
+        }
+
+        [AkkaSerializable(Manifest = "outer-v1")]
+        public sealed record Outer([property: AkkaField(1)] string Value) : IProtocol;
+
+        [AkkaSerializer<IProtocol>("closed-generic", 500006)]
+        [AkkaSerializable<int>(Manifest = "int-v1")]
+        public sealed partial class SampleSerializer : AkkaSerializer
+        {
+            public static partial SerializerRegistration CreateRegistration();
+        }
+        """;
+
+    private const string UnionMemberSource = """
+        #nullable enable
+        using Akka.Actor;
+        using Akka.Serialization.V2;
+
+        namespace LocationSample.UnionMember;
+
+        public interface IProtocol
+        {
+        }
+
+        public interface IEvent
+        {
+        }
+
+        public sealed record NotSerializable(string Value) : IEvent;
+
+        [AkkaSerializer<IProtocol>("union-member", 500007)]
+        public sealed partial class SampleSerializer : AkkaSerializer
+        {
+            public static partial SerializerRegistration CreateRegistration();
+        }
+
+        [AkkaSerializable(Manifest = "outer-v1")]
+        public sealed record Outer(
+            [property: AkkaField(1), AkkaUnion(typeof(NotSerializable))] IEvent Event) : IProtocol;
+        """;
+
+    private const string DuplicateFieldIndexSource = """
+        #nullable enable
+        using Akka.Actor;
+        using Akka.Serialization.V2;
+
+        namespace LocationSample.DuplicateFieldIndex;
+
+        public interface IProtocol
+        {
+        }
+
+        [AkkaSerializer<IProtocol>("dup-index", 500008)]
+        public sealed partial class SampleSerializer : AkkaSerializer
+        {
+            public static partial SerializerRegistration CreateRegistration();
+        }
+
+        [AkkaSerializable(Manifest = "dup-v1")]
+        public sealed record DupIndex(
+            [property: AkkaField(1)] string A,
+            [property: AkkaField(1)] string B) : IProtocol;
+        """;
+
+    /// <summary>The zero-based line index of the first line containing <paramref name="needle"/>.</summary>
+    private static int LineIndexOf(string source, string needle)
+    {
+        var lines = source.Replace("\r\n", "\n").Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].Contains(needle, StringComparison.Ordinal))
+                return i;
+        }
+
+        throw new InvalidOperationException($"'{needle}' was not found in the fixture source.");
+    }
+}

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorArchitectureSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorArchitectureSpec.cs
@@ -14,6 +14,7 @@ using System.Reflection;
 using Akka.Serialization.V2.Generators;
 using FluentAssertions;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Akka.Serialization.V2.Tests;
@@ -40,9 +41,14 @@ namespace Akka.Serialization.V2.Tests;
 public sealed class GeneratorArchitectureSpec
 {
     /// <summary>
-    /// A type assignable to any of these can never be part of a cached pipeline model: all four are
-    /// tied to one specific compilation/parse and are never equal to their counterpart from the
-    /// next incremental run, even when they represent "the same" declaration.
+    /// A type assignable to any of these can never be part of a cached pipeline model: each is tied
+    /// to one specific compilation/parse and is never equal to its counterpart from the next
+    /// incremental run, even when it represents "the same" declaration. <see cref="TextSpan"/> is
+    /// included alongside <see cref="Location"/> (S6 "locations"): a raw span is exactly as
+    /// whitespace-sensitive as a full <see cref="Location"/>, so a cached model must carry neither --
+    /// only the value-equatable <c>LocationSpec</c>/<c>LocationKey</c> pair belongs beside a model,
+    /// never inside one. See <see cref="Akka.Serialization.V2.Generators.AkkaSerializerGenerator"/>'s
+    /// own AkkaSerializerGenerator.Locations.cs file header for the full rule.
     /// </summary>
     private static readonly Type[] ForbiddenBaseTypes =
     {
@@ -51,7 +57,8 @@ public sealed class GeneratorArchitectureSpec
         typeof(SyntaxNode),
         typeof(SyntaxTree),
         typeof(Location),
-        typeof(SyntaxReference)
+        typeof(SyntaxReference),
+        typeof(TextSpan)
     };
 
     private static IReadOnlyList<Type> ModelTypes { get; } = DiscoverModelTypes();

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorCompilationFactsSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorCompilationFactsSpec.cs
@@ -174,6 +174,7 @@ public sealed class GeneratorCompilationFactsSpec
         return new AkkaSerializerGenerator.SerializerInfo(
             ns: "FactsSample",
             className: "TestSerializer",
+            key: new AkkaSerializerGenerator.TypeKey("FactsSample.TestSerializer", ImmutableArray<AkkaSerializerGenerator.TypeKey>.Empty, "global::FactsSample.TestSerializer"),
             fullyQualifiedName: "global::FactsSample.TestSerializer",
             name: "test-serializer",
             serializerId: 1,

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorIncrementalScenariosSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorIncrementalScenariosSpec.cs
@@ -123,19 +123,26 @@ public sealed class GeneratorIncrementalScenariosSpec
     [Fact(DisplayName = "Tracked pipeline stages should match TrackingNames.All exactly (a new stage must update this spec)")]
     public void TrackingNames_should_match_expected_stage_count()
     {
-        // Pins today's stage count. Adding a seventh (or removing one) named pipeline stage is a
+        // Pins today's stage count. Adding a ninth (or removing one) named pipeline stage is a
         // deliberate architectural change -- this assertion makes it fail loudly here instead of
         // only surfacing as a silent gap in the scenarios below. ResolvedSerializers (the
-        // per-serializer resolve stage from the S3 architecture pass) is the fifth; CompilationFacts
-        // (the whole-compilation facts stage from the S5 architecture pass) is the sixth. Both were
-        // ADDED downstream of the four stages above, which is why scenarios (a)/(c)/(d)/(e) below
-        // still pin the exact same reasons for those four as before.
-        AkkaSerializerGenerator.TrackingNames.All.Should().HaveCount(6);
+        // per-serializer resolve stage from the S3 architecture pass) and CompilationFacts (the
+        // whole-compilation facts stage from the S5 architecture pass) predate S6. S6 "locations"
+        // adds two: SerializerSchemas/MessageSchemas split ExtractedSerializers'/ExtractedMessages'
+        // raw output (schema vs location bag) -- see each constant's own doc comment in
+        // AkkaSerializerGenerator.cs. A locations-only counterpart to each (SerializerLocations/
+        // MessageLocations) existed briefly during development but was removed: a per-node Select
+        // for a value read back only once, batched, cost more than it saved -- the merged location
+        // bag (allLocations, in Initialize) now collects the raw ExtractedSerializer/ExtractedMessage
+        // values directly instead.
+        AkkaSerializerGenerator.TrackingNames.All.Should().HaveCount(8);
         AkkaSerializerGenerator.TrackingNames.All.Should().BeEquivalentTo(new[]
         {
             AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
+            AkkaSerializerGenerator.TrackingNames.SerializerSchemas,
             AkkaSerializerGenerator.TrackingNames.CollectedSerializers,
             AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
+            AkkaSerializerGenerator.TrackingNames.MessageSchemas,
             AkkaSerializerGenerator.TrackingNames.CollectedMessages,
             AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
             AkkaSerializerGenerator.TrackingNames.CompilationFacts
@@ -150,13 +157,25 @@ public sealed class GeneratorIncrementalScenariosSpec
     // at -- gives every attributed node a new input identity, so EVERY node's extraction transform
     // re-executes. A node whose resulting model still compares equal to its previous run reports
     // Unchanged (recomputed, but the same value), never Cached (skipped without recomputing); only
-    // a node whose model actually differs reports Modified. Nothing at the per-node
+    // a node whose model actually differs reports Modified. Nothing at the RAW per-node
     // (ExtractedSerializers/ExtractedMessages) level is ever Cached in any scenario below -- the
     // exact same "every node reruns" profile shows up whether the edit lands in the tracked file,
     // an unrelated file, or is a single added reference. Only downstream, at the Collect() level,
     // does the pipeline recover a Cached result -- and only when EVERY individual element that
     // feeds it is Unchanged/Cached; one truly Modified element (scenario (b)) is enough to make the
     // whole collected array report Modified instead.
+    //
+    // S6 "locations" adds a wrinkle: the RAW per-node output now carries a location bag alongside
+    // the schema, and that bag IS whitespace-sensitive (see LocationSpec's own doc comment). So the
+    // raw stage itself can report Modified purely because a span shifted, even when the SCHEMA is
+    // untouched (scenario (c)) or even when the location bag's KEY set changes from a same-length
+    // rename (scenario (b), where field name IS the key). The schemas-only projection immediately
+    // strips that back out, which is what keeps Collect/Resolve/Emit exactly as cached as before S6
+    // -- see each scenario's own comments for the concrete per-element reasons. The merged location
+    // bag (allLocations) that a raw-stage Modified eventually feeds is NOT one of the tracked stages
+    // below -- it collects the raw ExtractedSerializer/ExtractedMessage values directly, with no
+    // separate per-node Select of its own -- so it is not asserted on here either; the scenarios only
+    // pin what happens at the RAW/schemas/Collect/Resolve level.
     // ------------------------------------------------------------------------------------------
 
     [Fact(DisplayName = "Scenario (a): editing an unrelated file reuses every tracked stage and re-emits no file")]
@@ -168,10 +187,20 @@ public sealed class GeneratorIncrementalScenariosSpec
 
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+
+        // S6: neither serializer's location bag shifts (nothing in Main.cs moved), so the
+        // schemas-only projection of ExtractedSerializers reports the same reason as the raw stage.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.SerializerSchemas,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedSerializers, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+
+        // S6: same reasoning as the serializer projection above -- no message's location bag shifts.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.MessageSchemas,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
 
         // ResolvedSerializers' own input (serializers.Combine(messages)) is unchanged (both
@@ -205,10 +234,22 @@ public sealed class GeneratorIncrementalScenariosSpec
         // and Collect() lands on Cached.
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.SerializerSchemas,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedSerializers, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Modified, IncrementalStepRunReason.Unchanged,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+
+        // S6: "Count" -> "Total" is the same length, so no message's LOCATION SPAN actually moves --
+        // but AlphaTwo's location bag is keyed by FIELD NAME (LocationKey.Member), and that name
+        // itself changed, so the bag's key set differs from before ("Count" gone, "Total" added).
+        // AlphaTwo's raw ExtractedMessages element is therefore Modified for two independent reasons
+        // (schema AND location both differ), which is exactly what the assertion above already
+        // shows; MessageSchemas reports the SCHEMA half of that on its own.
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.MessageSchemas,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Modified, IncrementalStepRunReason.Cached,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Modified);
 
         // THE SCENARIO FLIP (S3): CollectedMessages changing forces the ResolvedSerializers
@@ -242,21 +283,43 @@ public sealed class GeneratorIncrementalScenariosSpec
     {
         var result = GeneratorTestHarness.RunIncremental(FixtureSource, FixtureWithCommentInsideBetaTwo);
 
-        // A comment carries no semantic information, so BetaTwo's recomputed model -- like every
-        // other node's -- compares EQUAL to its previous run. This scenario's tracked-step profile
-        // is therefore indistinguishable from scenario (a)'s (an edit to a wholly unrelated file):
-        // proof that the "everything reruns" behavior described above is driven by the Compilation
-        // changing identity, not by whether the edit is textually "inside" a tracked declaration.
+        // THE S6 SCENARIO FLIP: pre-S6, a comment carries no semantic information, so this scenario's
+        // tracked-step profile was indistinguishable from scenario (a)'s. S6 adds a location bag to
+        // the raw ExtractedMessages/ExtractedSerializers output, and a location bag IS
+        // whitespace-sensitive by design (that is the whole point -- it must track real spans, so a
+        // diagnostic points at the right place). The inserted comment sits inside BetaTwo, so every
+        // declaration PHYSICALLY AFTER it in Main.cs -- BetaTwo itself, BetaThree, and BetaSerializer
+        // -- gets a real, different absolute text position; nothing schema-level about any of them
+        // changed. AlphaOne/AlphaTwo/AlphaThree/AlphaSerializer/BetaOne sit BEFORE the comment and are
+        // completely unaffected.
+        //
+        // BetaSerializer's raw stage is Modified (its location bag shifted), but its SCHEMA is
+        // unaffected -- Unchanged, not Cached, since the stage still recomputed and produced an equal
+        // SerializerInfo.
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
-            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Modified);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.SerializerSchemas,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Unchanged);
+
+        // The schemas-only projection feeds a Collect() whose every element is Cached/Unchanged
+        // (equal to last run), so CollectedSerializers itself lands on Cached -- the raw stage's
+        // Modified-ness for BetaSerializer (its location bag shifted) never reaches here.
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedSerializers, IncrementalStepRunReason.Cached);
+
+        // BetaTwo (the edited message) and BetaThree (physically after it) both shift; BetaOne and
+        // every Alpha message do not.
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged,
-            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+            IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Modified, IncrementalStepRunReason.Modified);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.MessageSchemas,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
 
-        // Same as scenario (a): ResolvedSerializers' input is unchanged, so both serializers' resolve
-        // steps are skipped entirely (Cached).
+        // Same as scenario (a): both Collect()'d arrays are Cached, so ResolvedSerializers' own input
+        // never changed identity -- both serializers' resolve steps are skipped entirely (Cached).
+        // THIS is the property S6 exists to preserve: a location-only edit reaches neither Resolve nor
+        // Emit.
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ResolvedSerializers,
             IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
 
@@ -265,7 +328,8 @@ public sealed class GeneratorIncrementalScenariosSpec
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CompilationFacts, IncrementalStepRunReason.Unchanged);
 
         // TARGET: unchanged from today -- a comment-only edit re-emitting nothing is already the
-        // desired behavior; no migration PR needs to touch this.
+        // desired behavior; S6 must not regress it, and does not: no file is re-emitted even though
+        // three raw extraction nodes (BetaSerializer, BetaTwo, BetaThree) report Modified.
         ChangedHintNames(result).Should().BeEmpty();
     }
 
@@ -276,15 +340,23 @@ public sealed class GeneratorIncrementalScenariosSpec
             new[] { new SourceFile("Main.cs", FixtureSource), new SourceFile("Unrelated.cs", UnrelatedSourceBefore) },
             new[] { new SourceFile("Main.cs", FixtureSource), new SourceFile("Unrelated.cs", UnrelatedSourceWithTrivialKeystroke) });
 
-        // Same profile as (a)/(c): a single appended blank line in a file the generator never looks
-        // at is still enough to make every node's extraction transform recompute (Unchanged), and
-        // Collect() still lands on Cached since nothing actually differs.
+        // Same profile as (a): a single appended blank line in a file the generator never looks at
+        // is still enough to make every node's extraction transform recompute (Unchanged), and
+        // Collect() still lands on Cached since nothing actually differs. The edit is in a file
+        // Main.cs never shares -- no location in it shifts either, so the S6 schemas-only projection
+        // stays Cached for every element too (contrast scenario (c), where the edit lands INSIDE the
+        // tracked file).
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.SerializerSchemas,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedSerializers, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.MessageSchemas,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
 
         // Same as scenario (a): ResolvedSerializers' input is unchanged, so both serializers' resolve
@@ -332,13 +404,19 @@ public sealed class GeneratorIncrementalScenariosSpec
 
         // Same profile again: adding a reference nothing in the fixture uses still changes the
         // Compilation's identity, so every node recomputes (Unchanged) and Collect() lands on
-        // Cached since no extracted model actually differs.
+        // Cached since no extracted model actually differs. No text in Main.cs moved, so the S6
+        // schemas-only projection is Cached too.
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.SerializerSchemas,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedSerializers, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.MessageSchemas,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
 
         // Same as scenario (a): ResolvedSerializers' input is unchanged, so both serializers' resolve
@@ -379,13 +457,19 @@ public sealed class GeneratorIncrementalScenariosSpec
             afterExtraReferences: new[] { extraReference });
 
         // Same profile as scenario (e) up through ResolvedSerializers: nothing in the fixture itself
-        // changed, so every extracted/collected/resolved model still compares equal.
+        // changed, so every extracted/collected/resolved model still compares equal, and the S6
+        // schemas-only projection stays Cached (no text in Main.cs moved).
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedSerializers,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.SerializerSchemas,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedSerializers, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.ExtractedMessages,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged,
             IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged, IncrementalStepRunReason.Unchanged);
+        AssertReasons(result, AkkaSerializerGenerator.TrackingNames.MessageSchemas,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached,
+            IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached, IncrementalStepRunReason.Cached);
         AssertReasons(result, AkkaSerializerGenerator.TrackingNames.CollectedMessages, IncrementalStepRunReason.Cached);
 
         // TARGET (S5): CompilationFacts is NOT combined into ResolvedSerializers' inputs (see

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorResolveSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorResolveSpec.cs
@@ -282,6 +282,7 @@ public sealed class GeneratorResolveSpec
         return new AkkaSerializerGenerator.SerializerInfo(
             ns: "ResolveSample",
             className: className,
+            key: new AkkaSerializerGenerator.TypeKey($"ResolveSample.{className}", ImmutableArray<AkkaSerializerGenerator.TypeKey>.Empty, $"global::ResolveSample.{className}"),
             fullyQualifiedName: $"global::ResolveSample.{className}",
             name: "test-serializer",
             serializerId: 1,

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorResolvedSerializerSnapshotSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorResolvedSerializerSnapshotSpec.cs
@@ -175,6 +175,12 @@ public sealed class GeneratorResolvedSerializerSnapshotSpec
 
     private static string RenderDiagnostic(AkkaSerializerGenerator.DiagnosticSpec diagnostic)
     {
-        return $"{diagnostic.Key}({string.Join(", ", diagnostic.MessageArgs)})";
+        // Additive over the pre-S6 rendering: appends the chosen LocationKey (owner type plus member,
+        // "" meaning "the type/attribute itself") so this snapshot also proves each diagnostic picked
+        // the right local reference site, not just the right key/message-args.
+        var at = diagnostic.At is { } key
+            ? $" @ {key.Owner}{(key.Member.Length == 0 ? string.Empty : "." + key.Member)}"
+            : string.Empty;
+        return $"{diagnostic.Key}({string.Join(", ", diagnostic.MessageArgs)}){at}";
     }
 }

--- a/src/core/Akka.Serialization.V2.Tests/GeneratorValidatorSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/GeneratorValidatorSpec.cs
@@ -84,7 +84,9 @@ public sealed class GeneratorValidatorSpec
         var diagnostics = AkkaSerializerGenerator.Validate(serializer, ImmutableArray.Create(dupIndex));
 
         diagnostics.Should().Contain(new AkkaSerializerGenerator.DiagnosticSpec(
-            AkkaSerializerGenerator.DiagnosticKey.DuplicateFieldIndex, "ValidatorSample.DupIndex", "1"));
+            AkkaSerializerGenerator.DiagnosticKey.DuplicateFieldIndex,
+            new AkkaSerializerGenerator.LocationKey(dupIndex.Key, string.Empty),
+            "ValidatorSample.DupIndex", "1"));
     }
 
     [Fact(DisplayName = "Validate should report AKKASG006 when a top-level message has no manifest")]
@@ -111,7 +113,9 @@ public sealed class GeneratorValidatorSpec
         var diagnostics = AkkaSerializerGenerator.Validate(serializer, ImmutableArray.Create(noManifest));
 
         diagnostics.Should().Contain(new AkkaSerializerGenerator.DiagnosticSpec(
-            AkkaSerializerGenerator.DiagnosticKey.MissingManifest, "ValidatorSample.NoManifest"));
+            AkkaSerializerGenerator.DiagnosticKey.MissingManifest,
+            new AkkaSerializerGenerator.LocationKey(noManifest.Key, string.Empty),
+            "ValidatorSample.NoManifest"));
     }
 
     [Fact(DisplayName = "Validate should report AKKASG012 when two top-level messages of the same serializer duplicate a manifest")]
@@ -143,6 +147,7 @@ public sealed class GeneratorValidatorSpec
 
         diagnostics.Should().Contain(new AkkaSerializerGenerator.DiagnosticSpec(
             AkkaSerializerGenerator.DiagnosticKey.DuplicateManifest,
+            new AkkaSerializerGenerator.LocationKey(serializer.Key, string.Empty),
             "TestSerializer", "shared-v1", "ValidatorSample.MessageA, ValidatorSample.MessageB"));
     }
 
@@ -178,6 +183,7 @@ public sealed class GeneratorValidatorSpec
 
         diagnostics.Should().Contain(new AkkaSerializerGenerator.DiagnosticSpec(
             AkkaSerializerGenerator.DiagnosticKey.UnionMemberNotSerializable,
+            new AkkaSerializerGenerator.LocationKey(outer.Key, "Event"),
             "ValidatorSample.NotSerializable", "Event", "ValidatorSample.Outer"));
     }
 
@@ -365,6 +371,7 @@ public sealed class GeneratorValidatorSpec
         return new AkkaSerializerGenerator.SerializerInfo(
             ns: "ValidatorSample",
             className: "TestSerializer",
+            key: new AkkaSerializerGenerator.TypeKey("ValidatorSample.TestSerializer", ImmutableArray<AkkaSerializerGenerator.TypeKey>.Empty, "global::ValidatorSample.TestSerializer"),
             fullyQualifiedName: "global::ValidatorSample.TestSerializer",
             name: "test-serializer",
             serializerId: 1,


### PR DESCRIPTION
> Stack, bottom to top: S1 #8525 -> S2 #8526 -> S3 #8527 -> object elements #8528 -> S4 #8530 -> S5 #8532 -> S6 #8533 -> F1 #8534 -> F2 #8536 -> F3 #8537 -> S7 #8538. Each PR is one commit on top of the one below it. This PR is S6.

## What changes

Every diagnostic now points at a source line. Before, all 41 reported with no location, so a user saw the message in the error list and no squiggle in the editor. Ids, text, and triggers are unchanged. Generated text is byte-identical. No golden, wire, or model snapshot changed.

- **Where each diagnostic lands.** A field problem points at the `[AkkaField]` property, including the cross-assembly forms. A message problem points at the message declaration, or at the `[AkkaSerializable<T>]` registration attribute when the message is a closed construction, which has no declaration of its own. A serializer problem, including protocol coverage, points at the `[AkkaSerializer<T>]` attribute. A formatter or registration problem points at its own attribute. The rule is written once, in the header of the new locations file.
- **Locations live beside the model, not inside it.** A `LocationSpec` is a small value: file path, span, line and column. Each extracted type carries a bag of them next to its schema. No cached model holds a Roslyn location, and the architecture test now forbids `TextSpan` too.
- **Two views of each extracted type.** A schema-only view feeds the cached steps, so a whitespace edit that moves spans cannot invalidate them. The location bags are collected and merged for the report outputs only.
- **All reporting moves to report outputs.** Emission only emits. A diagnostic whose location cannot be resolved falls back to no location, and that is the one such site left in the generator.
- **Two more known types come from the S5 cache** instead of two name lookups per serializer per edit.

## Why locations are separate

Roslyn reuses a step's output when its inputs compare equal. A span changes on every whitespace edit. If spans lived in the model, every whitespace edit would regenerate every file.

## Scenarios

Scenario c is this PR's flip. A comment inside a message marks that message's extracted value as changed, because its spans moved, while the schema view reports unchanged and nothing is regenerated. Messages declared after the comment in the same file shift too and show the same pattern.

| Scenario | Extracted values | Schema view | Regenerated files |
|---|---|---|---|
| a. unrelated file edited | unchanged | cached | none |
| b. field renamed | one changed | one changed | one |
| c. comment inside a message | two changed | unchanged | none |
| d. trivial keystroke | unchanged | cached | none |
| e. unused reference added | unchanged | cached | none |
| e2. reference that references V2 | unchanged | cached | none |

## Cost

Base is the S5 tip. Both rows were measured twice on the same machine; allocations were identical and means agreed within noise.

| Row | Base (S5) | This PR | Change |
|---|---:|---:|---:|
| Fresh driver, full corpus | 22.3 ms, 18.1 MB | 22.8 ms, 18.9 MB | +0.5 ms, +0.9 MB |
| Warm driver, one field renamed | 13.6 ms, 8.6 MB | 16.1 ms, 9.5 MB | +2.5 ms, +0.9 MB |
| Warm driver, comment edit | 8.8 ms, 3.0 MB | 8.6 ms, 3.5 MB | flat, +0.6 MB |
| Warm driver, unrelated file edited | 6.5 ms, 2.9 MB | 7.2 ms, 3.5 MB | +0.7 ms, +0.6 MB |

This is the first step in the pass that costs something. The per-type step re-runs on every keystroke, so each of the 500 types builds its location bag each time: about 1 ms and 0.6 MB, or 1 KB per type. That is the price every mainstream generator pays for squiggles. Three trims kept it there: the two attribute lookups moved into the S5 cache, the bags are collected straight from the extracted values, and field locations are captured inside the existing property walk. The no-change row is still about half of where S4 left it.

## How it was checked

327 tests pass (313 plus 14): a corpus-wide check that no diagnostic lacks a location, plus exact-line checks for a field, a type, a serializer, a cross-assembly reference, protocol coverage, and a zero-field closed construction. Generator and `Akka.Remote` build with warnings as errors.
