### PR TITLE
De-flake ClusterShardingRegistrationCoordinatedShutdownSpec: wait on the spec's own budget instead of a probe's flat 5 s default

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
@@ -65,7 +65,17 @@ namespace Akka.Cluster.Sharding.Tests
 
         private async Task Region_registration_during_CoordinatedShutdown_must_try_next_oldest()
         {
-            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
+            // This 60s is a ceiling sized above every bounded wait this block contains, not a
+            // widened wait of its own. The "test" CoordinatedShutdown task below bounds its
+            // ExpectMsgAsync at Dilated(30s) (matching before-cluster-shutdown.timeout in the
+            // config above), and csTaskDone's ExpectMsgAsync<Done> immediately after it bounds at
+            // Dilated(20s) - both run sequentially on Config.Third, so 30 + 20 = 50s for those two
+            // alone. The rest of this block (three JoinAsync calls, the members-up
+            // AwaitAssertAsync, StartSharding, and two EnterBarrierAsync calls) has never measured
+            // above a couple of seconds locally, so 60s keeps 10s of margin above that 50s sum -
+            // enough that WithinAsync's own outer race timer (TestKitBase_Within.cs:346-350) does
+            // not fire before either inner bound gets a chance to.
+            await WithinAsync(TimeSpan.FromSeconds(60), async () =>
             {
                 // second should be oldest
                 await JoinAsync(Config.Second, Config.Second);
@@ -83,13 +93,25 @@ namespace Akka.Cluster.Sharding.Tests
                     CoordinatedShutdown.Get(Sys).AddTask(CoordinatedShutdown.PhaseBeforeClusterShutdown, "test", async () =>
                     {
                         await Task.Delay(200);
-                        // Wait on the spec's own 30s Within budget rather than a TestProbe's flat
-                        // akka.test.single-expect-default (5s): the shard home for [1] can't arrive
-                        // until the coordinator singleton hands off from `second` to `first`, which
-                        // can take longer than 5s. A TestProbe is its own TestKitBase with its own
-                        // deadline state, so it would never see this spec's Within budget - calling
-                        // ExpectMsgAsync on the spec itself does. This mirrors the JVM spec, which
-                        // sends from its own test actor.
+                        // Bound this explicitly at Dilated(30s) - the same 30s the config above
+                        // gives before-cluster-shutdown.timeout - rather than calling
+                        // ExpectMsgAsync(1) with no timeout. An unbounded call resolves through
+                        // RemainingOrDefault, which on THIS TestKitBase instance falls back to
+                        // whatever the outer WithinAsync below set as its deadline when the block
+                        // started (TestKitBase.cs:483-504) - i.e. the block's remainder, not a
+                        // fresh 30s. By the time this task actually runs (after the coordinator
+                        // singleton hands off from `second` to `first`), a meaningful slice of that
+                        // outer budget can already be gone, so an unbounded wait here would shrink
+                        // over time and, on a slow enough agent, end up shorter than the 5s
+                        // TestProbe default (akka.test.single-expect-default) it was written to
+                        // beat. An explicit Dilated(30s) gives it the same fresh window every run,
+                        // tied to the timeout that actually governs how long CoordinatedShutdown
+                        // will wait on this task, independent of how much of the outer block's
+                        // budget has already elapsed.
+                        //
+                        // A TestProbe is its own TestKitBase with its own deadline state, so it
+                        // would never see either budget - calling ExpectMsgAsync on the spec itself
+                        // does. This mirrors the JVM spec, which sends from its own test actor.
                         //
                         // This task body runs on a thread pool thread, not the test thread, so the
                         // implicit sender isn't set there - pass TestActor explicitly or this would
@@ -103,7 +125,7 @@ namespace Akka.Cluster.Sharding.Tests
                         // default 5s, CoordinatedShutdown would time the phase out and tear the
                         // region down while this task is still waiting on the shard-home handoff.
                         _region.Value.Tell(1, TestActor);
-                        await ExpectMsgAsync(1);
+                        await ExpectMsgAsync(1, Dilated(TimeSpan.FromSeconds(30)));
                         csTaskDone.Ref.Tell(Done.Instance);
                         return Done.Instance;
                     });

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
@@ -24,7 +24,14 @@ namespace Akka.Cluster.Sharding.Tests
         public RoleName Third { get; }
 
         public ClusterShardingRegistrationCoordinatedShutdownSpecConfig()
-            : base(loglevel: "DEBUG")
+            : base(
+                loglevel: "DEBUG",
+                // The `test` task below waits, on the spec's own thread/budget, for the shard home
+                // to arrive - which can take several seconds while the coordinator singleton hands
+                // off from `second` to `first`. Without this, an incomplete task would arm the
+                // default 5s `before-cluster-shutdown` phase timeout and CoordinatedShutdown would
+                // stop the region out from under the still-waiting task.
+                additionalConfig: "akka.coordinated-shutdown.phases.before-cluster-shutdown.timeout = 30s")
         {
             First = Role("first");
             Second = Role("second");
@@ -71,15 +78,25 @@ namespace Akka.Cluster.Sharding.Tests
                     Cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(3);
                 });
 
-                var probe = CreateTestProbe();
                 var csTaskDone = CreateTestProbe();
                 RunOn(() =>
                 {
                     CoordinatedShutdown.Get(Sys).AddTask(CoordinatedShutdown.PhaseBeforeClusterShutdown, "test", () =>
                     {
                         Thread.Sleep(200);
-                        _region.Value.Tell(1, probe.Ref);
-                        probe.ExpectMsg(1);
+                        // Wait on the spec's own Within(30s) budget rather than a TestProbe's flat
+                        // akka.test.single-expect-default (5s): the shard home for [1] can't arrive
+                        // until the coordinator singleton hands off from `second` to `first`, which
+                        // can take longer than 5s. A TestProbe is its own TestKitBase with its own
+                        // deadline state, so it would never see this spec's Within budget - calling
+                        // ExpectMsg on the spec itself does. This mirrors the JVM spec, which sends
+                        // from its own test actor.
+                        //
+                        // This task body runs on a thread pool thread, not the test thread, so the
+                        // implicit sender isn't set there - pass TestActor explicitly or this would
+                        // dead-letter.
+                        _region.Value.Tell(1, TestActor);
+                        ExpectMsg(1);
                         csTaskDone.Ref.Tell(Done.Instance);
                         return Task.FromResult(Done.Instance);
                     });

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
@@ -67,9 +67,9 @@ namespace Akka.Cluster.Sharding.Tests
         {
             // This 60s is a ceiling sized above every bounded wait this block contains, not a
             // widened wait of its own. The "test" CoordinatedShutdown task below bounds its
-            // ExpectMsgAsync at Dilated(30s) (matching before-cluster-shutdown.timeout in the
+            // ExpectMsgAsync at 30s (matching before-cluster-shutdown.timeout in the
             // config above), and csTaskDone's ExpectMsgAsync<Done> immediately after it bounds at
-            // Dilated(20s) - both run sequentially on Config.Third, so 30 + 20 = 50s for those two
+            // 20s - both run sequentially on Config.Third, so 30 + 20 = 50s for those two
             // alone. The rest of this block (three JoinAsync calls, the members-up
             // AwaitAssertAsync, StartSharding, and two EnterBarrierAsync calls) has never measured
             // above a couple of seconds locally, so 60s keeps 10s of margin above that 50s sum -
@@ -93,7 +93,7 @@ namespace Akka.Cluster.Sharding.Tests
                     CoordinatedShutdown.Get(Sys).AddTask(CoordinatedShutdown.PhaseBeforeClusterShutdown, "test", async () =>
                     {
                         await Task.Delay(200);
-                        // Bound this explicitly at Dilated(30s) - the same 30s the config above
+                        // Bound this explicitly at 30s - the same 30s the config above
                         // gives before-cluster-shutdown.timeout - rather than calling
                         // ExpectMsgAsync(1) with no timeout. An unbounded call resolves through
                         // RemainingOrDefault, which on THIS TestKitBase instance falls back to
@@ -104,10 +104,11 @@ namespace Akka.Cluster.Sharding.Tests
                         // outer budget can already be gone, so an unbounded wait here would shrink
                         // over time and, on a slow enough agent, end up shorter than the 5s
                         // TestProbe default (akka.test.single-expect-default) it was written to
-                        // beat. An explicit Dilated(30s) gives it the same fresh window every run,
+                        // beat. An explicit 30s gives it the same fresh window every run,
                         // tied to the timeout that actually governs how long CoordinatedShutdown
                         // will wait on this task, independent of how much of the outer block's
-                        // budget has already elapsed.
+                        // budget has already elapsed. ExpectMsgAsync dilates an explicit timeout
+                        // itself (RemainingOrDilated), so it is passed undilated here.
                         //
                         // A TestProbe is its own TestKitBase with its own deadline state, so it
                         // would never see either budget - calling ExpectMsgAsync on the spec itself
@@ -125,7 +126,7 @@ namespace Akka.Cluster.Sharding.Tests
                         // default 5s, CoordinatedShutdown would time the phase out and tear the
                         // region down while this task is still waiting on the shard-home handoff.
                         _region.Value.Tell(1, TestActor);
-                        await ExpectMsgAsync(1, Dilated(TimeSpan.FromSeconds(30)));
+                        await ExpectMsgAsync(1, TimeSpan.FromSeconds(30));
                         csTaskDone.Ref.Tell(Done.Instance);
                         return Done.Instance;
                     });
@@ -155,13 +156,13 @@ namespace Akka.Cluster.Sharding.Tests
                     await AwaitConditionAsync(() => Cluster.IsTerminated);
 
                     // csTaskDone is its own TestProbe / TestKitBase and never inherits this
-                    // spec's 30s Within budget, so its wait needs an explicit dilated bound. A
+                    // spec's Within budget, so its wait needs an explicit bound, which ExpectMsgAsync dilates. A
                     // clean local run measured the full handoff this depends on - the
                     // coordinator singleton migrating to `first`, the shard home for [1]
                     // arriving, and the "test" task's ExpectMsgAsync/Tell above completing -
                     // at 5.6s; 20s leaves roughly 3.5x margin for slower/loaded CI machines
                     // while still finishing well inside the phase's own 30s timeout.
-                    await csTaskDone.ExpectMsgAsync<Done>(Dilated(TimeSpan.FromSeconds(20)));
+                    await csTaskDone.ExpectMsgAsync<Done>(TimeSpan.FromSeconds(20));
                 }, Config.Third);
 
                 await EnterBarrierAsync("after-shutdown");

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Remote.TestKit;
@@ -59,47 +58,56 @@ namespace Akka.Cluster.Sharding.Tests
         #endregion
 
         [MultiNodeFact]
-        public void ClusterShardingRegistrationCoordinatedShutdownSpecs()
+        public async Task ClusterShardingRegistrationCoordinatedShutdownSpecs()
         {
-            Region_registration_during_CoordinatedShutdown_must_try_next_oldest();
+            await Region_registration_during_CoordinatedShutdown_must_try_next_oldest();
         }
 
-        private void Region_registration_during_CoordinatedShutdown_must_try_next_oldest()
+        private async Task Region_registration_during_CoordinatedShutdown_must_try_next_oldest()
         {
-            Within(TimeSpan.FromSeconds(30), () =>
+            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
             {
                 // second should be oldest
-                Join(Config.Second, Config.Second);
-                Join(Config.First, Config.Second);
-                Join(Config.Third, Config.Second);
+                await JoinAsync(Config.Second, Config.Second);
+                await JoinAsync(Config.First, Config.Second);
+                await JoinAsync(Config.Third, Config.Second);
 
-                AwaitAssert(() =>
+                await AwaitAssertAsync(() =>
                 {
                     Cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(3);
                 });
 
                 var csTaskDone = CreateTestProbe();
-                RunOn(() =>
+                await RunOnAsync(() =>
                 {
-                    CoordinatedShutdown.Get(Sys).AddTask(CoordinatedShutdown.PhaseBeforeClusterShutdown, "test", () =>
+                    CoordinatedShutdown.Get(Sys).AddTask(CoordinatedShutdown.PhaseBeforeClusterShutdown, "test", async () =>
                     {
-                        Thread.Sleep(200);
-                        // Wait on the spec's own Within(30s) budget rather than a TestProbe's flat
+                        await Task.Delay(200);
+                        // Wait on the spec's own 30s Within budget rather than a TestProbe's flat
                         // akka.test.single-expect-default (5s): the shard home for [1] can't arrive
                         // until the coordinator singleton hands off from `second` to `first`, which
                         // can take longer than 5s. A TestProbe is its own TestKitBase with its own
                         // deadline state, so it would never see this spec's Within budget - calling
-                        // ExpectMsg on the spec itself does. This mirrors the JVM spec, which sends
-                        // from its own test actor.
+                        // ExpectMsgAsync on the spec itself does. This mirrors the JVM spec, which
+                        // sends from its own test actor.
                         //
                         // This task body runs on a thread pool thread, not the test thread, so the
                         // implicit sender isn't set there - pass TestActor explicitly or this would
                         // dead-letter.
+                        //
+                        // Making this body async means AddTask's delegate now returns an incomplete
+                        // Task the moment it hits its first await, instead of the old synchronous
+                        // body's already-completed Task.FromResult - so CoordinatedShutdown actually
+                        // waits on it, up to the phase's own timeout. That is safe only because the
+                        // config above raises before-cluster-shutdown's timeout to 30s; at the
+                        // default 5s, CoordinatedShutdown would time the phase out and tear the
+                        // region down while this task is still waiting on the shard-home handoff.
                         _region.Value.Tell(1, TestActor);
-                        ExpectMsg(1);
+                        await ExpectMsgAsync(1);
                         csTaskDone.Ref.Tell(Done.Instance);
-                        return Task.FromResult(Done.Instance);
+                        return Done.Instance;
                     });
+                    return Task.CompletedTask;
                 }, Config.Third);
 
                 StartSharding(
@@ -107,31 +115,43 @@ namespace Akka.Cluster.Sharding.Tests
                     typeName: "Entity",
                     entityProps: Props.Create(() => new ShardedEntity()));
 
-                EnterBarrier("before-shutdown");
+                await EnterBarrierAsync("before-shutdown");
 
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
-                    CoordinatedShutdown.Get(Sys).Run(CoordinatedShutdown.UnknownReason.Instance);
-                    AwaitCondition(() => Cluster.IsTerminated);
+                    // Fire-and-forget, same as before the migration: the assertions below poll
+                    // Cluster.IsTerminated rather than awaiting this task directly.
+                    _ = CoordinatedShutdown.Get(Sys).Run(CoordinatedShutdown.UnknownReason.Instance);
+                    await AwaitConditionAsync(() => Cluster.IsTerminated);
                 }, Config.Second);
 
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
-                    CoordinatedShutdown.Get(Sys).Run(CoordinatedShutdown.UnknownReason.Instance);
-                    AwaitCondition(() => Cluster.IsTerminated);
-                    csTaskDone.ExpectMsg<Done>();
+                    // Fire-and-forget, same as before the migration: the assertions below poll
+                    // Cluster.IsTerminated rather than awaiting this task directly.
+                    _ = CoordinatedShutdown.Get(Sys).Run(CoordinatedShutdown.UnknownReason.Instance);
+                    await AwaitConditionAsync(() => Cluster.IsTerminated);
+
+                    // csTaskDone is its own TestProbe / TestKitBase and never inherits this
+                    // spec's 30s Within budget, so its wait needs an explicit dilated bound. A
+                    // clean local run measured the full handoff this depends on - the
+                    // coordinator singleton migrating to `first`, the shard home for [1]
+                    // arriving, and the "test" task's ExpectMsgAsync/Tell above completing -
+                    // at 5.6s; 20s leaves roughly 3.5x margin for slower/loaded CI machines
+                    // while still finishing well inside the phase's own 30s timeout.
+                    await csTaskDone.ExpectMsgAsync<Done>(Dilated(TimeSpan.FromSeconds(20)));
                 }, Config.Third);
 
-                EnterBarrier("after-shutdown");
+                await EnterBarrierAsync("after-shutdown");
 
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
                     _region.Value.Tell(2);
-                    ExpectMsg(2);
+                    await ExpectMsgAsync(2);
                     LastSender.Path.Address.HasLocalScope.Should().BeTrue();
                 }, Config.First);
 
-                EnterBarrier("after-1");
+                await EnterBarrierAsync("after-1");
             });
         }
     }


