### PR TITLE
ClusterSingletonRestartSpec: assert the hand-over confirmation reaches the new oldest, so a lost HandOverInProgress is named instead of timed out

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
@@ -109,7 +109,14 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             // on the same host:port below. dot-netty's tcp-reuse-addr is off-for-windows, so that rebind
             // is exactly the kind of thing that fails on Windows and nowhere else. Terminate() runs
             // CoordinatedShutdown to completion: the hand-over to sys2 finishes and the port is released.
-            await _sys1.Terminate();
+            //
+            // A failure here means sys2 never logged the hand-over confirmation from sys1 - i.e. the
+            // "Hand-over in progress at" message that ClusterSingletonManager.BecomingOldest logs on
+            // receiving HandOverToMe (see #8589 for the transport-level loss that can cause this). Naming
+            // it here turns a later, unrelated-looking timeout into a filter failure at the point the
+            // hand-over actually broke.
+            await CreateEventFilter(_sys2).Info(start: "Hand-over in progress at")
+                .ExpectOneAsync(async () => { await _sys1.Terminate(); });
             // it will be downed by the join attempts of the new incarnation
 
             // ReSharper disable once PossibleInvalidOperationException
@@ -141,15 +148,30 @@ namespace Akka.Cluster.Tools.Tests.Singleton
 
             await AwaitProxyReplyAsync(_sys2, proxy2, "hello2", TimeSpan.FromSeconds(5));
 
