### PR TITLE
De-flake ShardingBufferAdapterSpec: re-send the cold messages with a fresh probe per attempt under a sharding-derived budget

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardingBufferAdapterSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardingBufferAdapterSpec.cs
@@ -238,7 +238,8 @@ public class ShardingBufferAdapterSpec: AkkaSpec
 
         _regionA.Tell(1, _pA.Ref);
         await _pA.ExpectMsgAsync(1, warm);
-        // Same entity incarnation as phase one - ActorPath.Equals includes the uid, so a
+        // Same entity incarnation as phase one. IActorRef equality compares the path's uid as
+        // well as the path (ActorPath.Equals alone compares only address and names), so a
         // Shard restart between phases (which would recreate the entity under a new uid)
         // shows up here instead of leaving the counter assertions below comparing two
         // different buffer histories.

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardingBufferAdapterSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardingBufferAdapterSpec.cs
@@ -52,7 +52,7 @@ public class ShardingBufferAdapterSpec: AkkaSpec
             return true;
         }
     }
-    
+
     private class TestMessageAdapter: IShardingBufferMessageAdapter
     {
         private readonly AtomicCounter _counter;
@@ -78,12 +78,12 @@ public class ShardingBufferAdapterSpec: AkkaSpec
 
     private static Config SpecConfig =>
         ConfigurationFactory.ParseString("""
-                                         
+
                                                      akka.loglevel = DEBUG
                                                      akka.actor.provider = cluster
                                                      akka.remote.dot-netty.tcp.port = 0
                                                      akka.remote.log-remote-lifecycle-events = off
-                                         
+
                                                      akka.test.single-expect-default = 5 s
                                                      akka.cluster.sharding.state-store-mode = "ddata"
                                                      akka.cluster.sharding.verbose-debug-logging = on
@@ -104,49 +104,99 @@ public class ShardingBufferAdapterSpec: AkkaSpec
 
     private readonly IActorRef _regionA;
     private readonly IActorRef _regionB;
-    
+
     public ShardingBufferAdapterSpec(ITestOutputHelper helper) : base(SpecConfig, helper)
     {
         _sysA = Sys;
         _sysB = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
-        
+
         InitializeLogger(_sysB, "[sysB]");
-        
+
         // ReSharper disable VirtualMemberCallInConstructor
         _pA = CreateTestProbe(_sysA);
         _pB = CreateTestProbe(_sysB);
         // ReSharper restore VirtualMemberCallInConstructor
-        
+
         ClusterSharding.Get(_sysA).SetShardingBufferMessageAdapter(new TestMessageAdapter(_counterA));
         ClusterSharding.Get(_sysB).SetShardingBufferMessageAdapter(new TestMessageAdapter(_counterB));
-        
+
         _regionA = StartShard(_sysA);
         _regionB = StartShard(_sysB);
     }
 
     protected override void AfterAll()
     {
-        if(_sysA != null)
-            Shutdown(_sysA);
+        // TODO(#8545): TestKit will gain an async dispose chain (override DisposeAsync) -
+        // move these two to `await ShutdownAsync(...)` then. Until then they have to stay
+        // blocking here.
+        //
+        // _sysA is Sys: TestKit.Dispose's `finally` already calls the parameterless
+        // Shutdown() (== Shutdown(Sys)) right after AfterAll returns, so shutting _sysA down
+        // here too was a redundant blocking wait on every run. Only _sysB needs shutting
+        // down explicitly.
         if(_sysB != null)
             Shutdown(_sysB);
         base.AfterAll();
     }
-    
+
+    private static ClusterShardingSettings ShardingSettings(ActorSystem sys)
+        => ClusterShardingSettings.Create(sys).WithRememberEntities(true);
+
     private IActorRef StartShard(ActorSystem sys)
     {
+        // was ClusterShardingSettings.Create(Sys) - sysB's region was built from sysA's
+        // settings. Harmless today (sysB is created from Sys.Settings.Config, so the two are
+        // identical) but wrong: use the settings of the system whose region is being started.
         return ClusterSharding.Get(sys).Start(
             ShardTypeName,
             Props.Create(() => new EntityActor()),
-            ClusterShardingSettings.Create(Sys).WithRememberEntities(true),
+            ShardingSettings(sys),
             new MessageExtractor());
     }
-    
+
+    /// <summary>
+    /// The first message through a region has to survive coordinator allocation (two ddata
+    /// majority writes), shard start (five ddata majority reads) and entity start (one more
+    /// majority write) - and on a two-node cluster majority-min-cap (5) exceeds the cluster
+    /// size, so every one of those is majority == all. If the Shard's remember-entities write
+    /// does not complete in time the Shard throws and the ShardRegion restarts it, and the
+    /// restart takes the Shard's _messageBuffers with it while the region has already emptied
+    /// its own buffer for that shard. Sharding is at-most-once: the request has to be
+    /// re-sent, not merely re-awaited.
+    /// </summary>
+    private async Task<IActorRef> FirstMessageThrough<T>(
+        ActorSystem sys, IActorRef region, object message, T expected)
+    {
+        var tuning = ShardingSettings(sys).TuningParameters;
+
+        // One shard-start-timeout (the region's own budget for "the shard did not start")
+        // plus one updating-state-timeout (the remember-entities store's write budget):
+        // the cold path plus one full Shard restart cycle.
+        var budget = tuning.ShardStartTimeout + tuning.UpdatingStateTimeout;
+
+        IActorRef entity = null;
+        await AwaitAssertAsync(async () =>
+        {
+            // Fresh probe per attempt: a late reply to a timed-out attempt must not be
+            // mistaken for this attempt's, and must not be left sitting in _pA/_pB for the
+            // second phase below to consume.
+            var probe = CreateTestProbe(sys);
+            region.Tell(message, probe.Ref);
+            // Per-attempt bound = the region's re-ask cadence for an unanswered
+            // GetShardHome, so the loop actually iterates instead of spending the whole
+            // budget in one expect.
+            await probe.ExpectMsgAsync(expected, tuning.RetryInterval);
+            entity = probe.LastSender;
+        }, budget, TimeSpan.FromMilliseconds(500));
+
+        return entity;
+    }
+
     [Fact(DisplayName = "ClusterSharding buffer message adapter must be called when message was buffered")]
     public async Task ClusterSharding_must_initialize_cluster_and_allocate_sharded_actors()
     {
         await Cluster.Get(_sysA).JoinAsync(Cluster.Get(_sysA).SelfAddress); // coordinator on A
-        
+
         await AwaitAssertAsync(() =>
         {
             Cluster.Get(_sysA).SelfMember.Status.Should().Be(MemberStatus.Up);
@@ -167,32 +217,44 @@ public class ShardingBufferAdapterSpec: AkkaSpec
         });
 
         // need to make sure that ShardingEnvelope doesn't impacted by this change
-        _regionA.Tell(new ShardingEnvelope("1", 1), _pA.Ref);
-        await _pA.ExpectMsgAsync(1);
-
-        _regionB.Tell(2, _pB.Ref);
-        await _pB.ExpectMsgAsync(2);
-
-        _regionB.Tell(3, _pB.Ref);
-        await _pB.ExpectMsgAsync(3);
+        var entityA1 = await FirstMessageThrough(_sysA, _regionA, new ShardingEnvelope("1", 1), 1);
+        var entityB2 = await FirstMessageThrough(_sysB, _regionB, 2, 2);
+        var entityB3 = await FirstMessageThrough(_sysB, _regionB, 3, 3);
 
         var counterAValue = _counterA.Current;
         var counterBValue = _counterB.Current;
-        
+
         // Each newly instantiated entities should have their messages buffered at least once
         // Buffer message adapter should be called everytime a message is buffered
         counterAValue.Should().BeGreaterOrEqualTo(1);
         counterBValue.Should().BeGreaterOrEqualTo(2);
-        
+
+        // Phase two: the entities are live, so nothing should reach the buffer. These stay
+        // single sends on purpose - re-sending here would let a Shard restart hide behind a
+        // retry and make the counter assertions below meaningless. The bound is the
+        // remember-entities store's own write budget instead of the flat
+        // akka.test.single-expect-default the probes otherwise fall back to.
+        var warm = ShardingSettings(_sysA).TuningParameters.UpdatingStateTimeout;
+
         _regionA.Tell(1, _pA.Ref);
-        await _pA.ExpectMsgAsync(1);
+        await _pA.ExpectMsgAsync(1, warm);
+        // Same entity incarnation as phase one - ActorPath.Equals includes the uid, so a
+        // Shard restart between phases (which would recreate the entity under a new uid)
+        // shows up here instead of leaving the counter assertions below comparing two
+        // different buffer histories.
+        _pA.LastSender.Should().Be(entityA1,
+            because: "a Shard restart between phases would make the counter assertions compare two different buffer histories");
 
         _regionB.Tell(2, _pB.Ref);
-        await _pB.ExpectMsgAsync(2);
+        await _pB.ExpectMsgAsync(2, warm);
+        _pB.LastSender.Should().Be(entityB2,
+            because: "a Shard restart between phases would make the counter assertions compare two different buffer histories");
 
         _regionB.Tell(3, _pB.Ref);
-        await _pB.ExpectMsgAsync(3);
-        
+        await _pB.ExpectMsgAsync(3, warm);
+        _pB.LastSender.Should().Be(entityB3,
+            because: "a Shard restart between phases would make the counter assertions compare two different buffer histories");
+
         // Each entity should not have their messages buffered once they were instantiated
         _counterA.Current.Should().Be(counterAValue);
         _counterB.Current.Should().Be(counterBValue);


### PR DESCRIPTION
Stacked on #8569.

## What changes

`ShardingBufferAdapterSpec` re-sends its first message through each region instead of waiting once on a probe's flat default.

- A helper sends the cold message under `AwaitAssertAsync` with a fresh probe per attempt. The budget is the shard start timeout plus the updating-state timeout from the sharding settings, about 15 s, which is the cold path plus one shard restart cycle; each attempt waits the retry interval, about 2 s, so the loop iterates instead of spending the budget in one wait. A fresh probe per attempt keeps a late reply from one attempt from satisfying the next.
- The warm-phase sends stay single sends, bounded by the updating-state timeout instead of the flat default, and check that the reply came from the same entity as the cold phase, so a shard restart between the phases cannot make the two counter snapshots describe different buffer histories. Passivation is off and the warm phase writes nothing to the remember-entities store, so that identity check holds.
- The counter assertions are unchanged and still snapshot after the sends.
- `StartShard` created both regions with the test system's settings; each region now uses its own system's. `AfterAll` no longer shuts the test system down twice, which also flips teardown to B then A, the order in which B's graceful leave can complete while A is still leader. The one blocking shutdown left in `AfterAll`, and the implicit one the TestKit's dispose runs after it, both wait on #8545, which gives the TestKit an async dispose chain; a `TODO` marks the spot.

## Why

Build 131348, Windows unit tests, on a PR that changed only the serialization generator: the first message through region A was not echoed within the probe's 5 s default. The message had been destroyed mid-wait. The healthy cold path on that same agent took 35 ms, then the whole test process stalled for about 5.8 s, both actor systems missing their heartbeat timers by identical amounts at identical instants. During the stall the shard's remember-entities write timed out, the region restarted the shard, and its buffered messages died with the instance with no dead letter. The write acknowledgement arrived 5 ms after the shard gave up. Waiting longer could not have helped; sharding is at-most-once, so the request has to be re-sent.

Two product findings came out of this. The shard arms its remember-entities write timeout with the read setting, 2 s instead of the documented 5 s, since #6479 in 2023, so the ddata store gets none of the retries it sizes against the 5 s value; that is fixed separately. And a shard restart drops its buffer silently; that is #8572. The stall itself is the thread-pool scheduler pattern on #8549, now with a fourth data point there.

The generator change on the triggering PR is not involved: the only generated types in Akka.Remote are Artery's, this spec runs the classic transport, and nothing in the default serialization bindings is generated.

## How it was checked

`dotnet build src/contrib/cluster/Akka.Cluster.Sharding.Tests -c Release -warnaserror` clean. The spec run five times: passed each time, about 4 s per run. The grep for synchronous TestKit calls, blocking waits, and sleeps on the file returns only the one `Shutdown(_sysB)` that #8545 blocks. Test-only change. No ledger entry.

## Second commit

From the adversarial review: the comment on the identity check said `ActorPath.Equals` includes the uid. It does not; `IActorRef` equality compares the uid, `ActorPath` alone compares address and names. The assertion was right, the reason was wrong, and a reader who trusted it could have swapped in a path comparison and silently lost the check. Comment corrected, nothing else. A related TestKit finding from the same analysis, `AwaitAssert` reading the clock twice so a stall between the reads turns into a thrown `ArgumentOutOfRangeException`, is recorded on #8565.
