### PR TITLE
De-flake RemoteNodeDeathWatchSpec: barrier after the subject stops, resend-derived bound, identify asserts the actor exists

### DIFF
--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteNodeDeathWatchSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteNodeDeathWatchSpec.cs
@@ -166,9 +166,13 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
     /// <see cref="RemoteNodeDeathWatch_must_receive_Terminated_when_remote_actor_is_stoppedAsync"/>) that
     /// the <c>DeathWatchNotification</c> system message was already handed to remoting. Nominal cost from
     /// there is one one-way hop on an association this phase has already exercised in both directions
-    /// (identify out, "helloN" back) - single-digit ms. A lost or unacked frame is recovered by the
-    /// repeating AttemptSysMsgRedelivery timer at akka.remote.resend-interval (Remote.conf, 2s), so budget
-    /// two resend cycles plus one hop and dispatcher scheduling slack on a loaded CI agent: 2s + 2s + 2s = 6s.
+    /// (identify out, "helloN" back), plus three local mailbox hops on the receiving side
+    /// (/system/remote-watcher, then the watcher actor, then the TestActor) - single-digit ms. A lost or
+    /// unacked frame is recovered by system-message redelivery: on classic remoting the repeating
+    /// AttemptSysMsgRedelivery timer at akka.remote.resend-interval (Remote.conf, 2s), which is the value
+    /// read below; Artery resends at akka.remote.artery.advanced.system-message-resend-interval (1s), so
+    /// the same budget covers it with more room. Budget two resend cycles plus one hop and dispatcher
+    /// scheduling slack on a loaded CI agent: 2s + 2s + 2s = 6s.
     ///
     /// NOT derived from the watch failure detector: the peer stays alive and keeps heartbeating in this
     /// scenario, so RemoteWatcher never marks it unreachable and AddressTerminated never fires. The FD is
@@ -184,7 +188,7 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
     {
         get
         {
-            var resend = RARP.For(Sys).Provider.RemoteSettings.SysResendTimeout; // 2s
+            var resend = RARP.For(Sys).Provider.RemoteSettings.SysResendTimeout; // classic resend-interval, 2s
             return resend + resend + TimeSpan.FromSeconds(2);                   // = 6s
         }
     }
@@ -198,10 +202,7 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
             await AwaitAssertAsync(async () =>
             {
                 (await GetRemoteWatcherAsync()).Tell(RemoteWatcher.Stats.Empty);
-                // Explicit bound: an unbounded expect here takes RemainingOrDefault, i.e. the whole
-                // remaining WithinAsync window, so a slow first reply would leave AwaitAssertAsync only
-                // one attempt instead of retrying at its ~100ms interval.
-                await ExpectMsgAsync<RemoteWatcher.Stats>(s => Equals(s, RemoteWatcher.Stats.Empty), TimeSpan.FromSeconds(1));
+                await ExpectMsgAsync<RemoteWatcher.Stats>(s => Equals(s, RemoteWatcher.Stats.Empty));
             });
         });
     }
@@ -250,11 +251,14 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
 
             await SleepAsync();
             // A local watch on second's own TestActor + Sys.Stop proves the subject is dead on second
-            // before first's window opens. ActorCell.TellWatchersWeDied notifies REMOTE watchers
-            // (first's watcher1) in a strictly earlier loop than LOCAL watchers (second's TestActor
-            // here), so by the time ExpectTerminatedAsync completes, the DeathWatchNotification bound
-            // for first has already been handed to the remoting stack. That closes out the independent
-            // Task.Delay(3000) timer-skew term that used to be part of first's wait budget.
+            // before first's window opens. ActorCell.TellWatchersWeDied notifies REMOTE watchers in a
+            // strictly earlier loop than LOCAL watchers (second's TestActor here). The remote watcher
+            // recorded on the subject is first's /system/remote-watcher, which re-issued watcher1's
+            // watch over the wire (RemoteActorRef intercepts Watch; RemoteWatcher forwards the
+            // notification to watcher1 locally). So by the time ExpectTerminatedAsync completes, the
+            // DeathWatchNotification bound for first has already been handed to the remoting stack.
+            // That closes out the independent Task.Delay(3000) timer-skew term that used to be part
+            // of first's wait budget.
             await WatchAsync(subject);
             Sys.Stop(subject);
             await ExpectTerminatedAsync(subject);

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteNodeDeathWatchSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteNodeDeathWatchSpec.cs
@@ -16,6 +16,7 @@ using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.Remote.Transport;
 using Akka.TestKit;
