### PR TITLE
Build: bump Microsoft.SourceLink.GitHub to 10.0.303 to clear NU1902 (CVE-2026-62900)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -64,7 +64,7 @@
   </ItemGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.303" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\docs\images\akkalogo.png" Pack="true" Visible="false" PackagePath="\" />


### PR DESCRIPTION
## Summary

GitHub advisory [GHSA-23fw-v26w-5fgq](https://github.com/advisories/GHSA-23fw-v26w-5fgq) (CVE-2026-62900, published 2026-09-08 20:25 UTC) marks `Microsoft.Build.Tasks.Git` 10.0.300 as vulnerable. Every project inherits that package through the `Microsoft.SourceLink.GitHub` reference in `Directory.Build.props`. When NuGet audit sees the advisory it raises NU1902, and `TreatWarningsAsErrors` turns that into a restore failure.

How wide this is: on build 131173 (PR #8534, 05:11 UTC) only the Windows Artery job failed at restore while 14 jobs restored clean. By build 131176 (PR #8536, about two hours later) the DocFX and NuGet Pack jobs failed the same way, and by 08:00 UTC a developer machine that had restored clean all morning started failing too. The audit feed has propagated. Every restore in the repo now fails until this lands.

## Fix

Bump `Microsoft.SourceLink.GitHub` from 10.0.300 to 10.0.303, the first patched version in the 10.0.3xx band per the advisory. One line in `Directory.Build.props`. SourceLink output is unchanged.

## Verified

The CI log on build 131173 shows NU1902 at 10.0.300, and the advisory names 10.0.303 as the first patched version in this band. A local `dotnet restore --force` did not reproduce the warning on this machine, which appears to hold a cached older copy of the audit feed, so the local check only confirms that restore succeeds at 10.0.303.

## After merge

Open PRs whose base is another feature branch do not pick this up from `dev` on their own, because their merge ref merges into the base branch. The Serialization.V2 stack (#8525 to #8534) gets a bottom-up rebase onto `dev` once this lands.