-            Cluster.Get(_sys2).Leave(Cluster.Get(_sys2).SelfAddress);
+            // As above: a failure here means sys3 never saw the "Hand-over in progress at" confirmation
+            // from sys2, which is what happened in PR #8588 build 131555 - sys2's HandOverInProgress and
+            // HandOverDone were written to the socket before it closed, but a TCP RST on Windows (see
+            // #8589) discarded them on the wire, so sys3 never cancelled its hand-over retry timer and
+            // fell back to the removal-margin/hand-over-retries path instead. That path does eventually
+            // recover the singleton, but only after 20s+ (removal margin) or ~27s (hand-over retries
+            // exhausted, manager crash-restart) - both well outside the 5s AwaitProxyReplyAsync budget
+            // below, which is sized for the designed hand-over path (HandOverDone reaches sys3 about
+            // 1ms after sys2 starts handing over, before sys2's system terminates). The budget is deliberately not widened to cover the fallback: doing
+            // so would only make the test pass on a path where the hand-over was lost and the manager had
+            // to crash to recover, which defeats the point of a spec named after the hand-over.
+            await CreateEventFilter(_sys3).Info(start: "Hand-over in progress at")
+                .ExpectOneAsync(async () =>
+                {
+                    Cluster.Get(_sys2).Leave(Cluster.Get(_sys2).SelfAddress);
 
-            await AwaitAssertAsync(() =>
-            {
-                Cluster.Get(_sys3)
-                    .State.Members.Select(x => x.UniqueAddress)
-                    .Should()
-                    .Equal(Cluster.Get(_sys3).SelfUniqueAddress);
-            }, TimeSpan.FromSeconds(15));
+                    await AwaitAssertAsync(() =>
+                    {
+                        Cluster.Get(_sys3)
+                            .State.Members.Select(x => x.UniqueAddress)
+                            .Should()
+                            .Equal(Cluster.Get(_sys3).SelfUniqueAddress);
+                    }, TimeSpan.FromSeconds(15));
+                });
 
             var proxy3 =
                 _sys3.ActorOf(ClusterSingletonProxy.Props("user/echo", ClusterSingletonProxySettings.Create(_sys3)),


### PR DESCRIPTION
## Why

`ClusterSingletonRestartSpec.Restarting_cluster_node_with_same_hostname_and_port_must_handover_to_next_oldest`
failed in PR #8588, build 131555 (Windows unit lane), with only:

```
Timeout 00:00:01 while waiting for a message of type System.String
```

from the final `AwaitProxyReplyAsync(_sys3, proxy3, "hello3", 5s)`. That message says nothing about the
actual cause.

Tracing the log (`scratchpad/racy/logs/131555-unit-windows.txt` lines 116-404 in the investigation) shows
sys2 wrote `HandOverInProgress`, `HandOverDone`, and `ExitingConfirmed` to its socket before closing it
during `CoordinatedShutdown`. On Windows, DotNetty's close is `shutdown(SD_BOTH)` + `closesocket`; if any
inbound byte from the peer (sys3) is queued or arrives in that window, the OS turns the close into a TCP
RST, and the RST makes the peer's stack discard whatever it had not yet read. sys3 never saw the hand-over
confirmation, so it never cancelled its `HandOverRetryTimer` and instead lived the fallback: ~6s to declare
sys2 unreachable via the failure detector, then either a 20s removal-margin wait or ~27s of hand-over
retries ending in `ClusterSingletonManagerIsStuckException` and a manager crash-restart. Both recovery
paths land well outside the test's 5s `AwaitProxyReplyAsync` budget, which is sized for the designed
hand-over path (confirmation lands on the new oldest about 1ms after the old oldest stops). This transport-level
loss is tracked as #8589.

## What changed

Wrapped both hand-overs in `ClusterSingletonRestartSpec.cs` in an `EventFilter` on the INFO line
`ClusterSingletonManager` logs when the new oldest receives the previous oldest's hand-over confirmation
(`Log.Info("Hand-over in progress at [{0}]", ...)`):

- sys1 -> sys2 hand-over: wraps `await _sys1.Terminate();` in
  `CreateEventFilter(_sys2).Info(start: "Hand-over in progress at").ExpectOneAsync(...)`.
- sys2 -> sys3 hand-over: wraps `Cluster.Get(_sys2).Leave(...)` and the following 15s `AwaitAssertAsync`
  (sys3 sees only itself) in the same pattern against `_sys3`.

Added a short comment above each filter explaining what a failure there means (the hand-over confirmation
never arrived; see #8589) and why the 5s reply budget is deliberately not widened.

Nothing else changed: no timeout, window, or config value was touched, and the `AwaitProxyReplyAsync`
helper is untouched. The wrapped test code uses async TestKit API only (`ExpectOneAsync(Func<Task>)`,
`AwaitAssertAsync`).

## Why not widen the timeout instead

From the mechanism in the failing build: the loss path resolves via
`min(6s failure-detector + 20s removal-margin, ~27s hand-over-retry exhaustion + manager crash-restart)`,
i.e. roughly 21s or more before the singleton recovers on sys3. Widening `AwaitProxyReplyAsync`'s 5s
budget to cover that would make the test pass on a path where the hand-over was lost and the manager had
to crash to recover - which defeats the point of a spec that is specifically named after, and meant to
exercise, the hand-over.

## Verification

- `dotnet build src/contrib/cluster/Akka.Cluster.Tools.Tests -c Release -f net10.0 -warnaserror -p:SuppressTfmSupportBuildWarnings=true` - clean, 0 warnings/errors. (The test project targets only `net10.0` on `dev`, so no `net48` build was needed.)
- Ran the spec 10x: `dotnet test src/contrib/cluster/Akka.Cluster.Tools.Tests -c Release -f net10.0 --no-build -p:SuppressTfmSupportBuildWarnings=true --filter "FullyQualifiedName~ClusterSingletonRestartSpec"` - **10/10 passed**, ~6-7s each.
- Negative check: temporarily changed the sys2->sys3 filter's `start:` text to `"Hand-over in progress at NOWHERE"` (a string that never logs). The fact then failed with the filter's own message:
  `Timeout (00:00:03) while waiting for messages. Only received 0/1 messages that matched filter [Info when Message starts with "Hand-over in progress at NOWHERE"]`
  confirming the filter discriminates real hand-over confirmations from their absence. Restored the real text; rebuilt clean and reran 10x, all green again; `git diff` shows only the intended change.
- `dotnet format` on the touched file flags one pre-existing, unrelated whitespace issue (`if(_sys3 != null)` in `AfterAll`, present on `dev` before this change) - left untouched to keep this PR focused.

## Backport note

This spec is identical on `v1.5`. Once #8588 lands there, this filter is a good candidate to backport as
well.