+using FluentAssertions;
 using static Akka.Remote.Tests.MultiNode.RemoteNodeDeathWatchMultiNetSpec;
 
 namespace Akka.Remote.Tests.MultiNode;
@@ -112,8 +113,7 @@ public class RemoteNodeDeathWatchMultiNetSpec : MultiNodeConfig
 public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
 {
     private readonly RemoteNodeDeathWatchMultiNetSpec _config;
-    private readonly Lazy<IActorRef> _remoteWatcher;
-    private readonly Func<RoleName, string, IActorRef> _identify;
+    private IActorRef _remoteWatcher;
 
     protected RemoteNodeDeathWatchSpec(Type type) : this(new RemoteNodeDeathWatchMultiNetSpec(), type)
     {
@@ -122,18 +122,6 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
     protected RemoteNodeDeathWatchSpec(RemoteNodeDeathWatchMultiNetSpec config, Type type) : base(config, type)
     {
         _config = config;
-
-        _remoteWatcher = new Lazy<IActorRef>(() =>
-        {
-            Sys.ActorSelection("/system/remote-watcher").Tell(new Identify(null));
-            return ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
-        });
-
-        _identify = (role, actorName) =>
-        {
-            Sys.ActorSelection(Node(role) / "user" / actorName).Tell(new Identify(actorName));
-            return ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
-        };
 
         MuteDeadLetters(null, typeof(Heartbeat));
     }
@@ -144,6 +132,63 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
 
     protected abstract Func<Task> SleepAsync { get; }
 
+    private async Task<IActorRef> GetRemoteWatcherAsync()
+    {
+        if (_remoteWatcher is null)
+        {
+            Sys.ActorSelection("/system/remote-watcher").Tell(new Identify(null));
+            _remoteWatcher = (await ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(10))).Subject;
+        }
+
+        return _remoteWatcher;
+    }
+
+    /// <summary>
+    /// Upstream (Pekko) asserts <c>actorIdentity.ref.isDefined</c> before unwrapping the identity; the
+    /// .NET port had dropped that assertion, so a node that never created the requested actor handed a
+    /// null <see cref="ActorIdentity.Subject"/> straight into <c>Context.Watch(null)</c> downstream. That
+    /// throws off the test thread, and the failure that surfaces is an unrelated Ack timeout rather than
+    /// the real "this actor doesn't exist" cause. Restoring the assertion here makes a missing actor fail
+    /// at the identify, naming the actor path.
+    /// </summary>
+    private async Task<IActorRef> IdentifyAsync(RoleName role, string actorName)
+    {
+        Sys.ActorSelection(await NodeAsync(role) / "user" / actorName).Tell(new Identify(actorName));
+        var identity = await ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(10));
+        identity.Subject.Should().NotBeNull(
+            "node [{0}] must answer for /user/{1}", role.Name, actorName);
+        return identity.Subject;
+    }
+
+    /// <summary>
+    /// Bound for a <see cref="WrappedTerminated"/> expected after the peer has already proven (via a
+    /// barrier entered only once its own local watch observed the death, see
+    /// <see cref="RemoteNodeDeathWatch_must_receive_Terminated_when_remote_actor_is_stoppedAsync"/>) that
+    /// the <c>DeathWatchNotification</c> system message was already handed to remoting. Nominal cost from
+    /// there is one one-way hop on an association this phase has already exercised in both directions
+    /// (identify out, "helloN" back) - single-digit ms. A lost or unacked frame is recovered by the
+    /// repeating AttemptSysMsgRedelivery timer at akka.remote.resend-interval (Remote.conf, 2s), so budget
+    /// two resend cycles plus one hop and dispatcher scheduling slack on a loaded CI agent: 2s + 2s + 2s = 6s.
+    ///
+    /// NOT derived from the watch failure detector: the peer stays alive and keeps heartbeating in this
+    /// scenario, so RemoteWatcher never marks it unreachable and AddressTerminated never fires. The FD is
+    /// the backstop for a dead node, not for a single lost notification on a live one.
+    ///
+    /// The old bound was the flat 3s akka.test.single-expect-default, which is shorter than one resend
+    /// cycle plus a hop - it could not survive a single dropped system message by construction.
+    ///
+    /// Pass this value undilated: ExpectMsgAsync's timeout parameter is [AutoDilate] and dilates
+    /// internally, so pre-dilating here would square the time factor.
+    /// </summary>
+    private TimeSpan RemoteTerminationTimeout
+    {
+        get
+        {
+            var resend = RARP.For(Sys).Provider.RemoteSettings.SysResendTimeout; // 2s
+            return resend + resend + TimeSpan.FromSeconds(2);                   // = 6s
+        }
+    }
+
     private async Task AssertCleanup(TimeSpan? timeout = null)
     {
         timeout ??= TimeSpan.FromSeconds(5);
@@ -152,8 +197,11 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
         {
             await AwaitAssertAsync(async () =>
             {
-                _remoteWatcher.Value.Tell(RemoteWatcher.Stats.Empty);
-                await ExpectMsgAsync<RemoteWatcher.Stats>(s => Equals(s, RemoteWatcher.Stats.Empty));
+                (await GetRemoteWatcherAsync()).Tell(RemoteWatcher.Stats.Empty);
+                // Explicit bound: an unbounded expect here takes RemainingOrDefault, i.e. the whole
+                // remaining WithinAsync window, so a slow first reply would leave AwaitAssertAsync only
+                // one attempt instead of retrying at its ~100ms interval.
+                await ExpectMsgAsync<RemoteWatcher.Stats>(s => Equals(s, RemoteWatcher.Stats.Empty), TimeSpan.FromSeconds(1));
             });
         });
     }
