### PR TITLE
De-flake PropsSpec: await the producer latch instead of blocking on it for a flat second

### DIFF
--- a/src/core/Akka.Tests/Actor/PropsSpec.cs
+++ b/src/core/Akka.Tests/Actor/PropsSpec.cs
@@ -9,6 +9,7 @@ using Akka.Actor;
 using Akka.TestKit;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Akka.Tests.Actor
@@ -32,13 +33,15 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void Props_must_create_actor_by_producer()
+        public async Task Props_must_create_actor_by_producer()
         {
             TestLatch latchProducer = new TestLatch();
             TestLatch latchActor = new TestLatch();
             var props = Props.CreateBy(new TestProducer(latchProducer, latchActor));
             IActorRef actor = Sys.ActorOf(props);
-            latchActor.Ready(TimeSpan.FromSeconds(1));
+            // 3s matches akka.test.single-expect-default, the dilated budget ExpectMsg gives a single
+            // dispatcher hop; the old 1s flat, undilated, blocking wait could be exhausted by one pool stall.
+            await AwaitConditionAsync(() => latchActor.IsOpen, TimeSpan.FromSeconds(3), TimeSpan.FromMilliseconds(50), "the producer's Produce() must run when the actor is created");
         }
 
         [Fact]


### PR DESCRIPTION
## What changes

`Akka.Tests.Actor.PropsSpec.Props_must_create_actor_by_producer` (`src/core/Akka.Tests/Actor/PropsSpec.cs`) is now `async Task` and awaits the producer latch instead of blocking on it:

- Replaced `latchActor.Ready(TimeSpan.FromSeconds(1));` with `await AwaitConditionAsync(() => latchActor.IsOpen, TimeSpan.FromSeconds(3), TimeSpan.FromMilliseconds(50), "the producer's Produce() must run when the actor is created");`
- No other line in the file changed. No dispatcher, thread-pool, or config settings were touched.

## Why

CI build 131484 (Windows unit tests, 2-vCPU agent) failed this test with:

```
System.TimeoutException : Timeout of 00:00:01
```

thrown from `TestLatch.Ready(TimeSpan)` at `PropsSpec.cs:41`.

The test creates an actor through `Props.CreateBy(new TestProducer(...))`, and `TestProducer.Produce()` counts down `latchActor` when the actor cell instantiates the actor on a dispatcher thread. The old code blocked on that `CountdownEvent` with a flat, undilated 1 second wait, covering exactly one dispatcher hop. On the 2-vCPU Windows CI agents, thread-pool stalls of several hundred milliseconds are common (see PR #8584, which measured a 408 ms stall in a similar spot), so a 1 second budget for a single hop has no margin.

The new wait is 3 seconds, matching `akka.test.single-expect-default`, the dilated budget `ExpectMsg` gives for the same class of event (a single dispatcher hop). It polls `latchActor.IsOpen` every 50 ms instead of blocking the test thread, so the wait is cooperative and dilation-aware via `[AutoDilate]`.

## How it was checked

- `dotnet build src/core/Akka.Tests -c Release -warnaserror -m:1` — clean, 0 warnings, 0 errors.
- Ran the fact 20 times in a row: `dotnet test src/core/Akka.Tests -c Release --no-build --framework net10.0 --filter "FullyQualifiedName~PropsSpec"` — 20/20 passed.
- Grepped the file for remaining blocking/sync TestKit calls (`ExpectMsg`, `Ready(`, `.Wait(`, `.Result`, `Thread.Sleep`, etc.) — no matches.
- Test-only change; no public API surface touched, so no `BREAKING_CHANGES_V1.6.md` entry is needed.
