### PR TITLE
De-flake ClusterShardingLeaseSpec: join the cluster in InitializeAsync instead of blocking a pool worker in the constructor

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeaseSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.Tools.Singleton;
@@ -18,7 +19,7 @@ using Xunit;
 
 namespace Akka.Cluster.Sharding.Tests
 {
-    public class ClusterShardingLeaseSpec : AkkaSpec
+    public class ClusterShardingLeaseSpec : AkkaSpec, IAsyncLifetime
     {
         private sealed class MessageExtractor: IMessageExtractor
         {
@@ -75,10 +76,11 @@ namespace Akka.Cluster.Sharding.Tests
                 .WithFallback(ClusterSingleton.DefaultConfig())
                 .WithFallback(TestLease.Configuration);
 
-        TimeSpan shortDuration = TimeSpan.FromMilliseconds(200);
-        Cluster cluster;
-        string leaseOwner;
-        TestLeaseExt testLeaseExt;
+        readonly TimeSpan shortDuration = TimeSpan.FromMilliseconds(200);
+        readonly Cluster cluster;
+        readonly string leaseOwner;
+        readonly TestLeaseExt testLeaseExt;
+        readonly bool rememberEntities;
 
         const string typeName = "echo";
         IActorRef region;
@@ -93,26 +95,56 @@ namespace Akka.Cluster.Sharding.Tests
             cluster = Cluster.Get(Sys);
             leaseOwner = cluster.SelfMember.Address.HostPort();
             testLeaseExt = TestLeaseExt.Get(Sys);
-
-            cluster.Join(cluster.SelfAddress);
-            AwaitAssert(() =>
-            {
-                cluster.SelfMember.Status.ShouldBe(MemberStatus.Up);
-            });
-            ClusterSharding.Get(Sys).Start(
-              typeName: typeName,
-              entityProps: SimpleEchoActor.Props(),
-              settings: ClusterShardingSettings.Create(Sys).WithRememberEntities(rememberEntities),
-              messageExtractor: new MessageExtractor());
-
-            region = ClusterSharding.Get(Sys).ShardRegion(typeName);
+            this.rememberEntities = rememberEntities;
         }
 
+        // Cluster formation used to run here in the constructor, behind a blocking AwaitAssert
+        // wrapper (AwaitAssertAsync(...).WaitAndUnwrapException, i.e. Task.Wait). MemberUp needs
+        // about six thread-pool dispatches, and akka.cluster.use-dispatcher is empty, so all of
+        // them run on akka.actor.default-dispatcher, which is the .NET thread pool. A CI run
+        // measured MemberUp at 3.462 s against the flat 3 s single-expect-default and missed by
+        // 462 ms, because xUnit never raises MinThreads in this assembly (parallelization is off,
+        // so SetupParallelism, the only caller of ThreadPool.SetMinThreads, never runs) and the
+        // pool floor stays at ProcessorCount.
+        //
+        // JoinAsync waits on the real MemberUp signal instead of polling a volatile field, and
+        // awaiting it here parks nothing: xUnit v3 awaits InitializeAsync inside its own async
+        // pipeline, so the worker goes back to the pool while the cluster forms. StartAsync avoids
+        // ClusterSharding.Start's Ask(...).Result on the same thread.
+        public async ValueTask InitializeAsync()
+        {
+            using var cts = new CancellationTokenSource(Dilated(TimeSpan.FromSeconds(30)));
+            await cluster.JoinAsync(cluster.SelfAddress, cts.Token);
 
-        private TestLease LeaseForShard(int shardId)
+            region = await ClusterSharding.Get(Sys).StartAsync(
+                typeName: typeName,
+                entityProps: SimpleEchoActor.Props(),
+                settings: ClusterShardingSettings.Create(Sys).WithRememberEntities(rememberEntities),
+                messageExtractor: new MessageExtractor());
+
+            // JoinAsync completes with RunContinuationsAsynchronously, so we resume on a different
+            // pool thread than the constructor ran on. InternalCurrentActorCellKeeper.Current is
+            // [ThreadStatic] and does not flow across that hop. Reading TestActor runs
+            // TestKit.EnsureImplicitSender on the thread xUnit will run the facts on. See #8144.
+            // The facts also pass TestActor explicitly, which is the part that must not regress.
+            _ = TestActor;
+        }
+
+        // xUnit v3's DisposalTracker calls IAsyncDisposable.DisposeAsync and skips
+        // IDisposable.Dispose when a type implements both, and IAsyncLifetime carries
+        // IAsyncDisposable. Without this bridge TestKit.Dispose never runs and every fact leaks a
+        // clustered ActorSystem. PR #8545 turns this into an override that chains to base.DisposeAsync
+        // once Akka.TestKit.Xunit.TestKit owns the async dispose chain.
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return default;
+        }
+
+        private async Task<TestLease> LeaseForShardAsync(int shardId)
         {
             TestLease lease = null;
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
             {
                 lease = testLeaseExt.GetTestLease(LeaseNameFor(shardId));
             }, TimeSpan.FromSeconds(6));
@@ -122,67 +154,73 @@ namespace Akka.Cluster.Sharding.Tests
         private string LeaseNameFor(int shardId, string typeName = typeName) => $"{Sys.Name}-shard-{typeName}-{shardId}";
 
         [Fact]
-        public void Cluster_sharding_with_lease_should_not_start_until_lease_is_acquired()
+        public async Task Cluster_sharding_with_lease_should_not_start_until_lease_is_acquired()
         {
-            region.Tell(1);
-            ExpectNoMsg(shortDuration);
-            var testLease = LeaseForShard(1);
+            region.Tell(1, TestActor);
+            await ExpectNoMsgAsync(shortDuration);
+            var testLease = await LeaseForShardAsync(1);
             testLease.InitialPromise.SetResult(true);
-            ExpectMsg(1);
+            await ExpectMsgAsync(1);
         }
 
         [Fact]
-        public void Cluster_sharding_with_lease_should_retry_if_initial_acquire_is_false()
+        public async Task Cluster_sharding_with_lease_should_retry_if_initial_acquire_is_false()
         {
-            region.Tell(2);
-            ExpectNoMsg(shortDuration);
-            var testLease = LeaseForShard(2);
+            region.Tell(2, TestActor);
+            await ExpectNoMsgAsync(shortDuration);
+            var testLease = await LeaseForShardAsync(2);
             testLease.InitialPromise.SetResult(false);
-            ExpectNoMsg(shortDuration);
+            await ExpectNoMsgAsync(shortDuration);
             testLease.SetNextAcquireResult(Task.FromResult(true));
-            ExpectMsg(2);
+            await ExpectMsgAsync(2);
         }
 
         [Fact]
-        public void Cluster_sharding_with_lease_should_retry_if_initial_acquire_fails()
+        public async Task Cluster_sharding_with_lease_should_retry_if_initial_acquire_fails()
         {
-            region.Tell(3);
-            ExpectNoMsg(shortDuration);
-            var testLease = LeaseForShard(3);
+            region.Tell(3, TestActor);
+            await ExpectNoMsgAsync(shortDuration);
+            var testLease = await LeaseForShardAsync(3);
             testLease.InitialPromise.SetException(new LeaseFailed("oh no"));
-            ExpectNoMsg(shortDuration);
+            await ExpectNoMsgAsync(shortDuration);
             testLease.SetNextAcquireResult(Task.FromResult(true));
-            ExpectMsg(3);
+            await ExpectMsgAsync(3);
         }
 
         [Fact]
-        public void Cluster_sharding_with_lease_should_recover_if_lease_lost()
+        public async Task Cluster_sharding_with_lease_should_recover_if_lease_lost()
         {
-            region.Tell(4);
-            ExpectNoMsg(shortDuration);
-            var testLease = LeaseForShard(4);
+            // Explicit sender: region.Tell(msg) reads the [ThreadStatic] implicit sender directly
+            // and never runs EnsureImplicitSender, so it must not be the first thing a fact does
+            // now that InitializeAsync moves us to a different thread.
+            region.Tell(4, TestActor);
+            await ExpectNoMsgAsync(shortDuration);
+            var testLease = await LeaseForShardAsync(4);
             testLease.InitialPromise.SetResult(true);
-            ExpectMsg(4);
+            await ExpectMsgAsync(4);
             testLease.GetCurrentCallback()(new LeaseFailed("oh dear"));
-            AwaitAssert(() =>
+            // Inner budget was the default 3 s inside a 10 s outer loop, which bought three
+            // attempts. TestLease re-acquire returns an already-completed task, so 1 s is ample
+            // and the outer loop now gets about ten attempts.
+            await AwaitAssertAsync(async () =>
             {
-                region.Tell(4);
-                ExpectMsg(4);
+                region.Tell(4, TestActor);
+                await ExpectMsgAsync(4, TimeSpan.FromSeconds(1));
             }, TimeSpan.FromSeconds(10));
         }
 
         [Fact]
-        public void Cluster_sharding_with_lease_should_release_lease_when_shard_stopped()
+        public async Task Cluster_sharding_with_lease_should_release_lease_when_shard_stopped()
         {
-            region.Tell(5);
-            ExpectNoMsg(shortDuration);
-            var testLease = LeaseForShard(5);
+            region.Tell(5, TestActor);
+            await ExpectNoMsgAsync(shortDuration);
+            var testLease = await LeaseForShardAsync(5);
             testLease.InitialPromise.SetResult(true);
-            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(leaseOwner));
-            ExpectMsg(5);
+            await testLease.Probe.ExpectMsgAsync(new TestLease.AcquireReq(leaseOwner));
+            await ExpectMsgAsync(5);
 
-            region.Tell(new ShardCoordinator.HandOff("5"));
-            testLease.Probe.ExpectMsg(new TestLease.ReleaseReq(leaseOwner));
+            region.Tell(new ShardCoordinator.HandOff("5"), TestActor);
+            await testLease.Probe.ExpectMsgAsync(new TestLease.ReleaseReq(leaseOwner));
         }
     }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeaseSpec.cs
