### PR TITLE
Revert "TestKit: put the DotNetty batching override under akka.remote, where the transport reads it (#8546)"

### DIFF
--- a/src/core/Akka.TestKit.Tests/TestKit_Config_Tests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKit_Config_Tests.cs
@@ -80,23 +80,5 @@ namespace Akka.TestKit.Tests.Xunit2
             CallingThreadDispatcher.Id.ShouldBe("akka.test.calling-thread-dispatcher");
         }
     }
-
-    // ReSharper disable once InconsistentNaming
-    public class TestKitDefaultConfig_RemoteBatchingOverride_Tests
-    {
-        [Fact]
-        public void DotNetty_batching_override_should_resolve_under_akka_remote()
-        {
-            // The TestKit's Reference.conf disables DotNetty write batching to avoid
-            // flakiness in low-frequency Akka.Remote tests. Akka.Remote only reads this
-            // setting at akka.remote.dot-netty.tcp.batching.enabled -- DotNettyTransportSettings
-            // resolves it via config.GetConfig("batching") relative to akka.remote.dot-netty.tcp
-            // -- so the override has to live at that exact path or it silently never applies.
-            var config = TestKitBase.DefaultConfig;
-
-            config.HasPath("akka.remote.dot-netty.tcp.batching.enabled").ShouldBeTrue();
-            config.GetBoolean("akka.remote.dot-netty.tcp.batching.enabled").ShouldBeFalse();
-        }
-    }
 }
 

--- a/src/core/Akka.TestKit/Internal/Reference.conf
+++ b/src/core/Akka.TestKit/Internal/Reference.conf
@@ -44,11 +44,8 @@ akka {
       type = "Akka.TestKit.CallingThreadDispatcherConfigurator, Akka.TestKit"
       throughput = 2147483647
     }
-  }
 
-  # Disable batching in order to prevent flakiness with Akka.Remote tests (since they
-  # have low message frequency). This key must sit under akka.remote, not akka.test:
-  # DotNettyTransportSettings reads config.GetConfig("batching") relative to
-  # akka.remote.dot-netty.tcp.
-  remote.dot-netty.tcp.batching.enabled = false
+    # Disable batching in order to prevent flakiness with Akka.Remote tests (since they have low message frequency)
+    remote.dot-netty.tcp.batching.enabled = false
+  }
 }


### PR DESCRIPTION
## What changes

Reverts #8546 (`d88eec8da`). The resulting tree is byte-identical to dev at `78f5cdc9a`, the commit before it, which had a full CI run.

## Why

#8546 was admin-merged without its own CI run. Once it landed, the TestKit override it fixed started reaching the DotNetty transport in every TestKit-based system, which:

- fails `RemoteConfigSpec.Remoting_should_contain_correct_BatchWriter_settings_in_ReferenceConf` on dev, since that fact reads the running test system;
- turns DotNetty batching off for every TestKit and multi-node remoting test, so the shipped `batching.enabled = on` default lost its end-to-end coverage without anyone deciding that.

Because no run happened before the merge, the full effect on the remoting suites was never inspected. This revert restores the last fully tested state. The key move comes back as its own PR with the `RemoteConfigSpec` adjustment folded in and runs CI the normal way.

Test-only change. No ledger entry.
