### PR TITLE
Cluster.Sharding: a coordinator hand-over only stops the local ShardRegion when the node is leaving

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardCoordinatorHandOverSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardCoordinatorHandOverSpec.cs
@@ -1,0 +1,99 @@
+//-----------------------------------------------------------------------
+// <copyright file="ShardCoordinatorHandOverSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Configuration;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    /// <summary>
+    /// A <see cref="ClusterSingletonManager"/> hand-over sends the coordinator its termination message, and a
+    /// hand-over is not always a shutdown: while a cluster forms, two members of the same role can both reach
+    /// Oldest, and the loser hands over while staying in the cluster. The coordinator used to read every
+    /// termination message as "this node is shutting down" and stop the node's own <see cref="ShardRegion"/>,
+    /// which <see cref="ClusterShardingGuardian"/> then dropped from <see cref="ClusterSharding"/>'s cache for the
+    /// rest of the process. This spec drives that path on one node.
+    /// </summary>
+    public class ShardCoordinatorHandOverSpec : AkkaSpec
+    {
+        private static Config SpecConfig =>
+            ConfigurationFactory.ParseString(@"
+                akka.loglevel = DEBUG
+                akka.actor.provider = cluster
+                akka.remote.dot-netty.tcp.port = 0
+                akka.cluster.sharding.state-store-mode = ddata
+                akka.cluster.sharding.distributed-data.durable.keys = []")
+                .WithFallback(ClusterSingleton.DefaultConfig())
+                .WithFallback(ClusterSharding.DefaultConfig());
+
+        private sealed class EchoActor : ReceiveActor
+        {
+            public EchoActor()
+            {
+                ReceiveAny(message => Sender.Tell(message));
+            }
+        }
+
+        private sealed class Extractor : IMessageExtractor
+        {
+            public string EntityId(object message) => message.ToString()!;
+            public object EntityMessage(object message) => message;
+            public string ShardId(object message) => "1";
+            public string ShardId(string entityId, object? messageHint = null) => "1";
+        }
+
+        public ShardCoordinatorHandOverSpec(ITestOutputHelper output) : base(SpecConfig, output)
+        {
+        }
+
+        [Fact(DisplayName = "ShardCoordinator should keep the local ShardRegion running when the singleton hands over and the node stays in the cluster")]
+        public async Task Should_keep_local_region_when_handover_is_not_a_shutdown()
+        {
+            var cluster = Cluster.Get(Sys);
+            cluster.Join(cluster.SelfAddress);
+            await AwaitAssertAsync(() => cluster.SelfMember.Status.Should().Be(MemberStatus.Up), TimeSpan.FromSeconds(10));
+
+            var region = ClusterSharding.Get(Sys).Start(
+                "Entity", Props.Create<EchoActor>(), ClusterShardingSettings.Create(Sys), new Extractor());
+
+            // One round trip: the coordinator is running and the region is registered with it.
+            region.Tell("1");
+            await ExpectMsgAsync("1", TimeSpan.FromSeconds(10));
+
+            // ClusterSingletonManager hands its termination message to the singleton child, the BackoffSupervisor
+            // named "singleton", which forwards it to the coordinator and treats it as the final stop message.
+            // Sending it there is the single-node stand-in for a hand-over.
+            var singleton = await Sys.ActorSelection("/system/sharding/EntityCoordinator/singleton")
+                .ResolveOne(TimeSpan.FromSeconds(5));
+            await WatchAsync(singleton);
+
+            singleton.Tell(ShardCoordinator.Terminate.Instance);
+
+            // The coordinator still stops on a hand-over; that is what lets the singleton manager finish it.
+            // Its supervisor stops with it, which is the Terminated we see here. The old code passes this
+            // step too, because it deferred the coordinator's stop until it had stopped the region.
+            await ExpectTerminatedAsync(singleton, TimeSpan.FromSeconds(5));
+
+            // The region must have survived. Watching an actor that has already stopped yields Terminated at
+            // once, so a short quiet window after the watch is the whole check, and the cache must still hold it.
+            await WatchAsync(region);
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+            ClusterSharding.Get(Sys).ShardRegion("Entity").Should().Be(region);
+
+            // Stop the region ourselves so teardown does not wait on a coordinator that is gone.
+            Sys.Stop(region);
+            await ExpectTerminatedAsync(region, TimeSpan.FromSeconds(5));
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
@@ -1609,6 +1609,7 @@ namespace Akka.Cluster.Sharding
 
         private readonly IActorRef _ignoreRef;
         private readonly Cluster _cluster;
+        private readonly CoordinatedShutdown _coordShutdown;
         private readonly TimeSpan _removalMargin;
         private readonly int _minMembers;
         private bool _allRegionsRegistered = false;
@@ -1657,6 +1658,7 @@ namespace Akka.Cluster.Sharding
             _ignoreRef = context.System.IgnoreRef;
 
             _cluster = Cluster.Get(context.System);
+            _coordShutdown = CoordinatedShutdown.Get(context.System);
             _removalMargin = _cluster.DowningProvider.DownRemovalMargin;
 
             if (string.IsNullOrEmpty(settings.Role))
@@ -1969,9 +1971,48 @@ namespace Akka.Cluster.Sharding
             return ReceiveTerminated(message);
         }
 
+        /// <summary>
+        /// <c>true</c> when this node is on its way out of the cluster. A <c>ClusterSingletonManager</c>
+        /// hand-over is not always a shutdown, so the coordinator may only tear the local <see cref="ShardRegion"/>
+        /// down along with itself when the node is leaving.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Cluster.SelfMember"/> reads a snapshot that a separate actor updates, so it can lag by one
+        /// mailbox hop. The only route where that matters is a self <c>MemberDowned</c>, and on a <c>Down</c> the
+        /// <see cref="ShardRegion"/> already skips its own graceful shutdown, so a stale read costs nothing.
+        /// <c>Removed</c> is deliberately not in the list: the read view synthesizes a <c>Removed</c> self member
+        /// whenever self is absent from its snapshot, including before the node has joined, and a real removal
+        /// stops the singleton manager outright, so no termination message is sent in that state.
+        /// </remarks>
+        private bool SelfIsLeavingCluster
+        {
+            get
+            {
+                if (_cluster.IsTerminated)
+                    return true;
+                if (_coordShutdown.ShutdownReason != null)
+                    return true;
+                // Leaving matters on its own: a peer can send HandOverToMe as soon as the leader moves us to
+                // Exiting, and that can beat the gossip that makes us run CoordinatedShutdown. In that window
+                // ShutdownReason is still null.
+                return _cluster.SelfMember.Status
+                    is MemberStatus.Leaving or MemberStatus.Exiting or MemberStatus.Down;
+            }
+        }
+
         private void HandleTerminate()
         {
-            if (_aliveRegions.Any(i => i.Path.Address.HasLocalScope) || _gracefulShutdownInProgress.Any(i => i.Path.Address.HasLocalScope))
+            // A hand-over is not always a shutdown. While a cluster forms, two members of the same role can both
+            // reach Oldest; the loser hands the singleton over and stays in the cluster. Stopping our own
+            // ShardRegion there is permanent: ClusterShardingGuardian watches the region and drops it from
+            // ClusterSharding's cache, so ClusterSharding.Get(sys).ShardRegion(typeName) throws for the rest
+            // of the process. The region only goes down with the coordinator when it is already handing off
+            // (the coordinated-shutdown path, which runs cluster-sharding-shutdown-region before cluster-exiting)
+            // or when this node is leaving.
+            var localRegionHandingOff = _gracefulShutdownInProgress.Any(i => i.Path.Address.HasLocalScope);
+            var localRegionAlive = _aliveRegions.Any(i => i.Path.Address.HasLocalScope);
+
+            if (localRegionHandingOff || (localRegionAlive && SelfIsLeavingCluster))
             {
                 foreach (var region in _aliveRegions.Where(i => i.Path.Address.HasLocalScope))
                 {
@@ -1984,6 +2025,12 @@ namespace Akka.Cluster.Sharding
             }
             else
             {
+                if (localRegionAlive)
+                    Log.Debug(
+                        "{0}: Coordinator singleton is handing over while this node stays in the cluster (self is [{1}]). Leaving the local ShardRegion running.",
+                        TypeName,
+                        _cluster.SelfMember.Status);
+
                 if (_rebalanceInProgress.Count == 0)
                     Log.Debug("{0}: Received termination message.", TypeName);
                 else if (Log.IsDebugEnabled)


### PR DESCRIPTION
## What changes

`ShardCoordinator.HandleTerminate` no longer treats every termination message from its `ClusterSingletonManager` as a node shutdown. It still stops the coordinator on every hand-over, which is what lets the singleton manager complete the hand-over. It only tears the node's own `ShardRegion` down with it when that region is already handing off, which is the coordinated-shutdown path, or when the node itself is leaving: the actor system is terminating, `CoordinatedShutdown` is running, or the self member is `Leaving`, `Exiting`, or `Down`. On a hand-over that is not a shutdown the region keeps running and the coordinator logs one debug line saying so.

A new single-node spec, `ShardCoordinatorHandOverSpec`, sends the singleton's termination message the way the manager does and asserts that the coordinator stops and the region does not. On dev it fails with "Expected no messages, instead we received Terminated [.../system/sharding/Entity]".

No public API, wire, or configuration change, so no ledger row; this restores the intent of a block that was written for the leaving case.

## Why

Fixes #8583. `ClusterShardingMinMembersPerRoleNotConfiguredSpec` has failed six times in two days on PRs that do not touch sharding, on both transports. The chain is the same in every log:

1. While the cluster forms with `min-nr-of-members = 2`, two nodes act as leader on disjoint views and assign conflicting up-numbers. Two members of the same role both reach `Oldest` for the coordinator singleton.
2. Gossip merges, the younger one hands over (`Oldest -> WasOldest -> HandingOver`) and stays `Up`. The manager sends the coordinator its termination message, as it does on every hand-over.
3. The coordinator reads that as "this node is shutting down", sends its own live region `GracefulShutdown`, and defers its stop until the region is gone.
4. `ClusterShardingGuardian` watches the region and removes it from `ClusterSharding`'s cache when it stops. From then on `ClusterSharding.Get(sys).ShardRegion(typeName)` throws on that node for the life of the process.

Steps 1 and 2 are by design and match Pekko line for line: the `TakeOverFromMe` / `HandOverToMe` exchange exists for exactly this, and it settled in about half a second in every log. Step 3 is the fault. The branch that sends `GracefulShutdown` to a live local region came from JVM Akka PR 30338 in 2021, a latency optimization for rolling updates whose own issue text says things work fine without it. Before that a termination message was a bare stop, which is still what the DData and persistent coordinators do on their other stop paths. So the change routes a benign hand-over back to what the coordinator did for six years before that optimization, and keeps the optimization on every real shutdown route.

The same gate also covers `LeaseLost` in the singleton manager, which sends the same termination message on a route that is not a shutdown at all.

Neither #8359 nor #8580 is involved: in every new log the racing pair is two joiners, never the self-joiner, and the up-number assignment, leader choice, and convergence check are unchanged and identical to upstream.

## Safety on the real shutdown routes

| Route | What the gate reads when the termination message arrives |
|---|---|
| `CoordinatedShutdown.Run`, any reason | `ShutdownReason` is set by the compare-and-swap at the top of `Run`, before any phase |
| `Cluster.Leave(self)`, region drained first | the region is already in the hand-off set; that branch is unchanged and unconditional |
| `Cluster.Leave(self)`, peer's `HandOverToMe` beats our own shutdown phase | self is `Leaving`. `Leaving` is part of the convergence set, so the leader can only move us to `Exiting` after we have seen that gossip, and a peer only becomes oldest on `MemberExited` |
| self downed by a peer | `Down`, or a stale `Up`; a stale read costs nothing because the region already skips its own drain when self is `Down` |
| actor system terminating | `Cluster.IsTerminated` |

`Removed` is deliberately not in the check: the read view synthesizes a `Removed` self member whenever self is absent from its snapshot, including before the node has joined, and a real removal stops the singleton manager outright.

## How it was checked

`dotnet build src/contrib/cluster/Akka.Cluster.Sharding.Tests -c Release -warnaserror` clean. The new spec fails on dev with the region's `Terminated` and passes with the change, ten of ten. The graceful-shutdown, leaving, and coordinated-shutdown specs in the unit project pass, and the multi-node `ClusterShardingGracefulShutdownOldestSpec`, `ClusterShardingGracefulShutdownSpec`, and `ClusterShardingLeavingSpec` pass; the first of those is the upstream gate for the optimization this touches. `ClusterShardingMinMembersPerRoleNotConfiguredSpec`, the spec that surfaced the fault, passes. The full `Akka.Cluster.Sharding.Tests` suite passes. `Akka.API.Tests` passes with no approval change.
