### PR TITLE
De-flake NodeChurnSpec: turn off legacy auto-down, widen the heartbeat pause over the measured stall, and make the payload listener match real log messages

### DIFF
--- a/src/core/Akka.Cluster.Tests.MultiNode/NodeChurnSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/NodeChurnSpec.cs
@@ -46,21 +46,33 @@ namespace Akka.Cluster.Tests.MultiNode
                   # unreachable or terminated (ClusterDaemon.cs:2345-2348 with
                   # MembershipState.RemoveUnreachableWithMemberStatus), which needs only the failure
                   # detector.
+                  #
+                  # Pekko's NodeChurnSpec keeps auto-down-unreachable-after = 1s; this port turns it
+                  # off on purpose, not by omission. Legacy auto-down is a second, uncoordinated
+                  # downing path with no quorum logic of its own, so leaving it on here would race the
+                  # explicit Leave/Down calls above with an independent auto-down decision. With it
+                  # off, the widened acceptable-heartbeat-pause below is the only guard against the
+                  # measured 5.628s heartbeat stall - there is no second downing path left to catch
+                  # what it misses.
                   akka.cluster.auto-down-unreachable-after = off
 
-                  # Second guard on the same event. MultiNodeClusterSpec.ClusterConfig() sets
-                  # heartbeat-interval = 500ms but leaves acceptable-heartbeat-pause at the 3s default
-                  # (Cluster.conf:219), and akka.test.timefactor does not dilate failure-detector
-                  # settings. Measured: a transient-system teardown produced a 5.628s heartbeat gap,
-                  # and detection fired 3.971s after the last heartbeat. 10s moves detection to about
-                  # 10.97s, a margin of 5.34s over the worst gap observed. This is a stopgap for a
-                  # product-side blocking wait in the scheduler shutdown path; it can come back down
-                  # once issue #8549 is addressed.
+                  # Only guard against that stall now that auto-down above is off.
+                  # MultiNodeClusterSpec.ClusterConfig() sets heartbeat-interval = 500ms but leaves
+                  # acceptable-heartbeat-pause at the 3s default (Cluster.conf:219), and
+                  # akka.test.timefactor does not dilate failure-detector settings. Measured: a
+                  # transient-system teardown produced a 5.628s heartbeat gap, and detection fired
+                  # 3.971s after the last heartbeat. 10s moves detection to about 10.97s, a margin of
+                  # 5.34s over the worst gap observed. This is a stopgap for a product-side blocking
+                  # wait in the scheduler shutdown path; it can come back down once issue #8549 is
+                  # addressed.
                   akka.cluster.failure-detector.acceptable-heartbeat-pause = 10s
 
-                  # Without this, tombstones never prune inside a 5-round run (Cluster.conf:151
-                  # defaults to 24h) and the payload growth this spec looks for cannot appear. Matches
-                  # Pekko.
+                  # This spec asserts the ABSENCE of gossip-payload growth (ExpectNoMsgAsync after
+                  # each round, driven by the LogListener below). Without this setting, tombstones for
+                  # removed members never prune inside a 5-round run (Cluster.conf:151 defaults to
+                  # 24h), so their vector-clock entries keep accumulating and a working payload
+                  # listener would eventually fire and fail the test. Pruning at 1s is what lets the
+                  # no-growth assertion hold across all five rounds. Matches Pekko.
                   akka.cluster.prune-gossip-tombstones-after = 1s
                   akka.remote.log-frame-size-exceeding = 2000b
                   akka.remote.dot-netty.tcp.batching.enabled = false # disable batching
@@ -86,11 +98,23 @@ namespace Akka.Cluster.Tests.MultiNode
                 // [.../cluster/core/daemon] to [/user/logListener]" - and the ExpectNoMsg assertions
                 // this spec exists for could never fail.
                 // RemoteMetricsSpec.cs:118 already uses the correct form.
