### PR TITLE
Build: bump Microsoft.SourceLink.GitHub to 10.0.303 (v1.5 backport, CVE-2026-62900)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -91,7 +91,7 @@ To see the full set of changes in Akka.NET v1.5.71, [click here](https://github.
   </ItemGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.303" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\docs\images\akkalogo.png" Pack="true" Visible="false" PackagePath="\" />


### PR DESCRIPTION
## Summary

Backport of #8535 to the `v1.5` maintenance branch.

GitHub advisory [GHSA-23fw-v26w-5fgq](https://github.com/advisories/GHSA-23fw-v26w-5fgq) (CVE-2026-62900, published 2026-09-08) marks `Microsoft.Build.Tasks.Git` 8.0.0 / 10.0.0-10.0.302 as vulnerable. Every project inherits it through the `Microsoft.SourceLink.GitHub` reference in `Directory.Build.props`. NuGet audit raises NU1902, and `TreatWarningsAsErrors` turns that into a restore failure on every affected machine.

The 8.0.0 band has **no patched 8.x** version, so this jumps straight to 10.0.303.

## Fix

Bump `Microsoft.SourceLink.GitHub` from 8.0.0 to 10.0.303 in `Directory.Build.props`. One line. SourceLink output is unchanged.

## Verified

Local Release build of `src/core/Akka/Akka.csproj` on this branch restored and built cleanly with 0 errors and no NU1902 (targets net6.0 and netstandard2.0 on v1.5).