### PR TITLE
De-flake ClusterSpec leave facts: wait for Up before leaving so the core ref is published, and re-tick until Removed

### DIFF
--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -214,25 +214,24 @@ namespace Akka.Cluster.Tests
         [Fact]
         public async Task A_cluster_must_return_completed_LeaveAsync_task_if_member_already_removed()
         {
-            // Join cluster
-            _cluster.Join(_selfAddress);
-            LeaderActions(); // Joining -> Up
-
-            // Subscribe to MemberRemoved and wait for confirmation
-            _cluster.Subscribe(TestActor, typeof(ClusterEvent.MemberRemoved));
+            // Subscribe before joining and await the snapshot, so the publisher has registered the
+            // subscription before any membership event can be published.
+            _cluster.Subscribe(TestActor, typeof(ClusterEvent.MemberUp), typeof(ClusterEvent.MemberRemoved));
             await ExpectMsgAsync<ClusterEvent.CurrentClusterState>();
+
+            // Join cluster. Awaiting MemberUp before issuing any further command orders everything
+            // behind the join. Cluster.ClusterCore re-targets from the supervisor to the core daemon
+            // when the ref is published, and a later command can otherwise overtake the join.
+            _cluster.Join(_selfAddress);
+            await ExpectMsgAsync<ClusterEvent.MemberUp>(TimeSpan.FromSeconds(10));
 
             // Leave the cluster prior to calling LeaveAsync()
             _cluster.Leave(_selfAddress);
 
-            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
-            {
-                LeaderActions(); // Leaving --> Exiting
-                LeaderActions(); // Exiting --> Removed
-
-                // Member should leave
-                (await ExpectMsgAsync<ClusterEvent.MemberRemoved>()).Member.Address.Should().Be(_selfAddress);
-            });
+            // Leaving to Exiting takes exactly one leader pass, and removal follows from the
+            // coordinated-shutdown round trip that pass starts, so no further tick is needed.
+            LeaderActions();
+            (await ExpectMsgAsync<ClusterEvent.MemberRemoved>(TimeSpan.FromSeconds(10))).Member.Address.Should().Be(_selfAddress);
 
             // LeaveAsync() task expected to complete immediately
             await _cluster.LeaveAsync().WaitAsync(RemainingOrDefault);
@@ -241,13 +240,14 @@ namespace Akka.Cluster.Tests
         [Fact]
         public async Task A_cluster_must_cancel_LeaveAsync_task_if_CancellationToken_fired_before_node_left()
         {
-            // Join cluster
-            _cluster.Join(_selfAddress);
-            LeaderActions(); // Joining -> Up
-
-            // Subscribe to MemberRemoved and wait for confirmation
-            _cluster.Subscribe(TestActor, typeof(ClusterEvent.MemberRemoved));
+            // See the sibling already-removed fact above for why the MemberUp wait below is a
+            // barrier: subscribe before joining and await the snapshot, so the publisher has
+            // registered the subscription before any membership event can be published.
+            _cluster.Subscribe(TestActor, typeof(ClusterEvent.MemberUp), typeof(ClusterEvent.MemberRemoved));
             await ExpectMsgAsync<ClusterEvent.CurrentClusterState>();
+
+            _cluster.Join(_selfAddress);
+            await ExpectMsgAsync<ClusterEvent.MemberUp>(TimeSpan.FromSeconds(10));
 
             // Requesting leave with cancellation token
             var cts = new CancellationTokenSource();
@@ -258,27 +258,22 @@ namespace Akka.Cluster.Tests
 
             // Cancelling the first task
             cts.Cancel();
-            await AwaitConditionAsync(() => Task.FromResult(task1.IsCanceled), null, "Task should be cancelled");
+            await AwaitConditionAsync(() => task1.IsCanceled, TimeSpan.FromSeconds(3), TimeSpan.FromMilliseconds(100), "Task should be cancelled");
 
-            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
-            {
-                // Second task should continue awaiting for cluster leave
-                task2.IsCompleted.Should().BeFalse();
+            // Second task should continue awaiting for cluster leave
+            task2.IsCompleted.Should().BeFalse();
 
-                // Waiting for leave
-                LeaderActions(); // Leaving --> Exiting
-                LeaderActions(); // Exiting --> Removed
+            // Leaving to Exiting takes exactly one leader pass, and removal follows from the
+            // coordinated-shutdown round trip that pass starts, so no further tick is needed.
+            LeaderActions();
+            (await ExpectMsgAsync<ClusterEvent.MemberRemoved>(TimeSpan.FromSeconds(10))).Member.Address.Should().Be(_selfAddress);
 
-                // Member should leave even a task was cancelled
-                (await ExpectMsgAsync<ClusterEvent.MemberRemoved>()).Member.Address.Should().Be(_selfAddress);
-
-                // Second task should complete (not cancelled)
-                await AwaitConditionAsync(() => Task.FromResult(task2.IsCompleted && !task2.IsCanceled), null, "Task should be completed, but not cancelled.");
-            });
+            // Second task should complete (not cancelled)
+            await AwaitConditionAsync(() => task2.IsCompleted && !task2.IsCanceled, TimeSpan.FromSeconds(3), TimeSpan.FromMilliseconds(100), "Task should be completed, but not cancelled.");
 
             // Subsequent LeaveAsync() tasks expected to complete immediately (not cancelled)
             var task3 = _cluster.LeaveAsync();
