### PR TITLE
De-flake UnreachableNodeJoinsAgainSpec: the master waits for the victim to go unreachable before it terminates

### DIFF
--- a/src/core/Akka.Cluster.Tests.MultiNode/UnreachableNodeJoinsAgainSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/UnreachableNodeJoinsAgainSpec.cs
@@ -38,7 +38,15 @@ namespace Akka.Cluster.Tests.MultiNode
             Second = Role("second");
             Third = Role("third");
             Fourth = Role("fourth");
-            CommonConfig = ConfigurationFactory.ParseString("akka.remote.log-remote-lifecycle-events = off")
+            // The master's end-of-spec path is now its 20s wait for End followed by up to 25s waiting
+            // for the victim to go unreachable, 45s back to back, while first and third are already
+            // parked on the final barrier. The conductor arms the barrier's clock at the FIRST arrival
+            // and never extends it, so the default 30s barrier could expire before the master's own
+            // assertion reports. 60s is the value InitialHeartbeatSpec and six other multi-node specs
+            // use for the same reason.
+            CommonConfig = ConfigurationFactory.ParseString(@"
+                akka.remote.log-remote-lifecycle-events = off
+                akka.testconductor.barrier-timeout = 60s")
                 .WithFallback(DebugConfig(false)).WithFallback(MultiNodeClusterSpec.ClusterConfig());
             TestTransport = true; // need to use the throttler and blackhole
         }
@@ -145,7 +153,7 @@ namespace Akka.Cluster.Tests.MultiNode
             await RunOnAsync(async () =>
             {
                 MarkNodeAsUnavailable(GetAddress(_victim.Value));
-                var victimNodeAddress = Node(_victim.Value).Address;
+                var victimNodeAddress = GetAddress(_victim.Value);
                 await WithinAsync(TimeSpan.FromSeconds(30), async () =>
                 {
                     // victim becomes unreachable

--- a/src/core/Akka.Cluster.Tests.MultiNode/UnreachableNodeJoinsAgainSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/UnreachableNodeJoinsAgainSpec.cs
@@ -219,7 +219,7 @@ namespace Akka.Cluster.Tests.MultiNode
             await RunOnAsync(async () =>
             {
                 // will shutdown ActorSystem of victim
-                await TestConductor.Shutdown(_victim.Value);
+                await TestConductor.ShutdownAsync(_victim.Value);
             }, _config.First);
 
             await RunOnAsync(async () =>
@@ -276,24 +276,28 @@ namespace Akka.Cluster.Tests.MultiNode
                     // before the handshake depends on it, and a failure names that problem
                     // instead of showing up as a missing EndAck.
                     var endProbe = CreateTestProbe(freshSystem);
-                    var masterEndActor = await freshSystem
+                    // ResolveOne throws (rather than returning null) if the actor can't be found,
+                    // so there is nothing left to assert here.
+                    await freshSystem
                         .ActorSelection(new RootActorPath(masterAddress) / "user" / "end")
                         .ResolveOne(Dilated(TimeSpan.FromSeconds(20)));
-                    Assert.NotNull(masterEndActor);
 
                     var endActor = freshSystem.ActorOf(Props.Create(() => new EndActor(endProbe.Ref, masterAddress)),
                         "end");
                     endActor.Tell(EndActor.SendEnd.Instance);
 
-                    // The master waits up to 20s for End, so the victim has to wait longer than
-                    // that for the EndAck. The old code inherited the 15s single-expect default,
-                    // which was the smallest budget in the spec and guarded the step needing the
-                    // most time.
-                    await endProbe.ExpectMsgAsync<EndActor.EndAck>(TimeSpan.FromSeconds(30));
+                    // The master now stays alive until it sees this system go unreachable (below),
+                    // so the ack is written by a provably live peer over a lane the resolve above
+                    // just proved hot - the sub-second path measured for this handshake, not the
+                    // ~30s a dead master would need. 10s is roughly 1000x that measured cost and
+                    // comfortably below the master's 25s wait, so a genuinely lost ack is reported
+                    // here, by the victim, with a message that names the problem - instead of the
+                    // master timing out first with a message that names nothing.
+                    await endProbe.ExpectMsgAsync<EndActor.EndAck>(TimeSpan.FromSeconds(10));
                 }
                 finally
                 {
-                    Shutdown(freshSystem);
+                    await ShutdownAsync(freshSystem, TimeSpan.FromSeconds(5));
                 }
                 // no barrier here, because it is not part of testConductor roles any more
             }, _victim.Value);
@@ -305,6 +309,36 @@ namespace Akka.Cluster.Tests.MultiNode
                 await RunOnAsync(async () =>
                 {
                     await ExpectMsgAsync<EndActor.End>(TimeSpan.FromSeconds(20));
+
+                    // Receiving End is not proof the victim is done - the EndAck this node just
+                    // emitted, in the same OnReceive that released the ExpectMsg above, still has
+                    // to reach it, and that ack is an ordinary, at-most-once Artery message. If we
+                    // return now, one already-parked barrier and xunit's teardown put this node
+                    // into ActorSystem.Terminate() within tens of milliseconds, /user stops, and
+                    // the outbound stream dies with it before any shutdown flush can run - so the
+                    // ack can be lost with no trace (no Dropped, no dead letter, nothing).
+                    //
+                    // Wait instead for the event that proves the victim no longer needs us: its
+                    // departure. The fresh system shuts itself down as soon as its
+                    // ExpectMsg<EndAck> returns OR throws, so "victim unreachable" is causally
+                    // downstream of the ack either landing or being given up on - this node
+                    // cannot begin terminating before that has happened. On the run that exposed
+                    // this race, the failure detector marked the victim unreachable 3.5-4.5s after
+                    // it terminated (heartbeat-interval/reaper 500ms each, MultiNodeClusterSpec.cs
+                    // :53/:56); 25s undilated is comfortably above that with headroom for the
+                    // victim's own 10s ack wait plus its 5s shutdown.
+                    //
+                    // Match on address, not uid: downing-provider-class is empty for multi-node
+                    // specs, so this member is never removed and Members never changes - only
+                    // reachability does. Waiting on Members would hang forever.
+                    var victimAddress = GetAddress(_victim.Value);
+                    await AwaitAssertAsync(() =>
+                    {
+                        var unreachable = ClusterView.UnreachableMembers.Select(m => m.Address).ToImmutableHashSet();
+                        Assert.True(unreachable.Contains(victimAddress),
+                            $"[{victimAddress}] should have become unreachable once the fresh victim " +
+                            $"system terminated; currently unreachable: [{string.Join(", ", unreachable)}]");
+                    }, TimeSpan.FromSeconds(25), TimeSpan.FromMilliseconds(250));
                 }, _master.Value);
                 await EndBarrierAsync();
             }, AllBut(_victim.Value).ToArray());