### PR DESCRIPTION
## What changes

Inside the coordinated-shutdown task that `ClusterShardingRegistrationCoordinatedShutdownSpec` arms on node `third`, the region ping is now sent from the spec's own test actor and awaited with `ExpectMsg(1)` on the spec, instead of through a `TestProbe`. One config line sets the before-cluster-shutdown phase timeout to 30 s. Nothing else moves.

## Why

This spec failed four times in two days on the Linux Artery lane (builds 131137, 131157, 131167, 131178), always the same three nodes, always at about 17 seconds. Node three's wait for the region echo missed its window by 581 ms. The other two nodes then failed the `after-shutdown` barrier because three never arrived.

The window was an accident of the port. The JVM spec sends from the spec's implicit sender and its `expectMsg` inherits the surrounding `within(30s)`. The .NET port used a `TestProbe`, which is its own TestKit instance with its own deadline, so the wait fell back to the flat 5 s `single-expect-default` while the spec still believed it had 30 s. The explicit `TestActor` sender is required, not a style choice: the task body runs on the thread pool, where the implicit sender is not set. The phase timeout line keeps the shutdown phase from stopping the region mid-wait if the task ever returns an incomplete task.

The event that takes 5.6 s is the shard coordinator moving from `second`, which is shutting down, to `first`. About 5 of those seconds are waste, and that is a product gap, the same in Pekko: a replicator that subscribes after a member is already `Leaving` is replayed `MemberLeft`, never `MemberUp`, so it never adds that member and drops the departing coordinator's state write as an unknown node. The coordinator then burns its full 5 s `updating-state-timeout`. A fix in the replicator's known-node check is coming as its own product PR; this PR does not touch it.