-            await AwaitConditionAsync(() => Task.FromResult(task3.IsCompleted && !task3.IsCanceled), null, "Task should be completed, but not cancelled.");
+            await AwaitConditionAsync(() => task3.IsCompleted && !task3.IsCanceled, TimeSpan.FromSeconds(3), TimeSpan.FromMilliseconds(100), "Task should be completed, but not cancelled.");
         }
 
         [Fact]


### PR DESCRIPTION
## What changes

The two `LeaveAsync` facts in `ClusterSpec` wait on membership events instead of counting leader ticks by hand.

- Each fact subscribes to `MemberUp` and `MemberRemoved` before it joins, takes the state snapshot, joins, and awaits `MemberUp` with a 10 s bound. No leader tick on the join path: a bootstrap self-join runs the leader actions inline inside the join itself.
- After the leave call, exactly one leader tick, then `MemberRemoved` with a 10 s bound and the existing address assertion. That tick moves the node from Leaving to Exiting and starts the coordinated-shutdown round trip that ends with the daemon stopping and `MemberRemoved` being published. The old second tick was always a no-op: with the node already Exiting there is nothing left for a leader pass to change.
- The `Within` around the tail of the cancel fact is gone; it only added the abandon-timer message and on dev still carried the already-cancelled token. The task-state waits use the plain condition overload with explicit bounds. No assertion changes.

## Why

Build 131421, Windows unit tests, on a PR that changes only the TestKit's teardown: the cancel fact timed out after 10 s waiting for `MemberRemoved`, and its own log shows why in its first line. The `Leave` reached the cluster core daemon before the node's own `JoinTo` and was dead-lettered, because the daemon's uninitialized state has no case for it. The node joined, went Up, and sat there.

The reorder is a product hazard, not a test-authoring mistake. `Cluster.ClusterCore` resolves to the core daemon once the reference is published and to the `/system/cluster` supervisor before that, and Akka's ordering guarantee is per sender-receiver pair, so a `Join` on the two-hop path and a `Leave` issued right after it on the direct path can arrive reversed, in a window of a few milliseconds at startup. This came in with #8359. The product fix is #8580; this PR keeps the spec correct on dev as it stands. Awaiting `MemberUp` before issuing anything else orders every later command behind the join, and the barrier stays correct after #8580 as well, because it waits on the membership event the facts are about.

An earlier version of this PR re-ticked in loops until Up and until Removed. The maintainer asked whether repeated ticks were needed at all, and a review of the leader path showed they are not: zero for the join, one for the leave, zero for the removal. This version is the minimal shape.

#8540 had fixed a different failure of the same fact and is not undone. The TestKit change on the triggering PR is not involved; dev fails the same way. The other two facts in the file that register on membership events do not issue `Leave` or `Down` before their `MemberUp`, and the calls they make are never dropped by the uninitialized state, so they are left alone.

## How it was checked

`dotnet build src/core/Akka.Cluster.Tests -c Release -warnaserror` clean. Each changed fact run 20 times: 20 of 20. The whole `ClusterSpec` class: 20 passed. A debug-level run shows no leader-tick dead letter after removal. The grep for synchronous TestKit calls, blocking waits, and sleeps on the file returns nothing. Test-only change. No ledger entry.
