### PR TITLE
De-flake EntityTerminationSpec: anchor on the shard's own entity set and wait out the restart backoff without blocking a pool thread

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/EntityTerminationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/EntityTerminationSpec.cs
@@ -7,7 +7,7 @@
 
 using System;
 using System.Linq;
-using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
@@ -110,20 +110,41 @@ namespace Akka.Cluster.Sharding.Tests
         {
         }
 
-        protected override void AtStartup()
+        private async Task JoinSelfAsync()
         {
             // Form a one node cluster
             var cluster = Cluster.Get(Sys);
             cluster.Join(cluster.SelfAddress);
-            AwaitAssert(() =>
+            await AwaitAssertAsync(() =>
             {
                 cluster.ReadView.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(1);
-            });
+            }, TimeSpan.FromSeconds(10));
+        }
+
+        /// <summary>
+        /// Polls the region until the shard's active entity set is exactly <paramref name="expected"/>.
+        /// An entity's Terminated reaches the shard as a user message, queued behind whatever else is in the
+        /// shard's mailbox, so the test actor seeing Terminated says nothing about the shard having processed
+        /// it. The active set is the observable the assertions in this spec read, so it is the anchor.
+        /// </summary>
+        private async Task AwaitActiveEntitiesAsync(IActorRef sharding, params string[] expected)
+        {
+            await AwaitAssertAsync(async () =>
+            {
+                sharding.Tell(GetShardRegionState.Instance);
+                var state = await ExpectMsgAsync<CurrentShardRegionState>(TimeSpan.FromSeconds(1));
+                state.Shards.Should().HaveCount(1);
+                if (expected.Length == 0)
+                    state.Shards.First().EntityIds.Should().BeEmpty();
+                else
+                    state.Shards.First().EntityIds.Should().BeEquivalentTo(expected);
+            }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
         }
 
         [Fact]
-        public void Sharding_when_an_entity_terminates_must_allow_stop_without_passivation_if_not_remembering_entities()
+        public async Task Sharding_when_an_entity_terminates_must_allow_stop_without_passivation_if_not_remembering_entities()
         {
+            await JoinSelfAsync();
             var sharding = ClusterSharding.Get(Sys).Start(
                 "regular",
                 StoppingActor.Props(),
@@ -131,30 +152,29 @@ namespace Akka.Cluster.Sharding.Tests
                 new MessageExtractor());
 
             sharding.Tell(new EntityEnvelope("1", "ping"));
-            ExpectMsg("pong-1");
+            await ExpectMsgAsync("pong-1");
             var entity = LastSender;
 
             sharding.Tell(new EntityEnvelope("2", "ping"));
-            ExpectMsg("pong-1");
+            await ExpectMsgAsync("pong-1");
 
-            Watch(entity);
+            await WatchAsync(entity);
             sharding.Tell(new EntityEnvelope("1", "stop"));
-            ExpectTerminated(entity);
+            await ExpectTerminatedAsync(entity, TimeSpan.FromSeconds(3));
 
-            Thread.Sleep(400); // restart backoff is 250 ms
-            sharding.Tell(GetShardRegionState.Instance);
-            var regionState = ExpectMsg<CurrentShardRegionState>();
-            regionState.Shards.Should().HaveCount(1);
-            regionState.Shards.First().EntityIds.Should().BeEquivalentTo("2");
+            // With remember-entities off there is no restart path, so there is no backoff to wait out:
+            // once the shard has processed the entity's Terminated, "2" is the whole active set.
+            await AwaitActiveEntitiesAsync(sharding, "2");
 
             // make sure the shard didn't crash (coverage for regression bug #29383)
             sharding.Tell(new EntityEnvelope("2", "ping"));
-            ExpectMsg("pong-2"); // if it lost state we know it restarted
+            await ExpectMsgAsync("pong-2"); // if it lost state we know it restarted
         }
 
         [Fact]
-        public void Sharding_when_an_entity_terminates_must_automatically_restart_a_terminating_entity_not_passivating_if_remembering_entities()
+        public async Task Sharding_when_an_entity_terminates_must_automatically_restart_a_terminating_entity_not_passivating_if_remembering_entities()
         {
+            await JoinSelfAsync();
             var sharding = ClusterSharding.Get(Sys).Start(
                 "remembering",
                 StoppingActor.Props(),
@@ -162,26 +182,28 @@ namespace Akka.Cluster.Sharding.Tests
                 new MessageExtractor());
 
             sharding.Tell(new EntityEnvelope("1", "ping"));
-            ExpectMsg("pong-1");
+            await ExpectMsgAsync("pong-1");
             var entity = LastSender;
-            Watch(entity);
+            await WatchAsync(entity);
 
-            sharding.Tell(new EntityEnvelope("1", "stop"));
-            ExpectTerminated(entity);
-
-            Thread.Sleep(400); // restart backoff is 250 ms
-            AwaitAssert(() =>
+            // The restart is the shard's own event: when entity-restart-backoff (250 ms) expires it starts the
+            // entity again and logs the same "Started entity" line it logged the first time. Waiting on that
+            // line proves the restart happened, and that nothing here caused it, without racing the shard's
+            // bookkeeping: until the shard processes the Terminated, the active set still holds the dead ref,
+            // so a state poll on its own could pass on the old incarnation.
+            await EventFilter.Debug(contains: "Started entity").ExpectOneAsync(TimeSpan.FromSeconds(5), async () =>
             {
-                sharding.Tell(GetShardRegionState.Instance);
-                var regionState = ExpectMsg<CurrentShardRegionState>();
-                regionState.Shards.Should().HaveCount(1);
-                regionState.Shards.First().EntityIds.Should().HaveCount(1);
-            }, TimeSpan.FromSeconds(2));
+                sharding.Tell(new EntityEnvelope("1", "stop"));
+                await ExpectTerminatedAsync(entity, TimeSpan.FromSeconds(3));
+            });
+
+            await AwaitActiveEntitiesAsync(sharding, "1");
         }
 
         [Fact]
