### PR TITLE
TestKit: put the DotNetty batching override under akka.remote, where the transport reads it

### DIFF
--- a/src/core/Akka.TestKit.Tests/TestKit_Config_Tests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKit_Config_Tests.cs
@@ -80,5 +80,23 @@ namespace Akka.TestKit.Tests.Xunit2
             CallingThreadDispatcher.Id.ShouldBe("akka.test.calling-thread-dispatcher");
         }
     }
+
+    // ReSharper disable once InconsistentNaming
+    public class TestKitDefaultConfig_RemoteBatchingOverride_Tests
+    {
+        [Fact]
+        public void DotNetty_batching_override_should_resolve_under_akka_remote()
+        {
+            // The TestKit's Reference.conf disables DotNetty write batching to avoid
+            // flakiness in low-frequency Akka.Remote tests. Akka.Remote only reads this
+            // setting at akka.remote.dot-netty.tcp.batching.enabled -- DotNettyTransportSettings
+            // resolves it via config.GetConfig("batching") relative to akka.remote.dot-netty.tcp
+            // -- so the override has to live at that exact path or it silently never applies.
+            var config = TestKitBase.DefaultConfig;
+
+            config.HasPath("akka.remote.dot-netty.tcp.batching.enabled").ShouldBeTrue();
+            config.GetBoolean("akka.remote.dot-netty.tcp.batching.enabled").ShouldBeFalse();
+        }
+    }
 }
 

--- a/src/core/Akka.TestKit/Internal/Reference.conf
+++ b/src/core/Akka.TestKit/Internal/Reference.conf
@@ -44,8 +44,11 @@ akka {
       type = "Akka.TestKit.CallingThreadDispatcherConfigurator, Akka.TestKit"
       throughput = 2147483647
     }
-
-    # Disable batching in order to prevent flakiness with Akka.Remote tests (since they have low message frequency)
-    remote.dot-netty.tcp.batching.enabled = false
   }
+
+  # Disable batching in order to prevent flakiness with Akka.Remote tests (since they
+  # have low message frequency). This key must sit under akka.remote, not akka.test:
+  # DotNettyTransportSettings reads config.GetConfig("batching") relative to
+  # akka.remote.dot-netty.tcp.
+  remote.dot-netty.tcp.batching.enabled = false
 }


### PR DESCRIPTION
## What changes

The TestKit's own override that turns off DotNetty write batching for remoting tests moves from under `akka.test` to under `akka.remote`, where the transport reads it. A new config test loads the TestKit defaults and asserts the key is present and false. It failed before the move and passes after.

## Why

`Akka.TestKit/Internal/Reference.conf` set `remote.dot-netty.tcp.batching.enabled = false` inside the `akka.test { }` block, so it resolved to `akka.test.remote.dot-netty.tcp.batching.enabled`. `DotNettyTransportSettings` reads the batching block relative to `akka.remote.dot-netty.tcp`, so the override never took effect and batching has stayed on for every TestKit-based remoting test since the line was added. The comment on the line says it exists to prevent flakiness in low-frequency remote tests, which is the exact class of failure that surfaced this while analyzing `StreamRefsSpec`.

This is a test-infrastructure change, not a product behavior change, so it is not recorded in the 1.6 breaking-changes ledger. A downstream test suite that wants batching on can set the key back to `true` in its own config.

## How it was checked

`Akka.TestKit` builds with warnings as errors. `Akka.TestKit.Tests`: 332 passed, 1 skipped as before. `RemotingSpec` in `Akka.Remote.Tests`: 20 passed with batching now actually off.