@@ -121,13 +121,6 @@ namespace Akka.Cluster.Sharding.Tests
                 entityProps: SimpleEchoActor.Props(),
                 settings: ClusterShardingSettings.Create(Sys).WithRememberEntities(rememberEntities),
                 messageExtractor: new MessageExtractor());
-
-            // JoinAsync completes with RunContinuationsAsynchronously, so we resume on a different
-            // pool thread than the constructor ran on. InternalCurrentActorCellKeeper.Current is
-            // [ThreadStatic] and does not flow across that hop. Reading TestActor runs
-            // TestKit.EnsureImplicitSender on the thread xUnit will run the facts on. See #8144.
-            // The facts also pass TestActor explicitly, which is the part that must not regress.
-            _ = TestActor;
         }
 
         // xUnit v3's DisposalTracker calls IAsyncDisposable.DisposeAsync and skips


### PR DESCRIPTION
## What changes

`ClusterShardingLeaseSpec`, the base that all fifteen lease tests and variants run through, no longer joins the cluster from its constructor with a blocking wait. The join moves into `InitializeAsync` and awaits `Cluster.JoinAsync` under a dilated 30 s cancellation bound, which completes on the node's own `MemberUp` and parks no thread. Sharding starts with `StartAsync`. A `DisposeAsync` bridge calls `Dispose()` so xUnit v3 still runs the TestKit teardown; once #8545 lands this becomes an `override` that chains to the base, and a comment says so.