@@ -179,7 +227,7 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
             var watcher = Sys.ActorOf(Props.Create(() => new ProbeActor(TestActor)), "watcher1");
             await EnterBarrierAsync("actors-started-1");
 
-            var subject = _identify(_config.Second, "subject1");
+            var subject = await IdentifyAsync(_config.Second, "subject1");
             watcher.Tell(new WatchIt(subject));
             await ExpectMsgAsync<RemoteNodeDeathWatchMultiNetSpec.Ack>(TimeSpan.FromSeconds(1));
             subject.Tell("hello1");
@@ -187,7 +235,8 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
             await EnterBarrierAsync("watch-established-1");
 
             await SleepAsync();
-            (await ExpectMsgAsync<WrappedTerminated>()).T.ActorRef.ShouldBe(subject);
+            await EnterBarrierAsync("subject-stopped-1");
+            (await ExpectMsgAsync<WrappedTerminated>(RemoteTerminationTimeout)).T.ActorRef.ShouldBe(subject);
         }, _config.First);
 
         await RunOnAsync(async () =>
@@ -200,7 +249,16 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
             await EnterBarrierAsync("watch-established-1");
 
             await SleepAsync();
+            // A local watch on second's own TestActor + Sys.Stop proves the subject is dead on second
+            // before first's window opens. ActorCell.TellWatchersWeDied notifies REMOTE watchers
+            // (first's watcher1) in a strictly earlier loop than LOCAL watchers (second's TestActor
+            // here), so by the time ExpectTerminatedAsync completes, the DeathWatchNotification bound
+            // for first has already been handed to the remoting stack. That closes out the independent
+            // Task.Delay(3000) timer-skew term that used to be part of first's wait budget.
+            await WatchAsync(subject);
             Sys.Stop(subject);
+            await ExpectTerminatedAsync(subject);
+            await EnterBarrierAsync("subject-stopped-1");
         }, _config.Second);
 
         await RunOnAsync(async () =>
@@ -208,6 +266,7 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
             await EnterBarrierAsync("actors-started-1");
             await EnterBarrierAsync("hello1-message-sent");
             await EnterBarrierAsync("watch-established-1");
+            await EnterBarrierAsync("subject-stopped-1");
         }, _config.Third);
 
         await EnterBarrierAsync("terminated-verified-1");
@@ -227,7 +286,7 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
             var watcher = Sys.ActorOf(Props.Create(() => new ProbeActor(TestActor)), "watcher2");
             await EnterBarrierAsync("actors-started-2");
 
-            var subject = _identify(_config.Second, "subject2");
+            var subject = await IdentifyAsync(_config.Second, "subject2");
             watcher.Tell(new WatchIt(subject));
             await ExpectMsgAsync<RemoteNodeDeathWatchMultiNetSpec.Ack>(TimeSpan.FromSeconds(1));
             await EnterBarrierAsync("watch-2");
@@ -239,8 +298,12 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
             await EnterBarrierAsync("unwatch-2");
         }, _config.First);
 
