### PR TITLE
De-flake InboxSpec: receive through ReceiveAsync so a deadline failure surfaces as TimeoutException

### DIFF
--- a/src/core/Akka.Tests/Actor/InboxSpec.cs
+++ b/src/core/Akka.Tests/Actor/InboxSpec.cs
@@ -53,14 +53,19 @@ namespace Akka.Tests.Actor
             // wrapped in AggregateException instead of letting the intended TimeoutException surface
             // directly.
             var task0 = _inbox.ReceiveAsync();
-            var task1 = Task.Factory.StartNew(() =>
+            // ReceiveWhere has no async overload, and it isn't in the race described above: by
+            // the time each of these runs, the matching message has already been told, so
+            // ReceiveWhere finds it queued and returns immediately instead of waiting on the
+            // inbox actor's scheduled deadline. Only the stagger before each call needs to be
+            // async; swap Thread.Sleep for Task.Delay so nothing blocks a pool thread.
+            var task1 = Task.Run(async () =>
             {
-                Thread.Sleep(100);
+                await Task.Delay(100);
                 return _inbox.ReceiveWhere(x => x.ToString() == "world");
             });
-            var task2 = Task.Factory.StartNew(() =>
+            var task2 = Task.Run(async () =>
             {
-                Thread.Sleep(200);
+                await Task.Delay(200);
                 return _inbox.ReceiveWhere(x => x.ToString() == "hello");
             });
 
@@ -153,8 +158,16 @@ namespace Akka.Tests.Actor
         [Fact]
         public async Task Inbox_Receive_will_timeout_gracefully_if_timeout_is_already_expired()
         {
+            // Deterministic: Get's deadline is already in the past when it reaches InboxActor, so
+            // Receive (Inbox.Actor.cs) enqueues it and immediately self-Tells a Kick instead of
+            // scheduling one. Kick finds the query overdue and replies with
+            // Status.Failure(new TimeoutException("Deadline passed")); the reply target is the
+            // FutureActorRef<object> behind ReceiveAsync's Ask, whose TellInternal faults the task
+            // with that bare TimeoutException instead of wrapping it. AwaitWithTimeout rethrows a
+            // single inner exception unwrapped, so the exact type surfacing here is always
+            // TimeoutException.
             var task = _inbox.ReceiveAsync(TimeSpan.FromSeconds(-1));
-            await Assert.ThrowsAnyAsync<Exception>(() => task.AwaitWithTimeout(TimeSpan.FromMilliseconds(1000)));
+            await Assert.ThrowsAsync<TimeoutException>(() => task.AwaitWithTimeout(TimeSpan.FromMilliseconds(1000)));
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/InboxSpec.cs
+++ b/src/core/Akka.Tests/Actor/InboxSpec.cs
@@ -44,43 +44,46 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void Inbox_support_queueing_multiple_queries()
+        public async Task Inbox_support_queueing_multiple_queries()
         {
-            var tasks = new[]
-                {
-                    Task.Factory.StartNew(() => _inbox.Receive()),
-                    Task.Factory.StartNew(() =>
-                    {
-                        Thread.Sleep(100);
-                        return _inbox.ReceiveWhere(x => x.ToString() == "world");
-                    }),
-                    Task.Factory.StartNew(() =>
-                    {
-                        Thread.Sleep(200);
-                        return _inbox.ReceiveWhere(x => x.ToString() == "hello");
-                    })
-                };
+            // Use ReceiveAsync instead of the synchronous Receive: Receive's AwaitResult blocks the
+            // calling thread on the wall clock for the same duration the inbox actor uses for its
+            // own scheduled deadline. When that deadline fires first, it faults the task with
+            // Status.Failure(TimeoutException), and the blocking wall-clock wait then rethrows it
+            // wrapped in AggregateException instead of letting the intended TimeoutException surface
+            // directly.
+            var task0 = _inbox.ReceiveAsync();
+            var task1 = Task.Factory.StartNew(() =>
+            {
+                Thread.Sleep(100);
+                return _inbox.ReceiveWhere(x => x.ToString() == "world");
+            });
+            var task2 = Task.Factory.StartNew(() =>
+            {
+                Thread.Sleep(200);
+                return _inbox.ReceiveWhere(x => x.ToString() == "hello");
+            });
 
             _inbox.Receiver.Tell(42);
             _inbox.Receiver.Tell("hello");
             _inbox.Receiver.Tell("world");
 
-            Task.WaitAll(tasks.Cast<Task>().ToArray());
+            await Task.WhenAll(task0, task1, task2);
 
-            tasks[0].Result.ShouldBe(42);
-            tasks[1].Result.ShouldBe("world");
-            tasks[2].Result.ShouldBe("hello");
+            (await task0).ShouldBe(42);
+            (await task1).ShouldBe("world");
+            (await task2).ShouldBe("hello");
         }
 
         [Fact]
-        public void Inbox_support_selective_receives()
+        public async Task Inbox_support_selective_receives()
         {
             _inbox.Receiver.Tell("hello");
             _inbox.Receiver.Tell("world");
 
             var selection = _inbox.ReceiveWhere(x => x.ToString() == "world");
             selection.ShouldBe("world");
-            _inbox.Receive().ShouldBe("hello");
+            (await _inbox.ReceiveAsync()).ShouldBe("hello");
         }
 
         [Fact]
@@ -102,18 +105,14 @@ namespace Akka.Tests.Actor
                 await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
 
                 //Receive all messages from the inbox
-                var gotit = Enumerable.Repeat(0, 1000).Select(_ => _inbox.Receive());
-                foreach (var o in gotit)
+                for (var i = 0; i < 1000; i++)
                 {
+                    var o = await _inbox.ReceiveAsync();
                     o.ShouldBe(0);
                 }
 
                 //The inbox should be empty now, so receiving should result in a timeout
-                Assert.Throws<TimeoutException>(() =>
-                {
-                    var received = _inbox.Receive(TimeSpan.FromSeconds(1));
-                    Log.Error("Received " + received);
-                });
+                await Assert.ThrowsAsync<TimeoutException>(() => _inbox.ReceiveAsync(TimeSpan.FromSeconds(1)));
             }
             finally
             {
@@ -124,29 +123,15 @@ namespace Akka.Tests.Actor
         [Fact]
         public async Task Inbox_have_a_default_and_custom_timeouts()
         {
-            await WithinAsync(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(6), () =>
+            await WithinAsync(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(6), async () =>
             {
-                // Inbox.Receive() may throw TimeoutException directly or wrapped in AggregateException
-                // depending on internal implementation (sync vs async path)
-                var ex = Record.Exception(() => _inbox.Receive());
-                Assert.NotNull(ex);
-                Assert.True(IsTimeoutException(ex), $"Expected TimeoutException but got: {ex.GetType().Name}");
-                return Task.CompletedTask;
+                await Assert.ThrowsAsync<TimeoutException>(() => _inbox.ReceiveAsync());
             });
 
-            await WithinAsync(TimeSpan.FromSeconds(1), () =>
+            await WithinAsync(TimeSpan.FromSeconds(1), async () =>
             {
-                var ex = Record.Exception(() => _inbox.Receive(TimeSpan.FromMilliseconds(100)));
-                Assert.NotNull(ex);
-                Assert.True(IsTimeoutException(ex), $"Expected TimeoutException but got: {ex.GetType().Name}");
-                return Task.CompletedTask;
+                await Assert.ThrowsAsync<TimeoutException>(() => _inbox.ReceiveAsync(TimeSpan.FromMilliseconds(100)));
             });
-        }
-
-        private static bool IsTimeoutException(Exception ex)
-        {
-            return ex is TimeoutException ||
-                   (ex is AggregateException agg && agg.Flatten().InnerExceptions.Any(e => e is TimeoutException));
         }
 
         [Fact]


### PR DESCRIPTION
Stacked on #8563.

## What changes

`InboxSpec` receives through `ReceiveAsync` instead of the blocking `Receive`, and the two facts that assert a timeout assert the exact exception type again.

- The 1000-message drain, the selective receive, and the queued-queries fact await `ReceiveAsync`.
- `Inbox_have_maximum_queue_size` asserts `TimeoutException` with `Assert.ThrowsAsync`.
- `Inbox_have_a_default_and_custom_timeouts` gets its exact-type assertions back. #8035 had loosened them to accept an `AggregateException` as well, through a helper that is now deleted.
- `ReceiveWhere` calls stay as they are; there is no async overload, and their timeouts never expire in these facts. The queued-queries fact runs them under `Task.Run` with awaited delays instead of thread sleeps.
- The negative-deadline fact asserts `TimeoutException` exactly. A deadline already in the past makes the inbox actor kick itself at once and answer with that one exception type, so nothing else can come out.

No change to `Inbox` itself. It is deprecated and slated for removal in #7946.

## Why

Build 131326, Linux unit tests, on a PR that touched a different spec: `Inbox_have_maximum_queue_size` expected `TimeoutException` and got an `AggregateException` wrapping `TimeoutException("Deadline passed")`.

The sync `Receive(timeout)` blocks on `task.Wait(timeout)`. The inbox actor schedules its own deadline for the same duration and faults the task with a `Status.Failure` carrying the timeout. When the actor's deadline fires before the wall-clock wait gives up, `Task.Wait` throws the aggregate, and the unwrap code written for the faulted case, right after the wait, never runs. Which side wins is a race between the scheduler and the wall clock over the same second. The same test was reported flaky in 2014 (#340), and the sibling fact in 2025 (#7934), which was closed as won't-fix because the Inbox is going away; #8035 then loosened the sibling's assertion instead.

`ReceiveAsync` is the `Ask` with the deadline and no wall-clock wait, so awaiting it surfaces the actor's timeout directly. That removes the race rather than tolerating either outcome, and it is the async form the touched-file rule asks for.

## How it was checked

`dotnet build src/core/Akka.Tests -c Release -warnaserror` clean. The `InboxSpec` class run ten times: 7 passed each time. The grep for blocking receives, waits, results, and synchronous throw assertions on the file returns only `ReceiveAsync` and `ReceiveWhere` calls. Test-only change. No ledger entry.

## Second commit

From the adversarial review: the two `Task.Factory.StartNew` blocks with thread sleeps became `Task.Run` with awaited delays, and the third timeout fact's any-exception assertion became the exact type, which the negative-deadline path produces deterministically. `InboxSpec` run five times: 7 of 7 each time.