+                //
+                // The prefix must be built from the .NET type, not carried over from the JVM class
+                // name. RemoteMetricsExtension.cs:109 logs type.FullName, and GossipEnvelope
+                // (Akka.Cluster, internal - Akka.Cluster has InternalsVisibleTo this assembly) is
+                // "Akka.Cluster.GossipEnvelope", not "akka.cluster.GossipEnvelope". String.StartsWith
+                // is case-sensitive, so a literal JVM-cased prefix never matches and this listener
+                // could never forward anything, leaving the payload assertions below unable to fail
+                // either.
+                //
+                // Under Artery there is no RemoteMetricsExtension at all (issue #8555), so this
+                // listener - and the payload-growth assertions it feeds - cannot fire on the Artery
+                // lane regardless of this fix. Only the classic (DotNetty) transport exercises them.
+                var payloadSizePrefix = "New maximum payload size for [" + typeof(GossipEnvelope).FullName + "]";
                 Receive<Info>(info =>
                 {
                     var text = info.Message?.ToString();
-                    if (text is not null &&
-                        text.StartsWith("New maximum payload size for [akka.cluster.GossipEnvelope]"))
+                    if (text is not null && text.StartsWith(payloadSizePrefix))
                     {
                         _testActor.Tell(text);
                     }
@@ -186,7 +210,14 @@ namespace Akka.Cluster.Tests.MultiNode
                 // AFTER the awaited task completes and nobody waits for it. Awaiting one system at a
                 // time therefore leaves that system's blocking scheduler shutdown overlapping the next
                 // one anyway. Sequential teardown moves none of it.
-                await Task.WhenAll(systems.Select(s => s.Terminate())).WaitAsync(30.Seconds());
+                // 20s, not 30s: the barrier immediately below has its own 30s timeout
+                // (Akka.Remote.TestKit/Internals/Reference.conf:13, barrier-timeout), and that clock
+                // arms at the first node's arrival, not at the last (BarrierCoordinator.cs:570-578). A
+                // 30s teardown budget equal to the barrier's own 30s timeout would leave zero skew
+                // margin between a node that finishes teardown quickly and a peer that uses its full
+                // budget - the slow peer would hit the barrier timeout at the same instant it arrives.
+                // 20s keeps 10s of margin before the barrier's own deadline.
+                await Task.WhenAll(systems.Select(s => s.Terminate())).WaitAsync(20.Seconds());
 
                 // Pekko has enterBarrier("end-round-" + n) here; the .NET port never did (checked back
                 // to the original port, 1c1ced42a). Without it, a node that finishes teardown early

--- a/src/core/Akka.Cluster.Tests.MultiNode/NodeChurnSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/NodeChurnSpec.cs
@@ -33,8 +33,35 @@ namespace Akka.Cluster.Tests.MultiNode
 
             CommonConfig = DebugConfig(false)
                 .WithFallback(ConfigurationFactory.ParseString(@"
-                  akka.cluster.auto-down-unreachable-after = 1s
                   akka.cluster.run-coordinated-shutdown-when-down = on
+                  # MultiNodeSpec.BaseConfig sets cluster.downing-provider-class to empty
+                  # (MultiNodeSpec.cs:420), so ANY value here selects the legacy AutoDowning provider
+                  # (ClusterSettings.cs:95-103), not the keep-majority SBR that Cluster.cs:128-130
+                  # promises in its warning. AutoDowning has no quorum logic: both sides of a
+                  # partition down each other and neither heals.
+                  #
+                  # This spec does not need a downing provider. It removes every transient member with
+                  # an explicit Leave (odd rounds) or Down (even rounds) and waits for the removal in
+                  # AwaitRemovedAsync. The leader removes a Down or Exiting member as soon as it is
+                  # unreachable or terminated (ClusterDaemon.cs:2345-2348 with
+                  # MembershipState.RemoveUnreachableWithMemberStatus), which needs only the failure
+                  # detector.
+                  akka.cluster.auto-down-unreachable-after = off
+
+                  # Second guard on the same event. MultiNodeClusterSpec.ClusterConfig() sets
+                  # heartbeat-interval = 500ms but leaves acceptable-heartbeat-pause at the 3s default
+                  # (Cluster.conf:219), and akka.test.timefactor does not dilate failure-detector
+                  # settings. Measured: a transient-system teardown produced a 5.628s heartbeat gap,
+                  # and detection fired 3.971s after the last heartbeat. 10s moves detection to about
+                  # 10.97s, a margin of 5.34s over the worst gap observed. This is a stopgap for a
+                  # product-side blocking wait in the scheduler shutdown path; it can come back down
+                  # once issue #8549 is addressed.
+                  akka.cluster.failure-detector.acceptable-heartbeat-pause = 10s
+
+                  # Without this, tombstones never prune inside a 5-round run (Cluster.conf:151
+                  # defaults to 24h) and the payload growth this spec looks for cannot appear. Matches
+                  # Pekko.
+                  akka.cluster.prune-gossip-tombstones-after = 1s
                   akka.remote.log-frame-size-exceeding = 2000b
                   akka.remote.dot-netty.tcp.batching.enabled = false # disable batching
                 "))
@@ -52,11 +79,20 @@ namespace Akka.Cluster.Tests.MultiNode
             {
                 _testActor = testActor;
 
-                Receive<Info>(info => info.Message is string, info =>
+                // info.Message is a LogMessage, never a string. RemoteMetricsExtension.cs:109 logs a
+                // format plus two arguments, and ILoggingAdapter.cs:56-61 wraps that in
+                // LogMessage<LogValues<T1, T2>>. The old `info.Message is string` guard never matched,
+                // so every Info went unhandled - visible in CI as "DeadLetter from
+                // [.../cluster/core/daemon] to [/user/logListener]" - and the ExpectNoMsg assertions
+                // this spec exists for could never fail.
+                // RemoteMetricsSpec.cs:118 already uses the correct form.
+                Receive<Info>(info =>
                 {
-                    if (((string)info.Message).StartsWith("New maximum payload size for [akka.cluster.GossipEnvelope]"))
+                    var text = info.Message?.ToString();
+                    if (text is not null &&
+                        text.StartsWith("New maximum payload size for [akka.cluster.GossipEnvelope]"))
                     {
-                        _testActor.Tell(info.Message);
+                        _testActor.Tell(text);
                     }
                 });
             }
@@ -135,16 +171,27 @@ namespace Akka.Cluster.Tests.MultiNode
                 await AwaitRemovedAsync(systems, n);
                 await EnterBarrierAsync("members-removed-" + n);
 
-                // Terminate the transient systems asynchronously and concurrently. The old
-                // synchronous Shutdown(node, verifySystemShutdown:true) helper blocked a
-                // thread-pool thread inside Task.Wait() for up to its 5s budget while the
-                // coordinated-shutdown pipeline itself needs the thread pool to make progress —
-                // a sync-over-async self-starvation that produced the intermittent
-                // "Failed to stop [NodeChurnSpec] within [00:00:05]" failures on slower CI agents.
-                // Awaiting Terminate() frees the thread; WaitAsync preserves the verify-shutdown
-                // semantics by throwing TimeoutException if a system fails to stop in time.
-                // (Same idiom as QuickRestartSpec / DistributedPubSubRestartSpec.)
+                // Terminate the transient systems asynchronously and concurrently. #8286 replaced the
+                // synchronous Shutdown(node, verifySystemShutdown:true) helper, which pinned a
+                // thread-pool thread inside Task.Wait(); awaiting Terminate() frees that thread and
+                // WaitAsync keeps the verify-shutdown semantics by throwing TimeoutException if a
+                // system fails to stop in time.
+                //
+                // Do NOT change this to a sequential `foreach (var s in systems) await s.Terminate();`.
+                // It looks like it would halve the teardown concurrency and it does not. Under
+                // MultiNodeSpec.BaseConfig, Terminate() calls FinalTerminate() directly
+                // (coordinated-shutdown.run-by-actor-system-terminate = off, MultiNodeSpec.cs:406), and
+                // the task it returns is the LAST-registered termination callback, not the last one to
+                // run (ActorSystemImpl.cs:554, 653-700). StopScheduler was registered first, so it runs
+                // AFTER the awaited task completes and nobody waits for it. Awaiting one system at a
+                // time therefore leaves that system's blocking scheduler shutdown overlapping the next
+                // one anyway. Sequential teardown moves none of it.
                 await Task.WhenAll(systems.Select(s => s.Terminate())).WaitAsync(30.Seconds());
+
+                // Pekko has enterBarrier("end-round-" + n) here; the .NET port never did (checked back
+                // to the original port, 1c1ced42a). Without it, a node that finishes teardown early
+                // starts creating two fresh ActorSystems while its peers still hold two dying ones.
+                await EnterBarrierAsync("end-round-" + n);
 
                 Log.Info("end of round-" + n);
                 // log listener will send to testActor if payload size exceed configured log-frame-size-exceeding


### PR DESCRIPTION
## What changes

Test-side only, in `NodeChurnSpec.cs`:

- **Legacy auto-down is off.** The multi-node base config empties `downing-provider-class`, so the spec's `auto-down-unreachable-after = 1s` was selecting the legacy `AutoDowning` provider, which has no quorum logic. The spec does not need a downing provider: it retires every transient member with an explicit Leave or Down, and the leader removes a Down or Exiting member as soon as it is unreachable.
- **The heartbeat pause rises from 3 s to 10 s.** The measured stall was 5.628 s and detection fired at 3.971 s, so 10 s leaves a 5.34 s margin over what was observed. The comment says plainly that this covers a product-side wait until issue #8549 is addressed.
- **Gossip tombstones prune after 1 s**, matching Pekko, so the payload growth the spec looks for can appear inside a five-round run.
- **The payload listener now matches real log messages.** Two defects kept it silent. It compared `info.Message is string`, but a parameterized log message is never a string. And it looked for the JVM type name `akka.cluster.GossipEnvelope`, while the metrics extension logs the .NET name `Akka.Cluster.GossipEnvelope`; the comparison is case sensitive. The prefix is now built from the type. The spec's payload assertions could never fail for as long as the listener has existed.
- **Pekko's end-of-round barrier** is added after each round's teardown, and `Task.WhenAll` over the transient terminations stays, with a corrected comment explaining why sequential termination would change nothing.

No thread pool or dispatcher setting changes.

## Why

Build 131192 (Windows Artery). During the round-one teardown, node three's main system sent no heartbeat for 5.628 s while it terminated two transient ActorSystems in the same process. Peers marked it unreachable 3.971 s after its last heartbeat, legacy auto-down downed it a second later, and the leader removed it. Node three woke 0.551 s after that removal and downed nodes one and two in return. The cluster split 8 plus 1 for good, and round two waited 25 s for nine members. StressSpec's keep-majority resolver survived the same stall a day earlier; this spec, on legacy auto-down, could not.

The stall itself is a product wait, not teardown work. The teardown took about a second. The rest is the scheduler's `Dispose` blocking a pool thread for up to its 5 s shutdown timeout waiting on a stop signal that only a pool continuation can deliver, and every scheduler in the process ticks on that same pool. Three separate node processes measured that tail at 5.470, 5.506, and 5.504 s. That mechanism is recorded on #8549.

Two more findings from the analysis are filed rather than fixed here: Artery has no payload-size metrics at all, so this spec's assertion stays inert on the Artery lane even with the listener fixed (#8555), and `ActorSystem.Terminate()` completes before all its termination callbacks have run (noted on #8549).

## How it was checked

`dotnet build src/core/Akka.Cluster.Tests.MultiNode -c Release -warnaserror` clean. The spec run locally through the multi-node adapter: classic transport, 3 of 3 nodes passed in 58 s; Artery, 3 of 3 passed in 58 s, all five rounds through their barriers with no unreachability on a live member.

## Second commit: what the adversarial review found

The first commit fixed only the `is string` half of the listener and left the JVM-cased type name, so the listener still never matched and the six runs in the first commit proved nothing about payload growth. The second commit builds the prefix from the .NET type. It also corrects the tombstone comment, which had the reasoning backwards: the spec asserts the absence of growth, and the 1 s prune is what lets that hold for five rounds. It states that Pekko keeps auto-down at 1 s and this port turns it off on purpose, and that with it off the widened heartbeat pause is the only guard. The teardown budget drops from 30 s to 20 s so it sits under the 30 s barrier that follows it. And it notes that the Artery lane has no metrics extension (#8555), so the payload assertion is inert there.

The spec now discriminates, checked both ways at the shipped 2000 byte threshold:

- With `prune-gossip-tombstones-after = 1s`, the committed value: classic 3 of 3 runs passed (53 to 58 s), Artery 3 of 3 passed (56 to 57 s). No gossip envelope crossed 2000 bytes.
- With the prune set back to its 24 h default and nothing else changed: the envelope grew from 2213 to 2337 bytes over the rounds, the listener forwarded each new maximum, and node one failed the round assertion with "Expected no messages during 00:00:02, instead we received New maximum payload size for [Akka.Cluster.GossipEnvelope] is [2216] bytes".

So the listener fix and the tombstone setting are each verified by the other. Before this PR the assertion could not fail under any setting.
