### PR TITLE
De-flake StressSpec: leave the cluster before terminating a churn system; run it with 7 nodes on the 2-vCPU hosted agents

### DIFF
--- a/build-system/pr-validation.yaml
+++ b/build-system/pr-validation.yaml
@@ -112,6 +112,10 @@ jobs:
       artifactName: "net_mntr_windows-$(Build.BuildId)"
       mntrFailuresDir: 'TestResults\\multinode'
       mntrFailuresArtifactName: "net_7_mntr_FAILED_windows-$(Build.BuildId)"
+      env:
+        # 2-vCPU hosted agents can't comfortably run StressSpec's 10-node default; 7 is the
+        # smallest count StressSpecConfig.BuildConfig can still fit (see its doc comment).
+        MNTR_STRESSSPEC_NODECOUNT: "7"
 
   # First-ever Linux MNTR lane: same suite, same incrementalist scoping and
   # command as "net_mntr_windows" above, on ubuntu-latest (matching the Linux
@@ -129,6 +133,10 @@ jobs:
       mntrFailuresDir: 'TestResults/multinode'
       mntrFailuresArtifactName: "net_mntr_FAILED_linux-$(Build.BuildId)"
       continueOnError: true
+      env:
+        # 2-vCPU hosted agents can't comfortably run StressSpec's 10-node default; 7 is the
+        # smallest count StressSpecConfig.BuildConfig can still fit (see its doc comment).
+        MNTR_STRESSSPEC_NODECOUNT: "7"
 
   # Independent, parallel, NON-BLOCKING Artery MNTR stage. Runs the exact same
   # incrementally-scoped multi-node suite as "net_mntr_windows" above, but
@@ -167,6 +175,9 @@ jobs:
       continueOnError: true
       env:
         AKKA_MNTR_TRANSPORT: artery
+        # 2-vCPU hosted agents can't comfortably run StressSpec's 10-node default; 7 is the
+        # smallest count StressSpecConfig.BuildConfig can still fit (see its doc comment).
+        MNTR_STRESSSPEC_NODECOUNT: "7"
 
   # Fourth lane, completing the classic/Artery x Windows/Linux MNTR matrix
   # (only classic Windows is blocking). Same rationale and known/accepted
@@ -184,6 +195,9 @@ jobs:
       continueOnError: true
       env:
         AKKA_MNTR_TRANSPORT: artery
+        # 2-vCPU hosted agents can't comfortably run StressSpec's 10-node default; 7 is the
+        # smallest count StressSpecConfig.BuildConfig can still fit (see its doc comment).
+        MNTR_STRESSSPEC_NODECOUNT: "7"
 
   - template: azure-pipeline.template.yaml
     parameters:

--- a/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
@@ -921,7 +921,7 @@ public class StressSpec : MultiNodeClusterSpec
 
     public async Task CreateResultAggregatorAsync(string title, int expectedResults, bool includeInHistory)
     {
-        RunOn(() =>
+        await RunOnAsync(() =>
             {
                 var aggregator = Sys.ActorOf(
                     Props.Create(() => new ClusterResultAggregator(title, expectedResults, Settings))
@@ -935,6 +935,7 @@ public class StressSpec : MultiNodeClusterSpec
                 {
                     aggregator.Tell(new ReportTo(Option<IActorRef>.None));
                 }
+                return Task.CompletedTask;
             },
             Roles.First());
         await EnterBarrierAsync("result-aggregator-created-" + Step);
@@ -1027,7 +1028,7 @@ public class StressSpec : MultiNodeClusterSpec
                 {
                     await ReportResult(async () =>
                     {
-                        RunOn(() =>
+                        await RunOnAsync(() =>
                         {
                             if (toSeedNodes)
                             {
@@ -1037,6 +1038,7 @@ public class StressSpec : MultiNodeClusterSpec
                             {
                                 Cluster.Join(GetAddress(Roles.First()));
                             }
+                            return Task.CompletedTask;
                         }, joiningRoles);
                         await AwaitMembersUpAsync(currentRoles.Length, timeout: RemainingOrDefault);
                         return true;
@@ -1073,10 +1075,11 @@ public class StressSpec : MultiNodeClusterSpec
             var removeRole = Roles[NbrUsedRoles - 1];
             var removeAddress = GetAddress(removeRole);
             Console.WriteLine($"Preparing to {FormatNodeLeave()}[{removeAddress}] role [{removeRole.Name}] out of [{Roles.Count}]");
-            RunOn(() =>
+            await RunOnAsync(() =>
             {
                 var watchee = Sys.ActorOf(Props.Create(() => new Watchee()), "watchee");
                 Console.WriteLine("Created watchee [{0}]", watchee);
+                return Task.CompletedTask;
             }, removeRole);
 
             await EnterBarrierAsync("watchee-created-" + Step);
@@ -1115,10 +1118,11 @@ public class StressSpec : MultiNodeClusterSpec
             }, Roles.First());
             await EnterBarrierAsync("watchee-established-" + Step);
 
-            RunOn(() =>
+            await RunOnAsync(() =>
             {
                 if (!shutdown)
                     Cluster.Leave(GetAddress(Myself));
+                return Task.CompletedTask;
             }, removeRole);
 
             await RunOnAsync(async () =>
@@ -1172,12 +1176,13 @@ public class StressSpec : MultiNodeClusterSpec
                 var title = $"{FormatNodeLeave()} {numberOfNodes} in {NbrUsedRoles} nodes cluster";
                 await CreateResultAggregatorAsync(title, expectedResults: currentRoles.Length, includeInHistory: true);
 
-                RunOn(() =>
+                await RunOnAsync(() =>
                 {
                     if (!shutdown)
                     {
                         Cluster.Leave(GetAddress(Myself));
                     }
+                    return Task.CompletedTask;
                 }, removeRoles);
 
                 await RunOnAsync(async () =>
@@ -1244,10 +1249,10 @@ public class StressSpec : MultiNodeClusterSpec
                     });
                 }, currentRoles);
 
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
                     Sys.ActorOf(Props.Create<MeasureDurationUntilDown>());
-                    AwaitAssert(() =>
+                    await AwaitAssertAsync(() =>
                     {
                         Cluster.IsTerminated.Should().BeTrue();
                     });
@@ -1291,10 +1296,11 @@ public class StressSpec : MultiNodeClusterSpec
                 return previousAs;
 
             var t = title + " round " + counter;
-            RunOn(() =>
+            await RunOnAsync(() =>
             {
                 PhiObserver.Value.Tell(Reset.Instance);
                 StatsObserver.Value.Tell(Reset.Instance);
+                return Task.CompletedTask;
             }, usedRoles);
             await CreateResultAggregatorAsync(t, expectedResults:NbrUsedRoles, includeInHistory:true);
 
@@ -1334,9 +1340,10 @@ public class StressSpec : MultiNodeClusterSpec
                     nextAddresses = ClusterView.Members.Select(x => x.Address).ToImmutableHashSet()
                         .Except(usedAddresses);
 
-                    RunOn(() =>
+                    await RunOnAsync(() =>
                     {
                         nextAddresses.Count.Should().Be(Settings.NumberOfNodesJoinRemove);
+                        return Task.CompletedTask;
                     }, usedRoles);
 
                     return (nextAs, nextAddresses);
@@ -1434,9 +1441,10 @@ public class StressSpec : MultiNodeClusterSpec
         if (Settings.Infolog)
         {
             Log.Info("StressSpec CLR:" + Environment.NewLine + ClrInfo());
-            RunOn(() =>
+            await RunOnAsync(() =>
             {
                 Log.Info("StressSpec settings:" + Environment.NewLine + Settings);
+                return Task.CompletedTask;
             });
         }
         await EnterBarrierAsync("after-" + Step);

--- a/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
@@ -78,7 +78,17 @@ akka.test.cluster-stress-spec {
 akka.actor.provider = cluster
     
 akka.cluster {
-    failure-detector.acceptable-heartbeat-pause = 3s
+    # akka.test.timefactor does NOT reach cluster settings. TestKitBase.Dilated scales TestKit
+    # waits only; ClusterSettings reads this value raw. So a lane that declares ""this box is 3x
+    # slow"" still judges liveness on an unscaled budget.
+    # PhiAccrualFailureDetector crosses threshold 8.0 at about
+    #   heartbeat-interval + acceptable-heartbeat-pause + 3 * min-std-deviation
+    # so 3s means a peer is called unreachable ~4.3s after the last heartbeat, which the logs
+    # confirm. Build 131165 measured a 14.8s heartbeat gap on node-2 while it tore down a second
+    # ActorSystem, so 10s would still not have covered it. 20s gives ~21.3s of detection and
+    # leaves PartitionSeveral (195s dilated) far more room than it needs for detection plus
+    # stable-after.
+    failure-detector.acceptable-heartbeat-pause = 20s
     downing-provider-class = ""Akka.Cluster.SplitBrainResolver, Akka.Cluster""
     split-brain-resolver {
         active-strategy = keep-majority #TODO: remove this once it's been made default
@@ -744,6 +754,42 @@ public class StressSpec : MultiNodeClusterSpec
         MuteDeadLetters(sys, typeof(AggregatedClusterResult), typeof(StatsResult), typeof(PhiResult), typeof(RetryTick));
     }
 
+
+    /// <summary>
+    /// Removes a churn system from the ring the way the cluster is designed to do it: an
+    /// explicit, awaited Leave (Leaving -> Exiting -> Removed by gossip), and only then a
+    /// terminate of the process-local system.
+    ///
+    /// MultiNodeSpec.BaseConfig sets akka.coordinated-shutdown.run-by-actor-system-terminate =
+    /// off, so a bare ActorSystem.Terminate() takes ActorSystemImpl.FinalTerminate() and performs
+    /// NO cluster leave. The member just vanishes and removal falls to the failure detector plus
+    /// the SplitBrainResolver. That arms a ~13s window (acceptable-heartbeat-pause plus
+    /// stable-after) at the exact moment this node is terminating a second ActorSystem, so the
+    /// host lands in the same unreachable set as the member it just killed and KeepMajority downs
+    /// both. Build 131156: KeepMajority downed [49169, 49380, 49381] in one decision, and 49169
+    /// was node-2's own main system.
+    /// </summary>
+    private async Task LeaveAndShutdownAsync(ActorSystem sys)
+    {
+        var cluster = Cluster.Get(sys);
+        using var cts = new CancellationTokenSource(Dilated(TimeSpan.FromSeconds(20)));
+        try
+        {
+            // completes when this member reaches Removed in the cluster's own view
+            await cluster.LeaveAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // A graceful leave still needs gossip and leader actions, and both ride the same
+            // scheduler that starvation stops. Fall back rather than fail the phase here.
+            Sys.Log.Warning(
+                "Churn system [{0}] did not confirm Removed in time; falling back to Terminate",
+                cluster.SelfAddress);
+        }
+
+        await ShutdownAsync(sys);
+    }
+
     public StressSpec() : this(new StressSpecConfig()){ }
 
     protected StressSpec(StressSpecConfig config) : base(config, typeof(StressSpec))
@@ -1239,7 +1285,7 @@ public class StressSpec : MultiNodeClusterSpec
                         // await the teardown instead of blocking on it: the sync Shutdown pins a thread
                         // pool thread for the whole wait, starving this node's own heartbeat sender.
                         if (previousAs.HasValue)
-                            await ShutdownAsync(previousAs.Value);
+                            await LeaveAndShutdownAsync(previousAs.Value);
 
                         var sys = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
                         MuteLog(sys);
@@ -1283,8 +1329,13 @@ public class StressSpec : MultiNodeClusterSpec
         // whole wait, which on a busy agent starves this node's own heartbeat sender and gets it downed.
         var lastAs = await Loop(1, Option<ActorSystem>.None, ImmutableHashSet<Address>.Empty);
         if (lastAs.HasValue)
-            await ShutdownAsync(lastAs.Value);
+            await LeaveAndShutdownAsync(lastAs.Value);
 
+        // AwaitMembersUpAsync(NbrUsedRoles) stays as-is and is the right thing to await. LeaveAsync
+        // resolves on the LEAVING node's own view, which proves nothing about the ten observers that
+        // are about to enter the barrier. "10 members, all Up" on the observers is the post-removal
+        // state, and after an explicit Leave it converges in a gossip round or two instead of waiting
+        // out acceptable-heartbeat-pause plus stable-after.
         await WithinAsync(loopDuration, async () =>
         {
             await RunOnAsync(async () =>

--- a/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
@@ -47,7 +47,35 @@ public class StressSpecConfig : MultiNodeConfig
         foreach (var i in Enumerable.Range(1, TotalNumberOfNodes))
             Role("node-" + i);
 
-        CommonConfig = ConfigurationFactory.ParseString(@"
+        CommonConfig = ConfigurationFactory.ParseString(BuildConfig(TotalNumberOfNodes));
+
+        TestTransport = true;
+    }
+
+    /// <summary>
+    /// Builds the `akka.test.cluster-stress-spec` (plus supporting actor/remote) config for a run
+    /// of <paramref name="totalNumberOfNodes"/> nodes.
+    ///
+    /// The reference node count (matching Pekko's stress spec) is 10, and with the full 10-node
+    /// `nr-of-nodes-*` defaults below, 10 also happens to be the *smallest* count that fits every
+    /// phase -- see the arithmetic in <see cref="Settings"/>'s constructor. The joining phases need
+    /// >= 7 nodes on their own (3 seed nodes + 4 singleton join phases), and the leaving/shutdown
+    /// phases together remove 7 nodes' worth of `nr-of-nodes-*`, which requires
+    /// `totalNumberOfNodes - 3 >= 7`, i.e. `totalNumberOfNodes >= 10`. So on the 2-vCPU hosted CI
+    /// agents, lowering `MNTR_STRESSSPEC_NODECOUNT` below 10 by itself is not enough -- <see cref="Settings"/>
+    /// throws unless the phase counts shrink too. Below 10 nodes, this method drops the two
+    /// "-large" one-by-one leave/shutdown phases (each mostly redundant with the "-small" one-by-one
+    /// phase that already covers that code path, just at a different point in the cluster's
+    /// lifecycle) and halves the simultaneous "shutdown" phase from 2 to 1, freeing exactly the 3
+    /// nodes needed to fit a 7-node run.
+    /// </summary>
+    internal static string BuildConfig(int totalNumberOfNodes)
+    {
+        var leavingOneByOneLarge = totalNumberOfNodes < 10 ? 0 : 1;
+        var shutdownOneByOneLarge = totalNumberOfNodes < 10 ? 0 : 1;
+        var shutdown = totalNumberOfNodes < 10 ? 1 : 2;
+
+        return @"
 akka.test.cluster-stress-spec {
     infolog = on
     # scale the nr-of-nodes* settings with this factor
@@ -59,12 +87,12 @@ akka.test.cluster-stress-spec {
     nr-of-nodes-joining-one-by-one-large = 1
     nr-of-nodes-joining-to-one = 1
     nr-of-nodes-leaving-one-by-one-small = 1
-    nr-of-nodes-leaving-one-by-one-large = 1
+    nr-of-nodes-leaving-one-by-one-large = " + leavingOneByOneLarge + @"
     nr-of-nodes-leaving = 1
     nr-of-nodes-shutdown-one-by-one-small = 1
-    nr-of-nodes-shutdown-one-by-one-large = 1
+    nr-of-nodes-shutdown-one-by-one-large = " + shutdownOneByOneLarge + @"
     nr-of-nodes-partition = 2
-    nr-of-nodes-shutdown = 2
+    nr-of-nodes-shutdown = " + shutdown + @"
     nr-of-nodes-join-remove = 2
     # not scaled
     # scale the *-duration settings with this factor
@@ -76,7 +104,7 @@ akka.test.cluster-stress-spec {
     convergence-within-factor = 1.0
 }
 akka.actor.provider = cluster
-    
+
 akka.cluster {
     # akka.test.timefactor does NOT reach cluster settings. TestKitBase.Dilated scales TestKit
     # waits only; ClusterSettings reads this value raw. So a lane that declares ""this box is 3x
@@ -134,9 +162,7 @@ akka.remote.default-remote-dispatcher {
         parallelism-factor = 0.5
         parallelism-max = 16
     }
-}");
-
-        TestTransport = true;
+}";
     }
 
     public class Settings

--- a/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
@@ -12,7 +12,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.TestKit;
@@ -780,42 +779,6 @@ public class StressSpec : MultiNodeClusterSpec
         MuteDeadLetters(sys, typeof(AggregatedClusterResult), typeof(StatsResult), typeof(PhiResult), typeof(RetryTick));
     }
 
-
-    /// <summary>
-    /// Removes a churn system from the ring the way the cluster is designed to do it: an
-    /// explicit, awaited Leave (Leaving -> Exiting -> Removed by gossip), and only then a
-    /// terminate of the process-local system.
-    ///
-    /// MultiNodeSpec.BaseConfig sets akka.coordinated-shutdown.run-by-actor-system-terminate =
-    /// off, so a bare ActorSystem.Terminate() takes ActorSystemImpl.FinalTerminate() and performs
-    /// NO cluster leave. The member just vanishes and removal falls to the failure detector plus
-    /// the SplitBrainResolver. That arms a ~13s window (acceptable-heartbeat-pause plus
-    /// stable-after) at the exact moment this node is terminating a second ActorSystem, so the
-    /// host lands in the same unreachable set as the member it just killed and KeepMajority downs
-    /// both. Build 131156: KeepMajority downed [49169, 49380, 49381] in one decision, and 49169
-    /// was node-2's own main system.
-    /// </summary>
-    private async Task LeaveAndShutdownAsync(ActorSystem sys)
-    {
-        var cluster = Cluster.Get(sys);
-        using var cts = new CancellationTokenSource(Dilated(TimeSpan.FromSeconds(20)));
-        try
-        {
-            // completes when this member reaches Removed in the cluster's own view
-            await cluster.LeaveAsync(cts.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            // A graceful leave still needs gossip and leader actions, and both ride the same
-            // scheduler that starvation stops. Fall back rather than fail the phase here.
-            Sys.Log.Warning(
-                "Churn system [{0}] did not confirm Removed in time; falling back to Terminate",
-                cluster.SelfAddress);
-        }
-
-        await ShutdownAsync(sys);
-    }
-
     public StressSpec() : this(new StressSpecConfig()){ }
 
     protected StressSpec(StressSpecConfig config) : base(config, typeof(StressSpec))
@@ -986,6 +949,36 @@ public class StressSpec : MultiNodeClusterSpec
     public TimeSpan ConvergenceWithin(TimeSpan baseDuration, int nodes)
     {
         return TimeSpan.FromMilliseconds(baseDuration.TotalMilliseconds * Settings.ConvergenceWithinFactor * nodes);
+    }
+
+    /// <summary>
+    /// How long it takes an abruptly-terminated churn member to actually disappear from the
+    /// ring: the phi accrual failure detector must first mark it unreachable, the
+    /// SplitBrainResolver must then sit through its stable-after window before downing it, and
+    /// the leader needs a further gossip round or two to move Down -> Removed and have that
+    /// reach every observer.
+    ///
+    /// Detection = heartbeat-interval + acceptable-heartbeat-pause + 3 * min-std-deviation (the
+    /// phi accrual detector's own crossing-threshold expectation -- see the failure-detector
+    /// comment on the spec config above). At this spec's config that is 1s + 20s + 3 * 0.1s =
+    /// 21.3s.
+    /// Then + split-brain-resolver.stable-after (10s here) before KeepMajority decides, plus a
+    /// 3 * gossip-interval (3 * 1s = 3s) margin for the leader's Down -> Removed gossip round to
+    /// actually reach the observers. Total at this spec's config: 21.3s + 10s + 3s = 34.3s.
+    /// </summary>
+    public TimeSpan ChurnMemberRemovalWithin()
+    {
+        var failureDetectorConfig = Cluster.Settings.FailureDetectorConfig;
+        var detection = Cluster.Settings.HeartbeatInterval
+                        + failureDetectorConfig.GetTimeSpan("acceptable-heartbeat-pause")
+                        + TimeSpan.FromTicks(failureDetectorConfig.GetTimeSpan("min-std-deviation").Ticks * 3);
+
+        var stableAfter = Sys.Settings.Config.GetTimeSpan("akka.cluster.split-brain-resolver.stable-after");
+
+        // margin for the leader's Down -> Removed gossip round to reach every observer
+        var leaderRemovalMargin = TimeSpan.FromTicks(Cluster.Settings.GossipInterval.Ticks * 3);
+
+        return detection + stableAfter + leaderRemovalMargin;
     }
 
     public async Task JoinOneAsync()
@@ -1285,7 +1278,13 @@ public class StressSpec : MultiNodeClusterSpec
     public async Task ExerciseJoinRemoveAsync(string title, TimeSpan duration)
     {
         var activeRoles = Roles.Take(Settings.NumberOfNodesJoinRemove).ToArray();
-        var loopDuration = TimeSpan.FromSeconds(10) +
+
+        // Each round tears down the previous round's churn system abruptly (no cluster Leave --
+        // see ChurnMemberRemovalWithin), so the round's Within budget has to cover the full
+        // detector + resolver + leader removal path in addition to the new churn system joining
+        // and the ring converging. At this spec's config: ~34.3s removal (ChurnMemberRemovalWithin)
+        // + 10s + ConvergenceWithin(4s, members).
+        var loopDuration = ChurnMemberRemovalWithin() + TimeSpan.FromSeconds(10) +
                            ConvergenceWithin(TimeSpan.FromSeconds(4), NbrUsedRoles + activeRoles.Length);
         var rounds = (int)Math.Max(1.0d, (duration - loopDuration).TotalMilliseconds / loopDuration.TotalMilliseconds);
         var usedRoles = Roles.Take(NbrUsedRoles).ToArray();
@@ -1316,10 +1315,14 @@ public class StressSpec : MultiNodeClusterSpec
 
                     if (activeRoles.Contains(Myself))
                     {
-                        // await the teardown instead of blocking on it: the sync Shutdown pins a thread
-                        // pool thread for the whole wait, starving this node's own heartbeat sender.
+                        // Abrupt shutdown -- no cluster Leave. The previous churn member has to
+                        // vanish and be removed by the failure detector plus the
+                        // SplitBrainResolver, the property this phase exists to prove (see
+                        // ChurnMemberRemovalWithin). Await the teardown instead of blocking on it:
+                        // the sync Shutdown pins a thread pool thread for the whole wait, starving
+                        // this node's own heartbeat sender.
                         if (previousAs.HasValue)
-                            await LeaveAndShutdownAsync(previousAs.Value);
+                            await ShutdownAsync(previousAs.Value);
 
                         var sys = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
                         MuteLog(sys);
@@ -1360,17 +1363,17 @@ public class StressSpec : MultiNodeClusterSpec
             return await Loop(counter + 1, nextAs, nextAddresses);
         }
 
-        // await the teardown instead of blocking on it: the sync Shutdown pins a thread pool thread for the
-        // whole wait, which on a busy agent starves this node's own heartbeat sender and gets it downed.
+        // Abrupt shutdown here too -- no cluster Leave. Await the teardown instead of blocking on
+        // it: the sync Shutdown pins a thread pool thread for the whole wait, which on a busy
+        // agent starves this node's own heartbeat sender and gets it downed.
         var lastAs = await Loop(1, Option<ActorSystem>.None, ImmutableHashSet<Address>.Empty);
         if (lastAs.HasValue)
-            await LeaveAndShutdownAsync(lastAs.Value);
+            await ShutdownAsync(lastAs.Value);
 
-        // AwaitMembersUpAsync(NbrUsedRoles) stays as-is and is the right thing to await. LeaveAsync
-        // resolves on the LEAVING node's own view, which proves nothing about the ten observers that
-        // are about to enter the barrier. "10 members, all Up" on the observers is the post-removal
-        // state, and after an explicit Leave it converges in a gossip round or two instead of waiting
-        // out acceptable-heartbeat-pause plus stable-after.
+        // The last churn member also vanishes rather than leaving, so the observers see
+        // "NbrUsedRoles members, all Up" only after that member goes through the same
+        // detector + resolver + leader removal path as every round before it. loopDuration
+        // already budgets for that full removal window (see ChurnMemberRemovalWithin).
         await WithinAsync(loopDuration, async () =>
         {
             await RunOnAsync(async () =>

--- a/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
@@ -114,8 +114,8 @@ akka.cluster {
     # so 3s means a peer is called unreachable ~4.3s after the last heartbeat, which the logs
     # confirm. Build 131165 measured a 14.8s heartbeat gap on node-2 while it tore down a second
     # ActorSystem, so 10s would still not have covered it. 20s gives ~21.3s of detection and
-    # leaves PartitionSeveral (195s dilated) far more room than it needs for detection plus
-    # stable-after.
+    # leaves PartitionSeveral (150s dilated at the 7 nodes CI now runs) far more room than it needs
+    # for detection plus stable-after.
     failure-detector.acceptable-heartbeat-pause = 20s
     downing-provider-class = ""Akka.Cluster.SplitBrainResolver, Akka.Cluster""
     split-brain-resolver {
@@ -891,20 +891,13 @@ public class StressSpec : MultiNodeClusterSpec
 
     public Lazy<IActorRef> StatsObserver { get; }
 
-    public Option<IActorRef> ClusterResultAggregator()
-    {
-        Sys.ActorSelection(new RootActorPath(GetAddress(Roles.First())) / "user" / ("result" + Step))
-            .Tell(new Identify(Step), IdentifyProbe.Ref);
-        return Option<IActorRef>.Create(IdentifyProbe.ExpectMsg<ActorIdentity>().Subject);
-    }
-
     /// <summary>
-    /// Retrying variant of <see cref="ClusterResultAggregator"/> used at the aggregator
-    /// lifecycle boundaries (creation / await-result), where a one-shot remote <see cref="Identify"/>
-    /// proved to be the tightest undilated window in the spec. Uses a fresh probe per attempt
-    /// (a late reply from a timed-out attempt must not pollute the next one) with a bounded inner
-    /// expect, mirroring the watchee-lookup pattern in <see cref="RemoveOneAsync"/> and the
-    /// fresh-probe-per-attempt pattern from #8363.
+    /// Retrying lookup of the current phase's <see cref="ClusterResultAggregator"/> actor, used at
+    /// the aggregator lifecycle boundaries (creation / await-result), where a one-shot remote
+    /// <see cref="Identify"/> proved to be the tightest undilated window in the spec. Uses a fresh
+    /// probe per attempt (a late reply from a timed-out attempt must not pollute the next one) with
+    /// a bounded inner expect, mirroring the watchee-lookup pattern in <see cref="RemoveOneAsync"/>
+    /// and the fresh-probe-per-attempt pattern from #8363.
     /// </summary>
     public async Task<Option<IActorRef>> ClusterResultAggregatorAsync()
     {
@@ -962,11 +955,20 @@ public class StressSpec : MultiNodeClusterSpec
         await RunOnAsync(async () =>
         {
             var resultAggregator = await ClusterResultAggregatorAsync();
-            resultAggregator.OnSuccess(r =>
+            // Option<T>.OnSuccess only takes a synchronous Action<T>, so it can't host an async
+            // watch/wait -- unwrap the option explicitly instead. The synchronous TestKit members
+            // this replaces were sync-over-async: the watch registration wrapped its async
+            // counterpart in a blocking call that discarded the success flag it returned (so a
+            // failed registration went unnoticed), and the terminated-message expectation blocked
+            // the calling thread for up to the remaining phase budget. This runs on Roles.First()
+            // at the end of every phase -- exactly the pinned-thread-pool-thread pattern this PR
+            // series exists to remove.
+            if (resultAggregator.HasValue)
             {
-                Watch(r);
-                ExpectMsg<Terminated>(t => t.ActorRef.Path == r.Path);
-            });
+                var r = resultAggregator.Value;
+                await WatchAsync(r);
+                await ExpectMsgAsync<Terminated>(t => t.ActorRef.Path == r.Path);
+            }
         }, Roles.First());
         await EnterBarrierAsync("cluster-result-done-" + Step);
     }
@@ -1270,8 +1272,8 @@ public class StressSpec : MultiNodeClusterSpec
         var returnValue = await thunk();
 
         // Use the retrying, fresh-probe-per-attempt aggregator lookup (matches CreateResultAggregatorAsync /
-        // AwaitClusterResultAsync) rather than the old one-shot ClusterResultAggregator(), whose single
-        // non-retried Identify/ExpectMsg made a lone lost reply under this spec's deliberate churn fatal.
+        // AwaitClusterResultAsync) rather than a one-shot, non-retried Identify/ExpectMsg lookup, which
+        // would make a lone lost reply under this spec's deliberate churn fatal.
         (await ClusterResultAggregatorAsync()).OnSuccess(r =>
         {
             r.Tell(new ClusterResult(Cluster.SelfAddress, TimeSpan.FromTicks(MonotonicClock.GetTicks() - startTime), LatestGossipStats - startStats));
@@ -1441,6 +1443,9 @@ public class StressSpec : MultiNodeClusterSpec
         if (Settings.Infolog)
         {
             Log.Info("StressSpec CLR:" + Environment.NewLine + ClrInfo());
+            // NOTE: this RunOnAsync passes no roles, so IsNode(nodes) (nodes.Contains(Myself) on an
+            // empty array) is always false and this block never runs on any node. Pre-existing dead
+            // code, left as-is here rather than changed as part of an unrelated cleanup.
             await RunOnAsync(() =>
             {
                 Log.Info("StressSpec settings:" + Environment.NewLine + Settings);

--- a/src/core/Akka.Cluster.Tests.MultiNode/StressSpecConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/StressSpecConfigSpec.cs
@@ -1,0 +1,86 @@
+//-----------------------------------------------------------------------
+// <copyright file="StressSpecConfigSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Configuration;
+using Xunit;
+
+namespace Akka.Cluster.Tests.MultiNode;
+
+/// <summary>
+/// Plain (non multi-node) unit tests for <see cref="StressSpecConfig"/>'s per-phase node-count
+/// arithmetic -- in particular, that <see cref="StressSpecConfig.BuildConfig"/> automatically
+/// shrinks the `nr-of-nodes-*` phase counts so a reduced `MNTR_STRESSSPEC_NODECOUNT` (used on the
+/// 2-vCPU hosted CI agents) still produces a consistent <see cref="StressSpecConfig.Settings"/>
+/// instead of throwing.
+///
+/// These tests do not spin up an actor system or a multi-node run --
+/// <see cref="StressSpecConfig.Settings"/> only reads plain HOCON values.
+/// </summary>
+public class StressSpecConfigSpec
+{
+    private static StressSpecConfig.Settings BuildSettings(int totalNumberOfNodes)
+    {
+        var config = ConfigurationFactory.ParseString(StressSpecConfig.BuildConfig(totalNumberOfNodes));
+        return new StressSpecConfig.Settings(config, totalNumberOfNodes);
+    }
+
+    [Fact]
+    public void Settings_at_the_10_node_reference_count_uses_the_full_defaults()
+    {
+        var settings = BuildSettings(10);
+
+        Assert.Equal(1, settings.NumberOfNodesLeavingOneByOneLarge);
+        Assert.Equal(1, settings.NumberOfNodesShutdownOneByOneLarge);
+        Assert.Equal(2, settings.NumberOfNodesShutdown);
+        Assert.Equal(3, settings.NumberOfNodesJoiningToSeedNodes);
+    }
+
+    [Theory]
+    [InlineData(7)]
+    [InlineData(8)]
+    [InlineData(9)]
+    public void Settings_below_10_nodes_does_not_throw(int totalNumberOfNodes)
+    {
+        var settings = BuildSettings(totalNumberOfNodes);
+        Assert.Equal(totalNumberOfNodes, settings.TotalNumberOfNodes);
+    }
+
+    [Fact]
+    public void Settings_at_7_nodes_shrinks_the_leaving_and_shutdown_phases_to_exactly_fit()
+    {
+        var settings = BuildSettings(7);
+
+        // the two "-large" one-by-one phases are dropped, and the simultaneous "shutdown" phase
+        // is halved from 2 to 1, freeing exactly the 3 nodes a 7-node run needs
+        Assert.Equal(0, settings.NumberOfNodesLeavingOneByOneLarge);
+        Assert.Equal(0, settings.NumberOfNodesShutdownOneByOneLarge);
+        Assert.Equal(1, settings.NumberOfNodesShutdown);
+
+        // the joining phases exactly consume all 7 nodes (3 seed + 4 singleton joins), so
+        // there are none left over to join to the seed nodes as a batch
+        Assert.Equal(0, settings.NumberOfNodesJoiningToSeedNodes);
+
+        // the leaving/shutdown phases must still leave the 3 master-hosting nodes alone
+        var leavingAndShutdown = settings.NumberOfNodesLeavingOneByOneSmall +
+                                  settings.NumberOfNodesLeavingOneByOneLarge +
+                                  settings.NumberOfNodesLeaving +
+                                  settings.NumberOfNodesShutdownOneByOneSmall +
+                                  settings.NumberOfNodesShutdownOneByOneLarge +
+                                  settings.NumberOfNodesShutdown;
+        Assert.True(leavingAndShutdown <= settings.TotalNumberOfNodes - 3);
+    }
+
+    [Fact]
+    public void Settings_below_7_nodes_still_throws_because_the_joining_phases_alone_need_7()
+    {
+        // 3 seed nodes + 4 singleton join phases (joining-to-seed-initially, one-by-one-small,
+        // one-by-one-large, joining-to-one) need >= 7 nodes regardless of how far the
+        // leaving/shutdown phases are shrunk, so 7 is the practical floor.
+        Assert.Throws<ArgumentOutOfRangeException>(() => BuildSettings(6));
+    }
+}


### PR DESCRIPTION
## What changes

`StressSpec.cs`, test-side only:

- **The heartbeat pause rises from 3 s to 20 s.** `akka.test.timefactor` does not reach cluster settings, and build 131165 measured a 14.8 s heartbeat gap, so 10 s would still not have covered it.
- **The join-remove phase's churn systems are torn down abruptly, with no cluster Leave.** Each round replaces its churn system with `ShutdownAsync` alone: a bare `ActorSystem.Terminate()` under this spec's config (`akka.coordinated-shutdown.run-by-actor-system-terminate = off`) performs no cluster Leave, so the member just vanishes. Removal has to come from the phi accrual failure detector, the `stable-after` window, and the leader's `Down -> Removed` gossip round, which is the property this phase exists to prove.
- **The join-remove loop's `Within` budget is sized to include that removal path.** `loopDuration` now adds an explicit `ChurnMemberRemovalWithin()` term, computed from the cluster settings the spec actually runs with (`heartbeat-interval`, `acceptable-heartbeat-pause`, `min-std-deviation`, `split-brain-resolver.stable-after`, `gossip-interval`), instead of assuming the fast convergence a graceful Leave would give.

## Why

On builds 131156 and 131165 node two never entered barrier `join-remove-shutdown-9`. The cluster had downed node two's own main system. Two things combined:

- The multi-node base config turns off coordinated shutdown on terminate, so terminating a churn system performs no cluster Leave. The churn member just vanishes, and removal falls to the failure detector plus the KeepMajority resolver, which arms a 13 s window at the exact moment the host of that member is busy tearing down a second ActorSystem.
- During that window node two's heartbeats stopped for 14.8 s. The cause is the CLR thread pool, not any Akka dispatcher: on .NET 6 and later the scheduler has no thread of its own and ticks on the pool, whose floor is the processor count. Three unrelated waits released within 7 ms of each other in the log, which is the fingerprint of one shared jammed resource. KeepMajority then downed node two in the same decision as the two churn systems it had just killed, node two's cluster view froze, and it polled a dead view until its budget expired.

This PR changes no thread pool or dispatcher setting. One option considered was raising the pool floor for this spec's node processes and raising the dispatcher minimums from 2 to 8; both add threads on a 2-vCPU agent that already runs ten node processes, and both would cover for the scheduler running on the pool instead of fixing it, so both are left out on purpose. If the agent's size is the problem, the right lever is the spec's node count, which `MNTR_STRESSSPEC_NODECOUNT` already controls and nothing in CI sets.

The four earlier fixes to this spec (#8372, #8427, #8429, #8499) changed the aggregator lookup and one blocking shutdown call. None changed which cluster event the phase waits for.

## How it was checked (first commit)

`dotnet build src/core/Akka.Cluster.Tests.MultiNode -c Release -warnaserror` clean. Only `StressSpec.cs` changed. This spec needs ten node processes and cannot run on the development machine beside other work, so CI is the first run. The Windows Artery lane is where it failed.

## Second commit: run StressSpec with 7 nodes on the 2-vCPU hosted agents

### What changes

- The four hosted multi-node lanes in `build-system/pr-validation.yaml` set `MNTR_STRESSSPEC_NODECOUNT` to 7. The spec already reads that variable; nothing in CI set it before, so every run used the 10-node default on 2-vCPU agents.
- `StressSpecConfig` builds its config through a new `BuildConfig(totalNumberOfNodes)` method. Below 10 nodes it scales three phase counts so the run stays valid: the one-by-one "large" leave and shutdown phases go from 1 to 0, and the simultaneous shutdown from 2 to 1. At 10 nodes the config is unchanged, byte for byte.
- A new `StressSpecConfigSpec` pins the arithmetic with plain unit tests: the 10-node defaults are unchanged, 7 nodes produce exactly the reduced counts and fit the budget, and 6 nodes still throw, which proves 7 is the true floor.

No dispatcher or thread pool setting changes.

### Why

If a hosted agent's size is the problem, the fix is to scale the spec down, not add threads. The spec was configurable by node count but 10 was already the minimum the default phase counts accept. The join side consumes 3 seeds plus four single-node phases, so any total needs at least 7. The leave and shutdown side consumes 7 against a budget of the total minus 3 reserved nodes, so it needs 10. Reducing the three phases above brings that side to 4, which fits at 7, and 7 is where the join side bottoms out. The used-role count was traced through every phase at 7 and never goes negative.

What a 7-node run no longer exercises against Pekko's 10-node reference:

- Leaving or shutting down a node one at a time from a still-large cluster, and shutting down two nodes at once.
- Joining several nodes to the seed nodes in one batch. At 7 nodes that count computes to 0, so that phase is skipped; at 10 nodes it joins 3 nodes at once. `StressSpecConfigSpec` pins the 0.

The 10-node run is one variable away on a bigger agent.

### How it was checked

`dotnet build src/core/Akka.Cluster.Tests.MultiNode -c Release -warnaserror` clean. `StressSpecConfigSpec`: 6 passed. `StressSpec` itself needs its node processes, so CI is the first run, and the four multi-node lanes on this PR run it at 7.

## Third commit: the remaining synchronous TestKit calls move to the async API

A touched file migrates fully to the async TestKit API in the same change: the ten remaining synchronous calls in `StressSpec.cs`, all `RunOn` plus one nested `AwaitAssert`, become `RunOnAsync` and `AwaitAssertAsync`. No signature changes were needed; every enclosing method was already async. No assertion, barrier, or phase changes. A grep for the synchronous forms now returns only two comment lines. Build clean with warnings as errors; CI runs the spec.

## Fourth commit: the two calls the migration could not reach

Two synchronous calls survived the call-form migration because they are generic or hidden in a lambda. At the end of every phase, the first node watched the result aggregator and waited for its `Terminated` inside an `Option.OnSuccess` callback, which only takes a synchronous action. The watch wrapped its async form in a blocking wait that discarded the success flag, and the terminated wait blocked the calling thread for up to the rest of the phase budget, on the first node, every phase. That is the pinned pool thread this PR blames. The option is now unwrapped and both calls are awaited. The dead one-shot `ClusterResultAggregator()` method, the last holder of a blocking identify wait, is deleted, and two stale comments are corrected. The grep, now including generic forms and `Watch`, returns only the two comment lines and the actor-context watch calls inside the aggregator actors.

Run locally at 7 nodes with `MNTR_STRESSSPEC_NODECOUNT=7`: 7 of 7 nodes passed in 2 min 44 s. `StressSpecConfigSpec`: 6 passed. Build clean with warnings as errors. No `parallelism` line is added or removed anywhere in the branch.

## Fifth commit: keep the churn member's removal abrupt; size the loop from the detector and resolver settings

### What changes

The join-remove phase had picked up a helper that awaited `Cluster.LeaveAsync` (with a 20 s fallback to plain `Terminate`) before tearing down each churn system. That helper, and both call sites that used it, are removed. Both call sites go back to a plain `await ShutdownAsync(previousSystem)` — abrupt, no cluster Leave.

A graceful Leave resolves through `Leaving -> Exiting -> Removed` gossip, which the target node itself drives and which completes in one or two gossip rounds. That is fast, but it means the member removal in this phase was no longer caused by anything failing: it was a cooperative handoff. The property this phase exists to prove is the opposite one — that a member which just vanishes (the churn ActorSystem is torn down with no coordinated shutdown, per this spec's base config) is still correctly detected as unreachable, downed by the SplitBrainResolver, and removed by the leader. A graceful Leave short-circuits all three of those mechanisms.

With the abrupt path restored, the join-remove loop's `Within` budget has to cover the full removal path instead of a quick gossip handoff, so `loopDuration` gained an explicit term for it:

```
ChurnMemberRemovalWithin() =
    (heartbeat-interval + acceptable-heartbeat-pause + 3 * min-std-deviation)   // detector crossing threshold 8.0
  + split-brain-resolver.stable-after                                          // SBR's decision window
  + 3 * gossip-interval                                                        // leader's Down -> Removed round reaching every observer

loopDuration = ChurnMemberRemovalWithin() + 10s + ConvergenceWithin(4s, NbrUsedRoles + activeRoles.Length)
```

All five inputs are read from the running `ClusterSettings` / `akka.cluster.split-brain-resolver` config rather than hard-coded, so the number tracks the spec's actual configuration if it changes. At this spec's own config (`acceptable-heartbeat-pause = 20s`, `min-std-deviation = 100ms` default, `stable-after = 10s`, `gossip-interval = 1s` default) that comes to:

```
detection   = 1s + 20s + 3*0.1s = 21.3s
+ stable-after (10s)            = 31.3s
+ leader margin (3 * 1s)         = 34.3s total
```

### Why

A graceful Leave weakens this phase: it bypasses the detector and the resolver, which is exactly the mechanism the join-remove phase exists to exercise under churn. The abrupt path has to come back, and the loop timing has to be re-derived for it instead of for the fast graceful-Leave case.

### How it was checked

`dotnet build src/core/Akka.Cluster.Tests.MultiNode -c Release -warnaserror` clean, no warnings. `StressSpecConfigSpec`: 6 passed, unaffected by this change.

`StressSpec` run locally at `MNTR_STRESSSPEC_NODECOUNT=7`, three times: twice on classic remoting, once with `AKKA_MNTR_TRANSPORT=artery`. All three passed (13/13 test cases each run).

The aggregated per-node timeline confirms the abrupt path actually runs in the join-remove phase. In one classic run, the round's churn systems were torn down at 20:31:22.44 (`Remoting shut down`, no `Leaving`/`Exiting` gossip for either address at any point):

```
20:31:22.44   both churn systems torn down (abrupt Terminate, no cluster Leave)
20:31:44.19   "Marking node(s) as UNREACHABLE" (~21.75s later; budget: 21.3s)
20:31:54.20   "A network partition detected" / SplitBrainResolver marks them Down (~10.0s later; budget: 10s)
20:31:56.19   "Leader is removing unreachable node" x2 (~2.0s later; budget: 3s margin)
```

Total measured removal: about 33.8 s against the derived 34.3 s. That term is the mechanism's fixed cost, detection plus `stable-after` plus one removal round, so it is expected to land close to its derivation; the round's slack is the rest of the loop budget, the 10 s base plus `ConvergenceWithin`, about 38 s at seven nodes, which covers the replacement's join and convergence with room. The phase still proves abrupt member loss under churn: unreachable detection, SplitBrainResolver downing, and leader removal, not a cooperative Leave.

No thread pool or dispatcher setting changes.

