### PR TITLE
Akka.Streams: Tcp Unbind completes at once when no connection is awaiting initialization; the counter was seeded at -1

### DIFF
--- a/src/core/Akka.Streams.Tests/IO/TcpUnbindSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpUnbindSpec.cs
@@ -1,0 +1,48 @@
+//-----------------------------------------------------------------------
+// <copyright file="TcpUnbindSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Streams.Dsl;
+using Akka.TestKit;
+using Xunit;
+using Tcp = Akka.Streams.Dsl.Tcp;
+
+namespace Akka.Streams.Tests.IO
+{
+    /// <summary>
+    /// Regression coverage for the <c>ConnectionSourceStage</c> unbind idle fast path
+    /// (see <c>Akka.Streams.Implementation.IO.TcpStages</c>). When a server binding is
+    /// unbound without ever having accepted a connection, <c>ServerBinding.Unbind()</c>
+    /// must complete right away instead of waiting out the full
+    /// <c>akka.stream.materializer.subscription-timeout.timeout</c> (5s by default).
+    /// </summary>
+    public class TcpUnbindSpec : TcpHelper
+    {
+        // Intentionally leave `akka.stream.materializer.subscription-timeout.timeout` at its
+        // production default (5s) so this test exercises the real-world timing exposure.
+        public TcpUnbindSpec(ITestOutputHelper helper) : base("", helper)
+        {
+        }
+
+        [Fact(DisplayName = "Unbind should complete promptly when no connection is awaiting initialization")]
+        public async Task Unbind_should_complete_promptly_when_no_connection_is_awaiting_initialization()
+        {
+            var binding = await Sys.TcpStream()
+                .Bind("127.0.0.1", 0)
+                .To(Sink.Ignore<Tcp.IncomingConnection>())
+                .Run(Materializer)
+                .WaitAsync(TimeSpan.FromSeconds(3));
+
+            // No client ever connects, so _connectionFlowsAwaitingInitialization stays at its
+            // resting value. The idle fast path in UnbindCompleted() should complete the stage
+            // immediately rather than falling through to the BindShutdownTimer, which would take
+            // the full subscription-timeout (5s by default) to fire.
+            await binding.Unbind().WaitAsync(TimeSpan.FromSeconds(1));
+        }
+    }
+}

--- a/src/core/Akka.Streams/Implementation/IO/TcpStages.cs
+++ b/src/core/Akka.Streams/Implementation/IO/TcpStages.cs
@@ -38,7 +38,11 @@ namespace Akka.Streams.Implementation.IO
         {
             private const string BindShutdownTimer = "BindTimer";
 
-            private readonly AtomicCounterLong _connectionFlowsAwaitingInitialization = new();
+            // This counter tracks the number of connection flows awaiting initialization, not
+            // ids, so it must start at 0, matching JVM Akka's `new AtomicLong()`. Seeded at -1
+            // (the id-generator default), the idle fast path in UnbindCompleted() below can
+            // never fire, and every graceful Unbind() waits out the full BindShutdownTimer.
+            private readonly AtomicCounterLong _connectionFlowsAwaitingInitialization = new(0);
             private readonly ConnectionSourceStage _stage;
             private IActorRef _listener;
             private readonly TaskCompletionSource<StreamTcp.ServerBinding> _bindingPromise;


### PR DESCRIPTION
## What changes

One token in `TcpStages.cs`: the counter of connection flows awaiting initialization is seeded at 0 instead of the `AtomicCounterLong` default of -1. A new `TcpUnbindSpec` binds a TCP source on port 0, accepts nothing, calls `Unbind()`, and asserts it completes within 1 s. It fails on the old code at about 5 s and passes on the new one at under 300 ms.

## Why

`AtomicCounterLong`'s parameterless constructor is an id generator: it starts at -1 so the first `Next()` returns 0. `ConnectionSourceStageLogic` uses one to count connection flows that have been accepted but not yet materialized, and checks `Current == 0` in its unbind handler to complete the stage at once when nothing is pending. Seeded at -1 the check is off by one: it holds when exactly one connection is still awaiting initialization, the one moment the guard exists to wait for, and never holds when the listener is idle. So an idle `Unbind()` falls into the bind-shutdown timer and waits the full `akka.stream.materializer.subscription-timeout.timeout`, 5 s by default, while an unbind with one pending connection completes at once and can cut that connection's handler off. Akka JVM seeds the same counter with `new AtomicLong()`, which is 0.

With the fix both cases behave as designed: idle completes at once, and an unbind with a pending connection waits up to the timer for that handler to materialize. A `Tcp.Connected` that arrives after `Unbound` no longer gets the accidental 5 s grace window an idle unbind used to give it, which matches upstream. The existing `TcpSpec` fact that binds without connecting and then waits 3 s against a 2 s timer is evidence of the old behavior.

This has affected every `Tcp().Bind` user who awaits `Unbind()` for as long as the code has existed. It surfaced now because #8554 hosts Artery's materializer under `/system`, so Artery's listener performs a real graceful unbind on every `ActorSystem.Terminate()` instead of dying with `/user` first, and each Artery shutdown started paying the 5 s. On that PR's own CI run the `Akka.Remote.Tests` assembly went from 470 s to 1185 s and the Windows job was cancelled at the 20-minute cap. Bisected to that commit, then to this line; with this fix the Artery test namespace goes from 13 min 25 s to 2 min 10 s with all 284 tests passing.

The three other `new AtomicCounterLong()` uses in `Hub.cs` are real id generators and are untouched.

Bug fix restoring upstream semantics, no public API change, approval files unchanged. No ledger entry, though the change is observable in both directions: an idle unbind gets faster, an unbind with one pending connection now waits for it. Say the word if that should be recorded.

## How it was checked

`Akka.Streams` and `Akka.Streams.Tests` build with warnings as errors. TCP specs: 21 passed, 3 pre-existing skips. `Akka.API.Tests`: 18 passed, no approval diff. #8554 is being restacked on top of this branch so its CI carries the fix.