The facts pass `TestActor` explicitly on every region tell, because the implicit sender reads a thread-static cell and a fact resumes on a different thread after `InitializeAsync`. The nested expect inside the lease-lost recovery loop gets a 1 s inner budget so the outer 10 s loop retries about ten times instead of three. The whole file moves to the async TestKit API per the maintainer's rule: every fact is `async Task`, and every wait is the `Async` form. No assertion changes.

## Why

Build 131196 (Windows unit tests) failed `PersistenceClusterShardingLeaseSpec.Cluster_sharding_with_lease_should_recover_if_lease_lost`, but not in the lease logic. The constructor asserted that the node had reached `Up` inside a blocking `AwaitAssert` with a flat 3 s default, polling every 100 ms. `MemberUp` arrived at 3.462 s, a 462 ms miss, after 3.17 s of log silence. The cluster daemon's startup needs about six dispatches on the default dispatcher, which is the thread pool, and the constructor's blocking wait held one of the two workers a 2-vCPU agent starts with. xUnit v3 never raises the pool floor for this assembly because it disables parallelization. The lease, shard-stop, and persistence paths have no race; the analysis ruled each out.

A product item from the analysis is not in this PR: `Shard.ReleaseLeaseIfNeeded` blocks in `PostStop` with a synchronous wait where Pekko fires and forgets.

## How it was checked

`dotnet build src/contrib/cluster/Akka.Cluster.Sharding.Tests -c Release -warnaserror` clean. All fifteen tests and variants run three times: 15 passed each time. A grep for the synchronous TestKit forms over the file returns nothing. `BREAKING_CHANGES_V1.6.md` untouched; this is test-only.

## Second commit

From the adversarial review: the `_ = TestActor` touch in `InitializeAsync` was redundant, because the ambient-context attribute already pins the actor cell on the test thread before each fact, and the touch only left a live cell on a returning pool worker. Removed with its comment. The spec passes 15 of 15. #8545 is stacked on this PR and converts this spec's lifecycle methods to overrides once the TestKit gains the virtuals.
