### PR TITLE
De-flake ClusterSpec: stop passing an already-cancelled token to its WithinAsync block

### DIFF
--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -313,7 +313,7 @@ namespace Akka.Cluster.Tests
             }
             finally
             {
-                Shutdown(sys2);
+                await ShutdownAsync(sys2);
             }
         }
 
@@ -374,7 +374,7 @@ namespace Akka.Cluster.Tests
             }
             finally
             {
-                Shutdown(sys);
+                await ShutdownAsync(sys);
             }
         }
 
@@ -435,7 +435,7 @@ namespace Akka.Cluster.Tests
             }
             finally
             {
-                Shutdown(sys);
+                await ShutdownAsync(sys);
             }
         }
 
@@ -481,7 +481,7 @@ namespace Akka.Cluster.Tests
             }
             finally
             {
-                Shutdown(sys2);
+                await ShutdownAsync(sys2);
             }
         }
 
@@ -518,7 +518,7 @@ namespace Akka.Cluster.Tests
             }
             finally
             {
-                Shutdown(sys2);
+                await ShutdownAsync(sys2);
             }
         }
 
@@ -552,7 +552,7 @@ namespace Akka.Cluster.Tests
             }
             finally
             {
-                Shutdown(sys2);
+                await ShutdownAsync(sys2);
             }
         }
 
@@ -585,7 +585,7 @@ namespace Akka.Cluster.Tests
             }
             finally
             {
-                Shutdown(sys3);
+                await ShutdownAsync(sys3);
             }
         }
     }

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -270,11 +270,11 @@ namespace Akka.Cluster.Tests
                 LeaderActions(); // Exiting --> Removed
 
                 // Member should leave even a task was cancelled
-                ExpectMsg<ClusterEvent.MemberRemoved>().Member.Address.Should().Be(_selfAddress);
+                (await ExpectMsgAsync<ClusterEvent.MemberRemoved>()).Member.Address.Should().Be(_selfAddress);
 
                 // Second task should complete (not cancelled)
                 await AwaitConditionAsync(() => Task.FromResult(task2.IsCompleted && !task2.IsCanceled), null, "Task should be completed, but not cancelled.");
-            }, cancellationToken: cts.Token);
+            });
 
             // Subsequent LeaveAsync() tasks expected to complete immediately (not cancelled)
             var task3 = _cluster.LeaveAsync();


### PR DESCRIPTION
## What changes

`ClusterSpec.A_cluster_must_cancel_LeaveAsync_task_if_CancellationToken_fired_before_node_left` no longer passes an already-cancelled token to its own wait block. One synchronous `ExpectMsg` inside that block becomes `await ExpectMsgAsync`, per the repo rule that tests use the async TestKit calls.

## Why

The test creates a token source, calls `LeaveAsync` with its token, cancels it, confirms that task is cancelled, and then passed the same cancelled token as the `cancellationToken:` of the 10 second `WithinAsync` block that drives the leader through Leaving, Exiting, and Removed. `WithinAsync` races the block against a delay bound to that token. With a cancelled token the delay is born cancelled, so whenever the block hits a real suspension point before the race is checked, `WithinAsync` throws `OperationCanceledException`. A fast run finishes the block synchronously and hides it. A slow run, like CI build 131162 on a one-line generator PR, fails in 71 ms with a message that has nothing to do with the cancellation behavior under test.

The bug has been in the test since the `cancellationToken:` argument was added in 2022. No prior fix targeted it. The de-flake inventory for this week's PR builds records the history.

## How it was checked

`dotnet build src/core/Akka.Cluster.Tests -c Release -warnaserror` clean. The single test run 25 times in a row: 25 passes. The whole `ClusterSpec` class: 20 passed.

## Second commit: the remaining synchronous TestKit calls move to the async API

Per the maintainer's rule that a touched file migrates in the same PR: the seven `Shutdown(system)` calls in the file's `finally` blocks become `await ShutdownAsync(system)`. Three `_cluster.Shutdown()` calls stay; that is the cluster extension's own method, not a TestKit wait, and it has no async form. No assertion changes. The whole `ClusterSpec` class run three times after the migration: 20 passed each time.

