### PR TITLE
TestKit: put the DotNetty batching override under akka.remote, where the transport reads it (re-land of #8546 with the RemoteConfigSpec fix)

### DIFF
--- a/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteConfigSpec.cs
@@ -195,13 +195,25 @@ namespace Akka.Remote.Tests
         [Fact]
         public void Remoting_should_contain_correct_BatchWriter_settings_in_ReferenceConf()
         {
-            var c = RARP.For(Sys).Provider.RemoteSettings.Config.GetConfig("akka.remote.dot-netty.tcp");
+            var c = Akka.Remote.Configuration.RemoteConfigFactory.Default().GetConfig("akka.remote.dot-netty.tcp");
             var s = DotNettyTransportSettings.Create(c);
 
             s.BatchWriterSettings.EnableBatching.Should().BeTrue();
             s.BatchWriterSettings.MaxExplicitFlushes.Should().Be(BatchWriterSettings.DefaultMaxPendingWrites);
         }
-        
+
+        [Fact]
+        public void Remoting_should_apply_TestKit_batching_override_to_the_running_system()
+        {
+            // The Akka.TestKit reference.conf (src/core/Akka.TestKit/Internal/Reference.conf) turns
+            // batching off for test systems, so the running system's settings should reflect that
+            // override rather than the Akka.Remote reference config default asserted above.
+            var c = RARP.For(Sys).Provider.RemoteSettings.Config.GetConfig("akka.remote.dot-netty.tcp");
+            var s = DotNettyTransportSettings.Create(c);
+
+            s.BatchWriterSettings.EnableBatching.Should().BeFalse();
+        }
+
         [Fact]
         public void Remoting_should_contain_correct_PrimitiveSerializer_settings_in_ReferenceConf()
         {

--- a/src/core/Akka.TestKit.Tests/TestKit_Config_Tests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKit_Config_Tests.cs
@@ -80,5 +80,23 @@ namespace Akka.TestKit.Tests.Xunit2
             CallingThreadDispatcher.Id.ShouldBe("akka.test.calling-thread-dispatcher");
         }
     }
+
+    // ReSharper disable once InconsistentNaming
+    public class TestKitDefaultConfig_RemoteBatchingOverride_Tests
+    {
+        [Fact]
+        public void DotNetty_batching_override_should_resolve_under_akka_remote()
+        {
+            // The TestKit's Reference.conf disables DotNetty write batching to avoid
+            // flakiness in low-frequency Akka.Remote tests. Akka.Remote only reads this
+            // setting at akka.remote.dot-netty.tcp.batching.enabled -- DotNettyTransportSettings
+            // resolves it via config.GetConfig("batching") relative to akka.remote.dot-netty.tcp
+            // -- so the override has to live at that exact path or it silently never applies.
+            var config = TestKitBase.DefaultConfig;
+
+            config.HasPath("akka.remote.dot-netty.tcp.batching.enabled").ShouldBeTrue();
+            config.GetBoolean("akka.remote.dot-netty.tcp.batching.enabled").ShouldBeFalse();
+        }
+    }
 }
 

--- a/src/core/Akka.TestKit.Tests/TestKit_Config_Tests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKit_Config_Tests.cs
@@ -52,9 +52,6 @@ namespace Akka.TestKit.Tests.Xunit2
               type = "Akka.Dispatch.DispatcherConfigurator, Akka"
               throughput = 2147483647
             }
-            
-            # Disable batching in order to prevent flakiness with Akka.Remote tests (since they have low message frequency)
-            remote.dot-netty.tcp.batching.enabled = false
         }
         """;
         

--- a/src/core/Akka.TestKit/Internal/Reference.conf
+++ b/src/core/Akka.TestKit/Internal/Reference.conf
@@ -44,8 +44,11 @@ akka {
       type = "Akka.TestKit.CallingThreadDispatcherConfigurator, Akka.TestKit"
       throughput = 2147483647
     }
-
-    # Disable batching in order to prevent flakiness with Akka.Remote tests (since they have low message frequency)
-    remote.dot-netty.tcp.batching.enabled = false
   }
+
+  # Disable batching in order to prevent flakiness with Akka.Remote tests (since they
+  # have low message frequency). This key must sit under akka.remote, not akka.test:
+  # DotNettyTransportSettings reads config.GetConfig("batching") relative to
+  # akka.remote.dot-netty.tcp.
+  remote.dot-netty.tcp.batching.enabled = false
 }


### PR DESCRIPTION
## What changes

Re-lands #8546, which was merged without a CI run and reverted in #8560, and folds in the `RemoteConfigSpec` adjustment from #8559. This PR runs CI the normal way.

- `src/core/Akka.TestKit/Internal/Reference.conf`: the override `remote.dot-netty.tcp.batching.enabled = false` sat under `akka.test`, where nothing reads it, so it has been dead since it was written. It now sits under `akka.remote`, where `DotNettyTransportSettings` reads it. A test in `TestKit_Config_Tests` pins the path; it failed before the move and passes after.
- `src/core/Akka.Remote.Tests/RemoteConfigSpec.cs`: the batching fact reads the Akka.Remote reference config directly, since that is what its name says it checks. A sibling fact reads the running test system and asserts the TestKit override is applied, so a future misplacement of either key fails a test.

## What this changes at runtime, so it can be judged rather than discovered

With the override live, DotNetty batching is off in every ActorSystem the TestKit creates, which includes every TestKit-based remoting test and every multi-node spec, since `MultiNodeSpec` pulls in the TestKit default config. Two consequences:

- The `FlushConsolidationHandler` leaves the pipeline for those tests. The shipped default, batching on, then has no end-to-end coverage in the test suites. If that matters, a handful of remoting specs should set `batching.enabled = on` explicitly.
- Any remoting test whose timing was tuned with batching silently on now runs without it. The comment on the override says batching was turned off to reduce flakiness in low-frequency tests, which was the intent all along, but it has never actually been exercised.

The first CI run of this PR is the first time the remoting suites run with the override in effect. Read its multi-node lanes with that in mind before merging.

## How it was checked

`Akka.Remote.Tests` and `Akka.TestKit.Tests` build with warnings as errors. `RemoteConfigSpec`: 11 passed. `TestKit_Config_Tests`: passes. Test-only change. No ledger entry.