### PR DESCRIPTION
Stacked on #8573.

## What changes

`UnreachableNodeJoinsAgainSpec`'s master no longer terminates the moment it has replied to the fresh victim's `End`. After the reply it waits for the victim's fresh incarnation to show up in its own cluster view as unreachable, matched on address, with a 25 s bound. The victim only terminates after its acknowledgement round completes. The same detection took 3.5 to 4.5 s in the reverse direction on the failing run, measured on node four as the other three died, and 4.06 s in the forward direction on a local run; the settings are symmetric and every node monitors every other, so the two are comparable. So the master's teardown now happens after the acknowledgement has been delivered, or after the victim has given up. Membership never changes here: the multi-node config has no downing provider, and it turns off `run-by-actor-system-terminate`, so the fresh system's `Terminate()` is a bare guardian stop with no coordinated shutdown and no leave. The victim stays `Up` and simply stops heartbeating, so the wait is on reachability, not on members. Without that config fact the victim would be removed instead and the wait would never complete.

The victim's acknowledgement bound drops from 30 s to 10 s: the resolve proves the lane, the acknowledgement is one write on a live association, the master now outlives it, and 10 s keeps the victim reporting before the master's 25 s wait. The fresh system shuts down with `ShutdownAsync`, the conductor call uses its async form, and a dead null check after `ResolveOne`, which throws rather than returning null, is gone. Both bounds that move get narrower; the master gains a new 25 s bound where it previously had none.

## Why

Build 131351, Linux Artery, on a stack PR: node four timed out after 30 s waiting for `EndAck`. This spec already had the resolve-before-send change from #8475, and it worked as designed: the fresh system bound its address at 04:59:57.05, the master welcomed it at 58.1, the resolve succeeded at about 58.4 over the single lane the acknowledgement uses, and the master replied and terminated within about 100 ms. Node four's log shows every connection to the master refused from 59.17 onwards. The acknowledgement died in the master's teardown: on dev Artery's stream supervisor lives under the user guardian and dies before any shutdown flush, and node four's own log shows its streams aborting 4 ms before the terminator announces the flush. No ordering on the sending side can close that, because the acknowledgement is emitted after the message that releases the master to terminate. Quarantine is ruled out: a plain reply cannot cross a quarantine, and the identity reply arrived.

The product side is #8554, whose second commit hosts the materializer under the system guardian so the flush is real. With it in place this spec still benefits from the narrower bounds; without it the master's wait is what keeps the acknowledgement alive. ClusterDeathWatchSpec, the other user of this handshake, cannot use the same wait because its end system is not a cluster member; #8563 narrows that spec and #8554 closes it.

## How it was checked

`dotnet build src/core/Akka.Cluster.Tests.MultiNode -c Release -warnaserror` clean. The spec run three times on each transport: 4 of 4 nodes passed every time, 13 to 17 s. The grep for synchronous TestKit calls, blocking waits, and sleeps on the file returns nothing after the second commit. Test-only change. No ledger entry.

## Second commit: what the adversarial review found

The master's end-of-spec path is now its 20 s wait for `End` followed by up to 25 s waiting for the victim to go unreachable, 45 s back to back, while the other two nodes are already parked on the final barrier. The conductor arms a barrier's clock at the first arrival and never extends it, so the default 30 s barrier could expire and fail those two nodes before the master's own assertion reported. The spec's config now sets a 60 s barrier, the value `InitialHeartbeatSpec` and six other multi-node specs use for the same reason, with the arithmetic in a comment. A pre-existing blocking `Node(...)` lookup on the same node became the cached `GetAddress`. Run once after the change: 4 of 4 nodes passed in 19 s.