-        public void Sharding_when_an_entity_terminates_must_allow_terminating_entity_to_passivate_if_remembering_entities()
+        public async Task Sharding_when_an_entity_terminates_must_allow_terminating_entity_to_passivate_if_remembering_entities()
         {
+            await JoinSelfAsync();
             var sharding = ClusterSharding.Get(Sys).Start(
                 "remembering",
                 StoppingActor.Props(),
@@ -189,16 +211,27 @@ namespace Akka.Cluster.Sharding.Tests
                 new MessageExtractor());
 
             sharding.Tell(new EntityEnvelope("1", "ping"));
-            ExpectMsg("pong-1");
+            await ExpectMsgAsync("pong-1");
             var entity = LastSender;
-            Watch(entity);
+            await WatchAsync(entity);
 
             sharding.Tell(new EntityEnvelope("1", "passivate"));
-            ExpectTerminated(entity);
-            Thread.Sleep(400); // restart backoff is 250 ms
+            await ExpectTerminatedAsync(entity, TimeSpan.FromSeconds(3));
 
+            // Anchor on the shard's own bookkeeping first. A shard that mistook the passivation for a crash
+            // would arm the entity-restart-backoff timer (250 ms) at the same moment, so once the entity has
+            // left the active set the clock for a wrongful restart is running.
+            await AwaitActiveEntitiesAsync(sharding);
+
+            // Wait out that backoff without blocking a thread-pool worker: this test body runs on one, and on
+            // a two-core agent the pool has only two. 400 ms is longer than the 250 ms backoff plus the entity
+            // start, so a wrongful restart has happened and is visible by the time we look.
+            await Task.Delay(TimeSpan.FromMilliseconds(400));
+
+            // Deliberately a single read, not a poll: polling for "empty" would accept the first empty reading
+            // and stop proving that nothing restarts afterwards.
             sharding.Tell(GetShardRegionState.Instance);
-            var regionState = ExpectMsg<CurrentShardRegionState>();
+            var regionState = await ExpectMsgAsync<CurrentShardRegionState>(TimeSpan.FromSeconds(3));
             regionState.Shards.Should().HaveCount(1);
             regionState.Shards.First().EntityIds.Should().BeEmpty();
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/EntityTerminationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/EntityTerminationSpec.cs
@@ -122,6 +122,22 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         /// <summary>
+        /// Asks the region for its state through a fresh probe. A fresh probe per request means a reply that
+        /// arrives after the caller stopped waiting goes to an actor nobody reads, instead of sitting in the
+        /// test actor's queue where a later expect would take it for a current snapshot. The region's own
+        /// query timeout is 3 s, which is longer than the per-attempt bound the polling helper uses.
+        /// </summary>
+        private async Task<CurrentShardRegionState> QueryRegionStateAsync(IActorRef sharding, TimeSpan timeout)
+        {
+            var probe = CreateTestProbe();
+            probe.Send(sharding, GetShardRegionState.Instance);
+            var state = await probe.ExpectMsgAsync<CurrentShardRegionState>(timeout);
+            state.Failed.Should().BeEmpty("every shard must answer the state query");
+            state.Shards.Should().HaveCount(1);
+            return state;
+        }
+
+        /// <summary>
         /// Polls the region until the shard's active entity set is exactly <paramref name="expected"/>.
         /// An entity's Terminated reaches the shard as a user message, queued behind whatever else is in the
         /// shard's mailbox, so the test actor seeing Terminated says nothing about the shard having processed
@@ -131,13 +147,20 @@ namespace Akka.Cluster.Sharding.Tests
         {
             await AwaitAssertAsync(async () =>
             {
-                sharding.Tell(GetShardRegionState.Instance);
-                var state = await ExpectMsgAsync<CurrentShardRegionState>(TimeSpan.FromSeconds(1));
-                state.Shards.Should().HaveCount(1);
-                if (expected.Length == 0)
-                    state.Shards.First().EntityIds.Should().BeEmpty();
-                else
-                    state.Shards.First().EntityIds.Should().BeEquivalentTo(expected);
+                var state = await QueryRegionStateAsync(sharding, TimeSpan.FromSeconds(1));
+                state.Shards.First().EntityIds.Should().BeEquivalentTo(expected);
+            }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
+        }
+
+        /// <summary>
+        /// Polls the region until the shard's active entity set is empty. See <see cref="AwaitActiveEntitiesAsync"/>.
+        /// </summary>
+        private async Task AwaitNoActiveEntitiesAsync(IActorRef sharding)
+        {
+            await AwaitAssertAsync(async () =>
+            {
+                var state = await QueryRegionStateAsync(sharding, TimeSpan.FromSeconds(1));
+                state.Shards.First().EntityIds.Should().BeEmpty();
             }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
         }
 
@@ -218,21 +241,22 @@ namespace Akka.Cluster.Sharding.Tests
             sharding.Tell(new EntityEnvelope("1", "passivate"));
             await ExpectTerminatedAsync(entity, TimeSpan.FromSeconds(3));
 
-            // Anchor on the shard's own bookkeeping first. A shard that mistook the passivation for a crash
-            // would arm the entity-restart-backoff timer (250 ms) at the same moment, so once the entity has
-            // left the active set the clock for a wrongful restart is running.
-            await AwaitActiveEntitiesAsync(sharding);
+            // Anchor on the shard's own bookkeeping first. The entity leaves the active set when the shard
+            // processes its Terminated, which is also the moment a shard that mistook the passivation for a
+            // crash would arm the entity-restart-backoff timer (250 ms). The remember-entities write for the
+            // stop may still be in flight at this point; it does not matter for what follows.
+            await AwaitNoActiveEntitiesAsync(sharding);
 
-            // Wait out that backoff without blocking a thread-pool worker: this test body runs on one, and on
-            // a two-core agent the pool has only two. 400 ms is longer than the 250 ms backoff plus the entity
-            // start, so a wrongful restart has happened and is visible by the time we look.
-            await Task.Delay(TimeSpan.FromMilliseconds(400));
+            // Now nothing may restart. "Started entity" is the shard's own restart line, so a zero-count filter
+            // held open for longer than the backoff observes a wrongful restart directly. The filter waits the
+            // whole window without blocking a thread-pool worker: this test body runs on one, and on a two-core
+            // agent the pool has only two.
+            await EventFilter.Debug(contains: "Started entity")
+                .ExpectAsync(0, TimeSpan.FromMilliseconds(600), () => Task.CompletedTask);
 
             // Deliberately a single read, not a poll: polling for "empty" would accept the first empty reading
-            // and stop proving that nothing restarts afterwards.
-            sharding.Tell(GetShardRegionState.Instance);
-            var regionState = await ExpectMsgAsync<CurrentShardRegionState>(TimeSpan.FromSeconds(3));
-            regionState.Shards.Should().HaveCount(1);
+            // and stop proving that nothing restarted in the meantime.
+            var regionState = await QueryRegionStateAsync(sharding, TimeSpan.FromSeconds(5));
             regionState.Shards.First().EntityIds.Should().BeEmpty();
         }
     }


### PR DESCRIPTION
## What changes

`EntityTerminationSpec` stops asserting shard state at a fixed wall-clock offset from an event the shard has not necessarily processed yet.

- **All three facts** wait for the shard's active entity set to reach the expected value before reading anything else. That set is the observable the assertions read, so it is the right anchor. An entity's `Terminated` reaches the shard as a system message that the cell re-queues as a user message behind whatever is already in the shard's mailbox, so the test actor seeing `Terminated` says nothing about the shard having processed it.
- **Passivation fact.** After the entity has left the active set, which is also the moment a shard that mistook the passivation for a crash would arm the 250 ms `entity-restart-backoff`, the fact holds a zero-count `EventFilter` on the shard's own "Started entity" line open for 600 ms, so a wrongful restart is observed directly rather than inferred from a later state read. Then it reads the state once more and asserts it is still empty. That read is deliberately a single read, not a poll: polling for "empty" would accept the first empty reading and stop proving that nothing restarted in the meantime.
- **Restart fact.** The restart is the shard's own event: when the backoff expires it starts the entity again and logs the same "Started entity" line it logged the first time. The fact waits on that line instead of sleeping, because until the shard processes the `Terminated` its active set still holds the dead ref, so a state poll on its own could pass on the old incarnation.
- **Non-remembering fact.** Its 400 ms sleep and the comment about a restart backoff are gone. With remember-entities off there is no restart path, so there is nothing to wait out.
- Every state query goes through a fresh test probe, and the region's `Failed` set is asserted empty. The polling helper bounds each attempt at 1 s while the region's own query timeout is 3 s, so a timed-out attempt's late reply must not land in the test actor's queue, where a later expect would take it for a current snapshot.
- The file is migrated to the async TestKit API. The one-node join moves from the synchronous `AtStartup` into an awaited helper each fact calls first.

## Why

Build 131434, Windows unit tests, on #8554 (an Artery change that is not on this code path): the passivation fact failed with `Expected collection to be empty, but found {"1"}`. The log shows the entity passivating at 42.814, the test actor's `ExpectTerminated` returning at once, then nothing from the shard until 43.222, when it answered the state query with the entity still active, and 43.223, when it processed the entity's `Terminated`. The shard's mailbox did not run for 408 ms.

Nothing in the shard or the mailbox lost that run. The test body runs on a thread-pool worker, the pool's worker floor on the two-core hosted agent is two, and `Thread.Sleep` is the one form of blocking the pool cannot see. The shard's mailbox item had been queued to the other worker's local queue; with one worker asleep in the test and the other not returning to its dispatch loop, nothing could pick it up until the sleep expired, which is why the stall is 408 ms and not the gate thread's 500 ms starvation check. Both ends of the stall line up with the sleep to within a millisecond. The test actor's prompt `Terminated` proves nothing about pool health, because the TestKit's test actor runs on the calling-thread dispatcher and receives it inline on the dying entity's thread.

The fixed sleep was also anchored to the wrong event even when the test passed. A wrongful restart timer would be armed when the shard processes the `Terminated`, not when the test actor sees it, so the 400 ms window often did not cover the backoff at all. Pekko's copy of this spec has the same shape.

Not related to #8574, which changed the remember-entities write timeout: the log shows the 5 s value in effect, and the writes here completed in about a millisecond.

## Later commit

The second commit answers review. The first version read the state on the test actor with a 1 s bound per polling attempt, shorter than the region's 3 s query timeout, so a timed-out attempt could leave a stale reply that the passivation fact's final read or the non-remembering fact's `pong-2` expect would dequeue. Queries now go through a fresh probe per attempt. The passivation fact's negative check moved from a `Task.Delay` plus a state read to the zero-count filter described above. Rebased onto dev.

## How it was checked

`dotnet build src/contrib/cluster/Akka.Cluster.Sharding.Tests -c Release -warnaserror` clean. The three facts run ten times through `dotnet test` after each commit: 60 of 60 passed, about 5 s per run. The grep for synchronous TestKit calls, blocking waits, and sleeps on the file returns nothing. Test-only change. No ledger entry.