## How it was checked

`dotnet build src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode -c Release -warnaserror` clean. The spec run locally through the multi-node adapter on the classic transport: 3 of 3 passed. On Artery, with `AKKA_MNTR_TRANSPORT=artery`, the lane that failed on CI: 3 of 3 passed, twice.

## Second commit: the spec moves to the async TestKit API

Per the maintainer's rule that a touched test file migrates in the same PR: the fact is now `async Task`, and `Within`, `Join`, `AwaitAssert`, `RunOn`, `EnterBarrier`, `AwaitCondition`, and `ExpectMsg` all become their `Async` forms. The coordinated-shutdown task on node three is an async body now, which is safe only because the first commit set the before-cluster-shutdown phase timeout to 30 s; the comment says so. The `csTaskDone` probe wait carries an explicit 20 s bound, since a probe never inherits the spec's budget, with the measured 5.6 s handoff in the comment. A grep for the synchronous forms over the file returns nothing. Run after the migration: classic 3 of 3, Artery 3 of 3 twice.

## Third and fourth commits: what the adversarial review found

The region wait inside the shutdown task had no explicit bound. An unbounded `ExpectMsgAsync` on the spec resolves to whatever remains of the outer `WithinAsync` window when the task runs, clamped at zero, so on a slow enough agent it could end up shorter than the 5 s probe default it replaced. It is now bound explicitly at 30 s, the same value the config gives the before-cluster-shutdown phase, so it gets the same fresh window every run. The outer window rises from 30 s to 60 s so that it is a ceiling above the bounded waits it contains: 30 s for the region wait plus 20 s for the `csTaskDone` wait is 50 s, with 10 s for joins, barriers, and asserts, which measure at a couple of seconds locally. That sizes a ceiling, it does not widen a wait.

The fourth commit passes both explicit bounds undilated. `ExpectMsgAsync` dilates an explicit timeout itself, so wrapping the value in `Dilated` first would have scaled it twice at any time factor above 1.

Run after the change: classic 3 of 3 and Artery 3 of 3 after the third commit, classic 3 of 3 after the fourth. The grep for synchronous TestKit calls on the file returns nothing.

