### PR TITLE
DistributedData: Replicator accepts writes from a member it first saw as Leaving or Exiting

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorKnownNodeSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorKnownNodeSpec.cs
@@ -1,0 +1,132 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ReplicatorKnownNodeSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster;
+using Akka.Configuration;
+using Akka.DistributedData.Internal;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.DistributedData.Tests
+{
+    /// <summary>
+    /// <para>
+    /// Covers a gap in <see cref="Replicator"/>'s cluster membership tracking: it subscribes to
+    /// cluster events with `InitialStateAsEvents`, and that replay reports each current member
+    /// at its CURRENT status. A replicator that starts after a member has already moved to
+    /// Leaving (or Exiting) therefore receives `MemberLeft`/`MemberExited` for it and never
+    /// `MemberUp`. Before the fix, that meant every `Write`/gossip message the member sent was
+    /// silently dropped by `IsKnownNode` as coming from an "unknown node" -- for as long as the
+    /// member stayed in the cluster. In cluster sharding, that can stall a departing shard
+    /// coordinator's ddata write for its whole `updating-state-timeout` during a rolling
+    /// restart or coordinated shutdown.
+    /// </para>
+    /// <para>
+    /// These specs reproduce the gap directly at the message level instead of racing a real
+    /// member leave: <see cref="_remoteSys"/> is its own single-node cluster that <see cref="AkkaSpec.Sys"/>
+    /// never joins, so Sys's own (real) cluster subscription never learns about it. We take a
+    /// real, valid <see cref="Member"/> from that foreign cluster, move it to the status we
+    /// want with the public <see cref="Member.Copy"/>, and hand it to a freshly created
+    /// replicator as the member event a late subscriber would have received -- deterministically,
+    /// with no timing race.
+    /// </para>
+    /// </summary>
+    public class ReplicatorKnownNodeSpec : AkkaSpec
+    {
+        public static readonly Config SpecConfig = ConfigurationFactory.ParseString(@"
+                akka.loglevel = INFO
+                akka.actor.provider = cluster
+                akka.remote.dot-netty.tcp.port = 0")
+            .WithFallback(DistributedData.DefaultConfig());
+
+        private readonly ActorSystem _remoteSys;
+
+        public ReplicatorKnownNodeSpec(ITestOutputHelper output) : base(SpecConfig, output)
+        {
+            _remoteSys = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+        }
+
+        private async Task<Member> SelfJoinAndGetUpMemberAsync(ActorSystem system)
+        {
+            var cluster = Cluster.Cluster.Get(system);
+            cluster.Join(cluster.SelfAddress);
+            await AwaitAssertAsync(() => cluster.SelfMember.Status.Should().Be(MemberStatus.Up));
+            return cluster.SelfMember;
+        }
+
+        [Fact(DisplayName = "Replicator should accept a Write from a member it first saw as Leaving")]
+        public async Task Should_accept_write_from_member_first_seen_as_Leaving()
+        {
+            await SelfJoinAndGetUpMemberAsync(Sys);
+            var remoteUp = await SelfJoinAndGetUpMemberAsync(_remoteSys);
+            var leavingMember = remoteUp.Copy(MemberStatus.Leaving);
+
+            var replicator = Sys.ActorOf(Replicator.Props(ReplicatorSettings.Create(Sys)));
+
+            // Simulates what a replicator subscribing after the member already left would get on
+            // InitialStateAsEvents replay: MemberLeft, never MemberUp.
+            replicator.Tell(new ClusterEvent.MemberLeft(leavingMember));
+
+            var probe = CreateTestProbe();
+            var envelope = new DataEnvelope(GCounter.Empty.Increment(leavingMember.UniqueAddress));
+            replicator.Tell(new Write("known-node-leaving", envelope, leavingMember.UniqueAddress), probe.Ref);
+
+            // Before the fix this write is dropped as coming from an "unknown node" and no reply
+            // is ever sent, so this would time out.
+            await probe.ExpectMsgAsync<WriteAck>(TimeSpan.FromSeconds(3));
+        }
+
+        [Fact(DisplayName = "Replicator should accept a Write from a member it first saw as Exiting")]
+        public async Task Should_accept_write_from_member_first_seen_as_Exiting()
+        {
+            await SelfJoinAndGetUpMemberAsync(Sys);
+            var remoteUp = await SelfJoinAndGetUpMemberAsync(_remoteSys);
+            var exitingMember = remoteUp.Copy(MemberStatus.Leaving).Copy(MemberStatus.Exiting);
+
+            var replicator = Sys.ActorOf(Replicator.Props(ReplicatorSettings.Create(Sys)));
+
+            // MemberExited routes to ReceiveMemberExiting, a different handler than the generic
+            // member-event path MemberLeft/MemberDowned use above, so this exercises that path
+            // separately.
+            replicator.Tell(new ClusterEvent.MemberExited(exitingMember));
+
+            var probe = CreateTestProbe();
+            var envelope = new DataEnvelope(GCounter.Empty.Increment(exitingMember.UniqueAddress));
+            replicator.Tell(new Write("known-node-exiting", envelope, exitingMember.UniqueAddress), probe.Ref);
+
+            await probe.ExpectMsgAsync<WriteAck>(TimeSpan.FromSeconds(3));
+        }
+
+        [Fact(DisplayName = "Replicator should still ignore a Write from a node it has never seen in any member event")]
+        public async Task Should_ignore_write_from_node_never_seen()
+        {
+            await SelfJoinAndGetUpMemberAsync(Sys);
+            var strangerUp = await SelfJoinAndGetUpMemberAsync(_remoteSys);
+
+            var replicator = Sys.ActorOf(Replicator.Props(ReplicatorSettings.Create(Sys)));
+
+            // No member event at all is sent about `strangerUp` this time. This proves the fix
+            // does not turn IsKnownNode into an open gate -- a node this replicator has never
+            // observed in any status is still rejected.
+            var probe = CreateTestProbe();
+            var envelope = new DataEnvelope(GCounter.Empty.Increment(strangerUp.UniqueAddress));
+            replicator.Tell(new Write("known-node-stranger", envelope, strangerUp.UniqueAddress), probe.Ref);
+
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+        }
+
+        protected override void AfterAll()
+        {
+            base.AfterAll();
+            Shutdown(_remoteSys);
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorKnownNodeSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorKnownNodeSpec.cs
@@ -51,7 +51,11 @@ namespace Akka.DistributedData.Tests
 
         public ReplicatorKnownNodeSpec(ITestOutputHelper output) : base(SpecConfig, output)
         {
-            _remoteSys = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+            // A distinct name is safe here, not just cosmetic for log readability: _remoteSys
+            // self-joins its own single-node cluster and Sys is never told to join it (see the
+            // class doc above), so nothing in this spec depends on the two systems sharing a
+            // name the way a real cluster join would.
+            _remoteSys = ActorSystem.Create(Sys.Name + "-peer", Sys.Settings.Config);
         }
 
         private async Task<Member> SelfJoinAndGetUpMemberAsync(ActorSystem system)
@@ -65,68 +69,89 @@ namespace Akka.DistributedData.Tests
         [Fact(DisplayName = "Replicator should accept a Write from a member it first saw as Leaving")]
         public async Task Should_accept_write_from_member_first_seen_as_Leaving()
         {
-            await SelfJoinAndGetUpMemberAsync(Sys);
-            var remoteUp = await SelfJoinAndGetUpMemberAsync(_remoteSys);
-            var leavingMember = remoteUp.Copy(MemberStatus.Leaving);
+            // Each fact owns its peer system and shuts it down here, asynchronously, on
+            // success or failure. The TestKit's sync AfterAll would pin a thread pool
+            // thread for the whole wait, and a DisposeAsync on this class would collide
+            // with the async dispose chain the TestKit is gaining in #8545.
+            try
+            {
+                await SelfJoinAndGetUpMemberAsync(Sys);
+                var remoteUp = await SelfJoinAndGetUpMemberAsync(_remoteSys);
+                var leavingMember = remoteUp.Copy(MemberStatus.Leaving);
 
-            var replicator = Sys.ActorOf(Replicator.Props(ReplicatorSettings.Create(Sys)));
+                var replicator = Sys.ActorOf(Replicator.Props(ReplicatorSettings.Create(Sys)));
 
-            // Simulates what a replicator subscribing after the member already left would get on
-            // InitialStateAsEvents replay: MemberLeft, never MemberUp.
-            replicator.Tell(new ClusterEvent.MemberLeft(leavingMember));
+                // Simulates what a replicator subscribing after the member already left would get on
+                // InitialStateAsEvents replay: MemberLeft, never MemberUp.
+                replicator.Tell(new ClusterEvent.MemberLeft(leavingMember));
 
-            var probe = CreateTestProbe();
-            var envelope = new DataEnvelope(GCounter.Empty.Increment(leavingMember.UniqueAddress));
-            replicator.Tell(new Write("known-node-leaving", envelope, leavingMember.UniqueAddress), probe.Ref);
+                var probe = CreateTestProbe();
+                var envelope = new DataEnvelope(GCounter.Empty.Increment(leavingMember.UniqueAddress));
+                replicator.Tell(new Write("known-node-leaving", envelope, leavingMember.UniqueAddress), probe.Ref);
 
-            // Before the fix this write is dropped as coming from an "unknown node" and no reply
-            // is ever sent, so this would time out.
-            await probe.ExpectMsgAsync<WriteAck>(TimeSpan.FromSeconds(3));
+                // Before the fix this write is dropped as coming from an "unknown node" and no reply
+                // is ever sent, so this would time out.
+                await probe.ExpectMsgAsync<WriteAck>(TimeSpan.FromSeconds(3));
+            }
+            finally
+            {
+                await ShutdownAsync(_remoteSys);
+            }
         }
 
         [Fact(DisplayName = "Replicator should accept a Write from a member it first saw as Exiting")]
         public async Task Should_accept_write_from_member_first_seen_as_Exiting()
         {
-            await SelfJoinAndGetUpMemberAsync(Sys);
-            var remoteUp = await SelfJoinAndGetUpMemberAsync(_remoteSys);
-            var exitingMember = remoteUp.Copy(MemberStatus.Leaving).Copy(MemberStatus.Exiting);
+            // The peer system is shut down per fact; see the first fact for why.
+            try
+            {
+                await SelfJoinAndGetUpMemberAsync(Sys);
+                var remoteUp = await SelfJoinAndGetUpMemberAsync(_remoteSys);
+                var exitingMember = remoteUp.Copy(MemberStatus.Leaving).Copy(MemberStatus.Exiting);
 
-            var replicator = Sys.ActorOf(Replicator.Props(ReplicatorSettings.Create(Sys)));
+                var replicator = Sys.ActorOf(Replicator.Props(ReplicatorSettings.Create(Sys)));
 
-            // MemberExited routes to ReceiveMemberExiting, a different handler than the generic
-            // member-event path MemberLeft/MemberDowned use above, so this exercises that path
-            // separately.
-            replicator.Tell(new ClusterEvent.MemberExited(exitingMember));
+                // MemberExited routes to ReceiveMemberExiting, a different handler than the generic
+                // member-event path MemberLeft/MemberDowned use above, so this exercises that path
+                // separately.
+                replicator.Tell(new ClusterEvent.MemberExited(exitingMember));
 
-            var probe = CreateTestProbe();
-            var envelope = new DataEnvelope(GCounter.Empty.Increment(exitingMember.UniqueAddress));
-            replicator.Tell(new Write("known-node-exiting", envelope, exitingMember.UniqueAddress), probe.Ref);
+                var probe = CreateTestProbe();
+                var envelope = new DataEnvelope(GCounter.Empty.Increment(exitingMember.UniqueAddress));
+                replicator.Tell(new Write("known-node-exiting", envelope, exitingMember.UniqueAddress), probe.Ref);
 
-            await probe.ExpectMsgAsync<WriteAck>(TimeSpan.FromSeconds(3));
+                await probe.ExpectMsgAsync<WriteAck>(TimeSpan.FromSeconds(3));
+            }
+            finally
+            {
+                await ShutdownAsync(_remoteSys);
+            }
         }
 
         [Fact(DisplayName = "Replicator should still ignore a Write from a node it has never seen in any member event")]
         public async Task Should_ignore_write_from_node_never_seen()
         {
-            await SelfJoinAndGetUpMemberAsync(Sys);
-            var strangerUp = await SelfJoinAndGetUpMemberAsync(_remoteSys);
+            // The peer system is shut down per fact; see the first fact for why.
+            try
+            {
+                await SelfJoinAndGetUpMemberAsync(Sys);
+                var strangerUp = await SelfJoinAndGetUpMemberAsync(_remoteSys);
 
-            var replicator = Sys.ActorOf(Replicator.Props(ReplicatorSettings.Create(Sys)));
+                var replicator = Sys.ActorOf(Replicator.Props(ReplicatorSettings.Create(Sys)));
 
-            // No member event at all is sent about `strangerUp` this time. This proves the fix
-            // does not turn IsKnownNode into an open gate -- a node this replicator has never
-            // observed in any status is still rejected.
-            var probe = CreateTestProbe();
-            var envelope = new DataEnvelope(GCounter.Empty.Increment(strangerUp.UniqueAddress));
-            replicator.Tell(new Write("known-node-stranger", envelope, strangerUp.UniqueAddress), probe.Ref);
+                // No member event at all is sent about `strangerUp` this time. This proves the fix
+                // does not turn IsKnownNode into an open gate -- a node this replicator has never
+                // observed in any status is still rejected.
+                var probe = CreateTestProbe();
+                var envelope = new DataEnvelope(GCounter.Empty.Increment(strangerUp.UniqueAddress));
+                replicator.Tell(new Write("known-node-stranger", envelope, strangerUp.UniqueAddress), probe.Ref);
 
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
-        }
-
-        protected override void AfterAll()
-        {
-            base.AfterAll();
-            Shutdown(_remoteSys);
+                await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            }
+            finally
+            {
+                await ShutdownAsync(_remoteSys);
+            }
         }
     }
 }

--- a/src/contrib/cluster/Akka.DistributedData/Replicator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Replicator.cs
@@ -314,13 +314,28 @@ namespace Akka.DistributedData
         private ImmutableDictionary<UniqueAddress, long> _removedNodes = ImmutableDictionary<UniqueAddress, long>.Empty;
 
         /// <summary>
+        /// Every member address this replicator has seen in a member event, no matter what status
+        /// that event carried. Used only by <see cref="IsKnownNode"/>.
+        ///
+        /// We subscribe to cluster events with `InitialStateAsEvents`, which replays each current
+        /// member at its CURRENT status. If this replicator starts after a member has already
+        /// moved to Leaving or Down, it gets `MemberLeft`/`MemberDowned` for that member and never
+        /// `MemberUp`, so the member would never land in <see cref="_nodes"/>. Without this set,
+        /// `IsKnownNode` would then treat that member as unknown to the cluster and drop every
+        /// `Write` and gossip message it sends, which can stall things like a shard coordinator
+        /// hand-off during a rolling restart.
+        /// </summary>
+        private ImmutableHashSet<Address> _seenNodes = ImmutableHashSet<Address>.Empty;
+
+        /// <summary>
         /// All nodes sorted with the leader first
         /// </summary>
         private ImmutableSortedSet<Member> _leader = ImmutableSortedSet<Member>.Empty.WithComparer(Member.LeaderStatusOrdering);
         private bool IsLeader => !_leader.IsEmpty && _leader.First().Address == _selfAddress;
 
         private bool IsKnownNode(Address node) => _nodes.Contains(node) || _weaklyUpNodes.Contains(node) ||
-                                                  _joiningNodes.Contains(node) || _selfAddress == node;
+                                                  _joiningNodes.Contains(node) || _exitingNodes.Contains(node) ||
+                                                  _seenNodes.Contains(node) || _selfAddress == node;
 
         /// <summary>
         /// For pruning timeouts are based on clock that is only increased when all nodes are reachable.
@@ -1339,6 +1354,7 @@ namespace Akka.DistributedData
                 _weaklyUpNodes = _weaklyUpNodes.Remove(m.Address);
                 _joiningNodes = _joiningNodes.Remove(m.Address);
                 _exitingNodes = _exitingNodes.Remove(m.Address);
+                _seenNodes = _seenNodes.Remove(m.Address);
 
                 _removedNodes = _removedNodes.SetItem(m.UniqueAddress, _allReachableClockTime);
                 _unreachable = _unreachable.Remove(m.Address);
@@ -1362,6 +1378,13 @@ namespace Akka.DistributedData
         {
             if (MatchingRole(m))
             {
+                // This handles MemberLeft, MemberDowned, and any other member status that does not
+                // have its own case above. Record the address here too, so a Write or gossip
+                // message from this member is not mistaken for one from a node outside the
+                // cluster. See the comment on _seenNodes for why this matters.
+                if (m.Address != _selfAddress)
+                    _seenNodes = _seenNodes.Add(m.Address);
+
                 // replace, it's possible that the ordering is changed since it based on MemberStatus
                 _leader = _leader.Where(x => x.UniqueAddress != m.UniqueAddress)
                     .ToImmutableSortedSet(Member.LeaderStatusOrdering);


### PR DESCRIPTION
## What changes

`Replicator.IsKnownNode` now also accepts a member the replicator has seen in any membership state and a member in its exiting set. Before, it accepted only members it had seen reach `Up`, `WeaklyUp`, or `Joining`, plus itself.

## Why

The replicator subscribes to cluster events with `InitialStateAsEvents`, which replays each member at its current status. A replicator that starts after a member has already reached `Leaving` receives `MemberLeft` and never `MemberUp`. Only `MemberUp` added a member to the known set, so every `Write`, `Read`, and `DeltaPropagation` that member sent was dropped as an unknown node for as long as it stayed in the cluster. A delete is a `Write` of a tombstone, so deletes were dropped too. Gossip and status messages were not affected: they are gated on the destination system uid and never reach this check.

Cluster sharding hits this during a coordinated shutdown. When the oldest node leaves, the departing shard coordinator writes its final state through the replicator on the next-oldest node. If that replicator started while the oldest node was already leaving, it drops the write, and the coordinator burns its full 5 s `updating-state-timeout` before the singleton hands over. That was 5.0 of the 5.6 seconds `ClusterShardingRegistrationCoordinatedShutdownSpec` waited on the Artery lane, where it failed four times in two days. Pekko has the same gap. The test-side fix for that spec is #8544; this PR removes the waste itself.

Quorum and majority sizing are untouched. `IsKnownNode` has one call site, the inbound gate, and every majority reads the up, exiting, and age-ordered sets directly. This is a bug fix that restores intended behavior, so it is not recorded in the 1.6 breaking-changes ledger.

## How it was checked

`Akka.DistributedData` builds with warnings as errors. `Akka.DistributedData.Tests`: 193 passed, 1 skipped as before. `Akka.API.Tests`: 18 passed, no approval change; the new state is private. The new `ReplicatorKnownNodeSpec` has three cases: a write from a member first seen as `Leaving` is accepted, a write from a member first seen as `Exiting` is accepted, and a write from an address never seen in any member event is still rejected. The first two fail on the old code with the exact "Ignoring message [Write] ... unknown node" log line.

## Second commit: the spec's teardown

From the adversarial review: the spec shut its peer system down with a blocking call in `AfterAll`, and named it the same as the test system. Each fact now shuts the peer down with `ShutdownAsync` in a `finally` block, so teardown runs on success or failure without pinning a thread. The class deliberately declares no `DisposeAsync`, because the TestKit gains an async dispose chain in #8545 and a bare method of that name on a derived class would then hide it and fail the build with warnings as errors. The peer is named with a `-peer` suffix; it self-joins its own cluster and the test system never joins it, so nothing depends on the names matching. Run three times: 3 passed each time.