-        RunOn(() => Sys.ActorOf(Props.Create(() => new ProbeActor(TestActor)), "subject2"), _config.Second);
-            
+        await RunOnAsync(() =>
+        {
+            Sys.ActorOf(Props.Create(() => new ProbeActor(TestActor)), "subject2");
+            return Task.CompletedTask;
+        }, _config.Second);
+
         await RunOnAsync(async () =>
         {
             await EnterBarrierAsync("actors-started-2");
@@ -265,7 +328,7 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
             await EnterBarrierAsync("actors-started-3");
 
             var other = Myself == _config.First ? _config.Second : _config.First;
-            var subject = _identify(other, "subject3");
+            var subject = await IdentifyAsync(other, "subject3");
             watcher.Tell(new WatchIt(subject));
             await ExpectMsgAsync<RemoteNodeDeathWatchMultiNetSpec.Ack>(TimeSpan.FromSeconds(1));
             await EnterBarrierAsync("watch-3");
@@ -303,8 +366,8 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
             await EnterBarrierAsync("actors-started-4");
 
             var other = Myself == _config.First ? _config.Second : _config.First;
-            var subject1 = _identify(other, "s1");
-            var subject2 = _identify(other, "s2");
+            var subject1 = await IdentifyAsync(other, "s1");
+            var subject2 = await IdentifyAsync(other, "s2");
             watcher1.Tell(new WatchIt(subject1));
             await ExpectMsgAsync<RemoteNodeDeathWatchMultiNetSpec.Ack>(TimeSpan.FromSeconds(1));
             watcher2.Tell(new WatchIt(subject2));
@@ -322,7 +385,7 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
 
             Sys.Stop(s2);
             await EnterBarrierAsync("stop-s2-4");
-            (await ExpectMsgAsync<WrappedTerminated>()).T.ActorRef.ShouldBe(subject2);
+            (await ExpectMsgAsync<WrappedTerminated>(RemoteTerminationTimeout)).T.ActorRef.ShouldBe(subject2);
         }, _config.First, _config.Second);
 
         await RunOnAsync(async () =>
@@ -355,9 +418,9 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
 
             await EnterBarrierAsync("actors-started-5");
 
-            var b1 = _identify(_config.Second, "b1");
-            var b2 = _identify(_config.Second, "b2");
-            var b3 = _identify(_config.Second, "b3");
+            var b1 = await IdentifyAsync(_config.Second, "b1");
+            var b2 = await IdentifyAsync(_config.Second, "b2");
+            var b3 = await IdentifyAsync(_config.Second, "b3");
 
             a1.Tell(new WatchIt(b1));
             await ExpectMsgAsync<RemoteNodeDeathWatchMultiNetSpec.Ack>(TimeSpan.FromSeconds(1));
@@ -399,9 +462,9 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
 
             await EnterBarrierAsync("actors-started-5");
 
-            var a1 = _identify(_config.First, "a1");
-            var a2 = _identify(_config.First, "a2");
-            var a3 = _identify(_config.First, "a3");
+            var a1 = await IdentifyAsync(_config.First, "a1");
+            var a2 = await IdentifyAsync(_config.First, "a2");
+            var a3 = await IdentifyAsync(_config.First, "a3");
 
             b1.Tell(new WatchIt(a1));
             await ExpectMsgAsync<RemoteNodeDeathWatchMultiNetSpec.Ack>(TimeSpan.FromSeconds(1));
@@ -418,7 +481,7 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
             await EnterBarrierAsync("watch-established-5");
             await EnterBarrierAsync("stopped-5");
 
-            p1.ReceiveN(2, TimeSpan.FromSeconds(20))
+            (await p1.ReceiveNAsync(2, TimeSpan.FromSeconds(20)).ToListAsync())
                 .Cast<WrappedTerminated>()
                 .Select(w => w.T.ActorRef)
                 .OrderBy(r => r.Path.Name)
@@ -455,7 +518,7 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
             var watcher2 = Sys.ActorOf(Props.Create(() => new ProbeActor(Sys.DeadLetters)));
             await EnterBarrierAsync("actors-started-6");
 
-            var subject = _identify(_config.Second, "subject6");
+            var subject = await IdentifyAsync(_config.Second, "subject6");
             watcher.Tell(new WatchIt(subject));
             await ExpectMsgAsync<RemoteNodeDeathWatchMultiNetSpec.Ack>(TimeSpan.FromSeconds(1));
             watcher2.Tell(new WatchIt(subject));
@@ -506,7 +569,7 @@ public abstract class RemoteNodeDeathWatchSpec : MultiNodeSpec
             var watcher = Sys.ActorOf(Props.Create(() => new ProbeActor(TestActor)), "watcher7");
             await EnterBarrierAsync("actors-started-7");
 
-            var subject = _identify(_config.First, "subject7");
+            var subject = await IdentifyAsync(_config.First, "subject7");
             watcher.Tell(new WatchIt(subject));
             await ExpectMsgAsync<RemoteNodeDeathWatchMultiNetSpec.Ack>(TimeSpan.FromSeconds(1));
             subject.Tell("hello7");


### PR DESCRIPTION
## What changes

`RemoteNodeDeathWatchSpec` (the Slow and Fast variants) gets a barrier between the subject being stopped and the remote watcher's wait for `Terminated`, so that wait opens on the real event instead of on a timer that happens to be the same length as the other node's sleep.

- **Phase 1.** `second` now watches the subject from its own test actor, stops it, awaits the local `Terminated`, and only then enters a new `subject-stopped-1` barrier. `first` and `third` enter the same barrier, and `first` waits for `WrappedTerminated` after it. The actor cell notifies remote watchers before local ones, so the local `Terminated` on `second` proves the `DeathWatchNotification` bound for `first` was already handed to remoting.
- **The bound.** `first`'s wait uses an explicit 6 s, derived from `akka.remote.resend-interval` (2 s): two resend cycles for a lost or unacked system message plus one hop and scheduling slack. It is not derived from the watch failure detector, which never fires here because the peer stays alive and heartbeating. The same bound replaces the flat 3 s default at the phase 4 wait. That barrier is entered right after `Sys.Stop`, so it proves the stop was issued rather than observed, a weaker point than the new phase 1 shape; the 6 s covers the extra guardian hop. Passed undilated, since the timeout parameter dilates itself. The value reads the classic resend interval; Artery resends system messages every 1 s, so the same budget covers it with more room.
- **Identify.** The helper asserts that `ActorIdentity.Subject` is not null, naming the node and actor path. Upstream has this assertion; the .NET port had dropped it, so a missing actor surfaced later as an unrelated `Ack` timeout.
- **Async migration** of what was left in the file: the remote-watcher lookup and the identify helper (including `NodeAsync` in place of the blocking `Node`), one `RunOn`, and one `ReceiveN`.

## Why

Build 131425, Windows multi-node, classic transport, on #8554 (whose Artery change is not on this code path): `RemoteNodeDeathWatchSlowSpec` failed on `first` with a 3 s timeout waiting for `WrappedTerminated` in phase 1. Nothing arrived at all.

The phase had `first` and `second` each sleep 3 s independently after the `watch-established-1` barrier, then `second` stopped the subject while `first` waited the flat 3 s single-expect default. Nothing ordered the stop before the wait, so the window had to absorb the skew between two `Task.Delay(3000)` timers on a loaded agent plus the remote notification hop, and a `DeathWatchNotification` that is lost once is only resent every 2 s. A 3 s window could not survive a single lost system message by construction. Upstream has the same shape, so this is a test-authoring gap rather than a product regression.

Two other 3 s waits in the file (the `hello6` and `hello7` phases) have a similar shape but no stop involved, and mirror upstream. They are left for a separate change rather than folded in here.

## Later commit

The second commit answers review. The phase 1 comment named the local watcher as the remote one; the remote watcher recorded on the subject is `first`'s `/system/remote-watcher`, which re-issues the watch over the wire and forwards the notification locally. The bound's comment now says which transport its resend value belongs to. A 1 s bound that the first commit had added to the nested expect inside `AssertCleanup` is removed again: the predicate overload asserts rather than filters, so the retry loop was already content-driven, and a timed-out attempt could offset later requests from their replies.

## How it was checked

`dotnet build src/core/Akka.Remote.Tests.MultiNode -c Release -warnaserror` clean. The three `RemoteNodeDeathWatch*` specs (six tests) run through the multi-node adapter: classic transport four times, Artery three times, all passed, about 80 s per run; once more on classic after the second commit, 6 of 6. The first commit also passed a full CI run on two heads. The grep for synchronous TestKit calls, blocking waits, and sleeps on the file returns only the actor-side `Context.Watch` and a doc comment. Test-only change. No ledger entry.
