### PR TITLE
De-flake RemoteDeliverySpec: give the final barrier a budget that covers the loop

### DIFF
--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteDeliverySpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteDeliverySpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Remote.TestKit;
 using Akka.Configuration;
@@ -26,6 +27,7 @@ namespace Akka.Remote.Tests.MultiNode
 
             CommonConfig = DebugConfig(true)
                 .WithFallback(ConfigurationFactory.ParseString(@"
+                  # Classic (DotNetty) only; Artery has no batching switch and ignores this key.
                   akka.remote.dot-netty.tcp.batching.enabled = false # disable batching
                 "));
         }
@@ -62,7 +64,7 @@ namespace Akka.Remote.Tests.MultiNode
     public class RemoteDeliverySpec : MultiNodeSpec
     {
         private readonly RemoteDeliveryMultiNetSpec _config;
-        private readonly Func<RoleName, string, IActorRef> _identify;
+        private readonly Func<RoleName, string, Task<IActorRef>> _identify;
 
         public RemoteDeliverySpec() : this(new RemoteDeliveryMultiNetSpec())
         {
@@ -72,11 +74,13 @@ namespace Akka.Remote.Tests.MultiNode
         {
             _config = config;
 
-            _identify = (role, actorName) => Within(TimeSpan.FromSeconds(10), () =>
+            _identify = (role, actorName) => WithinAsync(TimeSpan.FromSeconds(10), async () =>
                 {
-                    Sys.ActorSelection(Node(role)/"user"/actorName)
+                    // NodeAsync, not Node: Node blocks on the controller round trip, which would
+                    // run before the block hands WithinAsync a task and so outside the 10s bound.
+                    Sys.ActorSelection(await NodeAsync(role)/"user"/actorName)
                         .Tell(new Identify(actorName));
-                    return ExpectMsg<ActorIdentity>()
+                    return (await ExpectMsgAsync<ActorIdentity>())
                         .Subject;
                 });
         }
@@ -90,16 +94,16 @@ namespace Akka.Remote.Tests.MultiNode
         }
 
         [MultiNodeFact]
-        public void Remoting_with_TCP_must_not_drop_messages_under_normal_circumstances()
+        public async Task Remoting_with_TCP_must_not_drop_messages_under_normal_circumstances()
         {
             Sys.ActorOf<RemoteDeliveryMultiNetSpec.Postman>("postman-" + Myself.Name);
-            EnterBarrier("actors-started");
+            await EnterBarrierAsync("actors-started");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
                 {
-                    var p1 = _identify(_config.First, "postman-first");
-                    var p2 = _identify(_config.Second, "postman-second");
-                    var p3 = _identify(_config.Third, "postman-third");
+                    var p1 = await _identify(_config.First, "postman-first");
+                    var p2 = await _identify(_config.Second, "postman-second");
+                    var p3 = await _identify(_config.Third, "postman-third");
                     var route = new List<IActorRef>
                     {
                         p2,
@@ -113,7 +117,7 @@ namespace Akka.Remote.Tests.MultiNode
                     {
                         p1.Tell(new RemoteDeliveryMultiNetSpec.Letter(n, route));
                         var letterNumber = n;
-                        ExpectMsg<RemoteDeliveryMultiNetSpec.Letter>(
+                        await ExpectMsgAsync<RemoteDeliveryMultiNetSpec.Letter>(
                             letter => letter.N == letterNumber && letter.Route.Count == 0,
                             TimeSpan.FromSeconds(5));
 
@@ -126,7 +130,20 @@ namespace Akka.Remote.Tests.MultiNode
                 },
                 _config.First);
 
-            EnterBarrier("after-1");
+            // 'second' and 'third' reach this barrier about a second into the run, while 'first'
+            // is still looping, and BarrierCoordinator arms a barrier's clock on the FIRST
+            // arrival and only ever shortens it. So this budget, not the 5s per-letter wait, is
+            // what bounds the whole 500-letter loop, and at the 30s default the loop outlives
+            // its own barrier on a saturated CI agent. EnterBarrierAsync asks the coordinator
+            // for RemainingOr(barrier-timeout), so a Within around it sets that budget without
+            // raising akka.testconductor.barrier-timeout, which also drives the node teardown
+            // poll in MultiNodeSpecAfterAll (AwaitCondition polls at max/10) and would add
+            // barrier-timeout/10 of wall clock to every run. 300s over 500 letters permits a
+            // 600ms mean round trip: 3x the slowest mean measured on such an agent, and far
+            // under the 5s per-letter deadline, which stays the assertion that reports a real
+            // drop. A node that fails still aborts the barrier at once, because losing a client
+            // fails a barrier already in progress.
+            await WithinAsync(TimeSpan.FromSeconds(300), () => EnterBarrierAsync("after-1"));
         }
     }
 }


### PR DESCRIPTION
## What changes

`RemoteDeliverySpec` wraps its final `after-1` barrier in a `Within` that gives the barrier a 300 s budget. The 500-letter loop, its relay route, its per-letter `ExpectMsg` bound and its assertions are unchanged, so the spec proves exactly what it proved before. The rest of the diff is the file's migration to the async TestKit API.

## Why

`second` and `third` do no work of their own in this spec. They start a `Postman`, pass `actors-started`, and arrive at `after-1` about a second into the run, while `first` is still sending its 500 letters. `BarrierCoordinator` arms a barrier's clock on the **first** arrival and only ever shortens it, so the 30 s default `akka.testconductor.barrier-timeout`, not the 5 s per-letter wait, is what bounds the whole loop.

On a saturated CI agent the loop needs more than 30 s. The barrier then fails, the relay nodes stop, and `first` fails its next per-letter wait because the route it was using has gone away. The reported failure is a 5 s delivery timeout, which reads like a dropped message but is not one.

`EnterBarrierAsync` asks the coordinator for `RemainingOr(barrier-timeout)`, so a `Within` around the final barrier sets that budget directly.

**The number.** 300 s over 500 letters permits a 600 ms mean round trip. The slowest mean measured on a loaded two-core agent was about 190 ms, so this is roughly 3x that, and it stays far below the 5 s per-letter deadline, which remains the assertion that reports a real drop. A node that actually fails still aborts the barrier at once, because losing a client fails a barrier already in progress, so the longer budget does not slow down real failures.

**Why not the config key.** `akka.testconductor.barrier-timeout` also drives the teardown poll in `MultiNodeSpecAfterAll`, where `AwaitCondition` polls at `max/10` and the first poll always misses. Raising the key adds `barrier-timeout/10` of wall clock to every run. Measured at 30 s, 60 s, 100 s and 300 s, the spec took 5 s, 8 s, 12 s and 32 s. Scoping the budget to the barrier keeps the run at 5 s.

One comment was added to mark `akka.remote.dot-netty.tcp.batching.enabled` as classic-only; Artery has no batching switch and ignores it.

## How it was checked

`dotnet build src/core/Akka.Remote.Tests.MultiNode -c Release -warnaserror` clean.

The mechanism was reproduced and fixed locally. Adding a 40 s delay to `first`'s block makes the spec fail on `dev`'s shape with `barrier failed:after-1` on all three nodes, which is the CI signature. The same 40 s delay passes with the scoped budget in place.

The spec then ran through the multi-node adapter on the committed change: five runs on classic and three on Artery, all passed, 5 to 6 s each, the same as `dev`. The Artery runs were confirmed to load `ArteryRemoting`.

Measurements that did not justify a change: the two per-message classic log keys `log-sent-messages` and `log-received-messages` do emit 10 lines per letter, 5008 lines over a run, but turning them off, and turning off `DebugConfig` entirely, made no measurable difference to the loop (1.31 s, 1.38 s and 1.34 s mean over three runs each). They are left on, so a failing run keeps its diagnostics.

The grep for synchronous TestKit calls, blocking waits, and sleeps on the file returns nothing. Test-only change. No ledger entry.
