### PR TITLE
RemoteConfigSpec: read batching defaults from the Akka.Remote reference config; pin the TestKit override separately

### DIFF
--- a/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
@@ -195,13 +195,25 @@ namespace Akka.Remote.Tests
         [Fact]
         public void Remoting_should_contain_correct_BatchWriter_settings_in_ReferenceConf()
         {
-            var c = RARP.For(Sys).Provider.RemoteSettings.Config.GetConfig("akka.remote.dot-netty.tcp");
+            var c = Akka.Remote.Configuration.RemoteConfigFactory.Default().GetConfig("akka.remote.dot-netty.tcp");
             var s = DotNettyTransportSettings.Create(c);
 
             s.BatchWriterSettings.EnableBatching.Should().BeTrue();
             s.BatchWriterSettings.MaxExplicitFlushes.Should().Be(BatchWriterSettings.DefaultMaxPendingWrites);
         }
-        
+
+        [Fact]
+        public void Remoting_should_apply_TestKit_batching_override_to_the_running_system()
+        {
+            // The Akka.TestKit reference.conf (src/core/Akka.TestKit/Internal/Reference.conf) turns
+            // batching off for test systems, so the running system's settings should reflect that
+            // override rather than the Akka.Remote reference config default asserted above.
+            var c = RARP.For(Sys).Provider.RemoteSettings.Config.GetConfig("akka.remote.dot-netty.tcp");
+            var s = DotNettyTransportSettings.Create(c);
+
+            s.BatchWriterSettings.EnableBatching.Should().BeFalse();
+        }
+
         [Fact]
         public void Remoting_should_contain_correct_PrimitiveSerializer_settings_in_ReferenceConf()
         {


### PR DESCRIPTION
## Problem

`RemoteConfigSpec.Remoting_should_contain_correct_BatchWriter_settings_in_ReferenceConf` fails on `dev` since #8546 (`d88eec8da`). The spec reads the DotNetty settings from the running test system, and #8546 moved the TestKit's `batching.enabled = false` override to the key the transport reads. Before that commit the override was dead, so the running system still showed the Akka.Remote default and the fact passed by accident.

Full `Akka.Remote.Tests` run at `d88eec8da`: 670 passed, 1 failed, 5 skipped. The one failure is this fact.

## Fix

- The fact now reads the Akka.Remote reference config directly (`RemoteConfigFactory.Default()`), which is what its name says it checks. Both assertions are unchanged.
- A new sibling fact reads the running system's settings, as the old code did, and asserts batching is off, with a comment pointing at the TestKit `Reference.conf` that turns it off.

A future misplacement of either key now fails one of the two facts.

## Verification

- Before the change at `d88eec8da`: 9 of 10 pass, the batching fact fails with `Expected boolean to be true, but found False`.
- After: 11 of 11 pass.
- `dotnet build src/core/Akka.Remote.Tests -c Release -warnaserror` clean.

Test-only change. No ledger entry.
